### PR TITLE
Docs/add contribution guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+## Summary
+
+<!-- Briefly describe what this PR does and why it's needed. -->
+
+
+
+## Related Issues
+
+<!-- Link any related issues. Use "Fixes #123" to auto-close on merge. -->
+
+Fixes #
+
+## Type of Change
+
+<!-- Check one. -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Other (describe):
+
+## Changes
+
+<!-- List what you changed. Keep it concise. -->
+
+-
+-
+
+## How to Test
+
+<!-- Describe how a reviewer can verify your changes. -->
+
+1.
+2.
+
+## Screenshots
+
+<!-- Attach screenshots or videos for any UI change. Remove this section if not applicable. -->
+
+
+## Pre-submit Checklist
+
+- [ ] Ran `pnpm lint && pnpm check-types && pnpm build` with no errors
+- [ ] Self-reviewed the diff for mistakes
+- [ ] Tested manually in the browser
+- [ ] Updated relevant documentation (if applicable)
+- [ ] PR title follows commit convention: `type(scope): description`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,9 +169,21 @@ pnpm drizzle-kit migrate   # Apply migration
    git push origin feature/your-feature-name
    ```
 
+### PR Template
+
+**A template will auto-load when you open a PR on GitHub.**
+
+Just fill it out — don't leave sections empty. Use this title format (follow [Commit Convention](#commit-convention)):
+
+```
+<type>(<scope>): <clear description>
+```
+
+Examples: `feat(editor): add keyboard shortcuts`, `fix(auth): resolve session on custom domain`
+
 ### PR Guidelines
 
-- Fill out the PR description completely
+- **Fill out every section** of the auto-loaded template
 - Link related issues (e.g., `Fixes #123`)
 - Include screenshots for UI changes
 - Keep PRs focused — one feature or fix per PR


### PR DESCRIPTION
## Summary

Added comprehensive PR template and contribution guidelines to ensure consistent, high-quality pull requests from all contributors.

## Related Issues

N/A

## Type of Change

- [x] Documentation

## Changes

- Enhanced `CONTRIBUTING.md` with detailed PR guidelines, best practices (Do's/Don'ts), and structured workflow
- Added `.github/pull_request_template.md` that auto-loads when contributors open PRs
- Template includes: Summary, Related Issues, Type of Change, Changes list, Testing steps, Screenshots section, and Pre-submit checklist
- Clear examples of proper commit convention formatting

## How to Test

1. Once merged to `main`, open any new PR
2. The template should automatically populate in the description field
3. Verify all sections are present and easy to fill out

## Pre-submit Checklist

- [x] Ran `pnpm lint && pnpm check-types && pnpm build` with no errors
- [x] Self-reviewed the diff for mistakes
- [x] Tested manually in the browser
- [x] Updated relevant documentation (if applicable)
- [x] PR title follows commit convention: `docs(contributing): add PR template and guidelines`