### PR TITLE
fix(docker): run database migrations at container startup instead of build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,6 @@ ARG VITE_BACKEND_URL
 
 ENV VITE_BACKEND_URL=${VITE_BACKEND_URL:-}
 
-RUN cd /app/apps/backend && node node_modules/drizzle-kit/bin.cjs migrate
-
 
 RUN pnpm build --filter=web... --filter=@repo/backend...
 
@@ -52,11 +50,10 @@ RUN addgroup --system --gid 1001 nodejs && \
 
 COPY --from=builder /app/pruned-backend .
 COPY --from=builder /app/apps/backend/dist ./dist
+COPY --from=builder /app/apps/backend/drizzle ./drizzle
+COPY --from=builder /app/apps/backend/run-migrations.mjs ./run-migrations.mjs
 
 RUN mkdir -p storage && chown -R nodejs:nodejs storage
-
-# Copy the 'seed' database created during build
-COPY --from=builder --chown=nodejs:nodejs /app/apps/backend/local.db ./storage/local.db
 
 USER nodejs
 
@@ -67,7 +64,7 @@ ENV CLIENT_URL=http://localhost:5173
 
 EXPOSE 3000
 
-CMD ["node", "dist/index.js"]
+CMD ["sh", "-c", "node run-migrations.mjs && node dist/index.js"]
 
 # ==========================================
 # STAGE 4: Web Runner (Nginx)

--- a/apps/backend/run-migrations.mjs
+++ b/apps/backend/run-migrations.mjs
@@ -1,0 +1,6 @@
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { drizzle } from 'drizzle-orm/libsql';
+
+const db = drizzle(process.env.DB_FILE_NAME);
+await migrate(db, { migrationsFolder: './drizzle' });
+console.log('Migrations completed.');


### PR DESCRIPTION


Migrations were only running during the Docker build against a temporary DB, which was then baked into the image. On subsequent deploys, Docker volumes preserved the old database, so new migrations were never applied.

Now uses drizzle-orm's built-in migrator (already a prod dependency) via a small run-migrations.mjs script, run at container startup before the server. No drizzle-kit needed in the production image.

