### PR TITLE
feat(TEA-69): disable signups after the first account exists

### DIFF
--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+if [ "$LEFTHOOK_VERBOSE" = "1" -o "$LEFTHOOK_VERBOSE" = "true" ]; then
+  set -x
+fi
+
+if [ "$LEFTHOOK" = "0" ]; then
+  exit 0
+fi
+
+call_lefthook()
+{
+  if test -n "$LEFTHOOK_BIN"
+  then
+    "$LEFTHOOK_BIN" "$@"
+  elif lefthook -h >/dev/null 2>&1
+  then
+    lefthook "$@"
+  elif /Users/elshesheiny/Desktop/WordyMe/WordyMe/node_modules/.pnpm/lefthook-darwin-arm64@2.1.4/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  then
+    /Users/elshesheiny/Desktop/WordyMe/WordyMe/node_modules/.pnpm/lefthook-darwin-arm64@2.1.4/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+  else
+    dir="$(git rev-parse --show-toplevel)"
+    osArch=$(uname | tr '[:upper:]' '[:lower:]')
+    cpuArch=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/x64/')
+    if test -f "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook"
+    then
+      "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook" "$@"
+    elif test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook"
+    then
+      "$dir/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook" "$@"
+    elif test -f "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook"
+    then
+      "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook" "$@"
+    elif test -f "$dir/node_modules/lefthook/bin/index.js"
+    then
+      "$dir/node_modules/lefthook/bin/index.js" "$@"
+    elif go tool lefthook -h >/dev/null 2>&1
+    then
+      go tool lefthook "$@"
+    elif bundle exec lefthook -h >/dev/null 2>&1
+    then
+      bundle exec lefthook "$@"
+    elif yarn lefthook -h >/dev/null 2>&1
+    then
+      yarn lefthook "$@"
+    elif pnpm lefthook -h >/dev/null 2>&1
+    then
+      pnpm lefthook "$@"
+    elif swift package lefthook >/dev/null 2>&1
+    then
+      swift package --build-path .build/lefthook --disable-sandbox lefthook "$@"
+    elif command -v mint >/dev/null 2>&1
+    then
+      mint run csjones/lefthook-plugin "$@"
+    elif uv run lefthook -h >/dev/null 2>&1
+    then
+      uv run lefthook "$@"
+    elif mise exec -- lefthook -h >/dev/null 2>&1
+    then
+      mise exec -- lefthook "$@"
+    elif devbox run lefthook -h >/dev/null 2>&1
+    then
+      devbox run lefthook "$@"
+    else
+      echo "Can't find lefthook in PATH"
+    fi
+  fi
+}
+
+call_lefthook run "pre-commit" "$@"

--- a/apps/backend/drizzle/0002_disable_signup_after_bootstrap.sql
+++ b/apps/backend/drizzle/0002_disable_signup_after_bootstrap.sql
@@ -1,0 +1,6 @@
+CREATE TRIGGER `users_single_bootstrap_guard`
+BEFORE INSERT ON `users`
+WHEN EXISTS (SELECT 1 FROM `users` LIMIT 1)
+BEGIN
+	SELECT RAISE(ABORT, 'signup_disabled');
+END;

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775433600000,
       "tag": "0001_document_search_index",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1776110400000,
+      "tag": "0002_disable_signup_after_bootstrap",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -24,6 +24,7 @@ import { editorSettingsRouter } from './routes/editor-settings.js';
 import { favoritesRouter } from './routes/favorites.js';
 import { storageRouter } from './routes/storage.js';
 import { healthRouter } from './routes/health.js';
+import { authStateRouter } from './routes/auth-state.js';
 
 const app: Express = express();
 const server = createServer(app);
@@ -47,6 +48,7 @@ app.use('/api/revisions', revisionsRouter);
 app.use('/api/editor-settings', editorSettingsRouter);
 app.use('/api/favorites', favoritesRouter);
 app.use('/api/health', healthRouter);
+app.use('/api/auth-state', authStateRouter);
 
 app.use('/storage', storageRouter);
 

--- a/apps/backend/src/lib/auth.ts
+++ b/apps/backend/src/lib/auth.ts
@@ -4,10 +4,12 @@
  */
 
 import { betterAuth, BetterAuthOptions } from 'better-auth';
+import { APIError } from 'better-auth/api';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { bearer, customSession, openAPI, username } from 'better-auth/plugins';
 import { db } from './db.js';
 import { env } from '../env.js';
+import { users } from '../models/auth.js';
 import { getEditorSettings, setEditorSettings } from '../services/editor-settings.js';
 import { createDocument } from '../services/documents.js';
 import { dbWritesQueue } from '../queues/db-writes.js';
@@ -17,12 +19,16 @@ export const adapter = drizzleAdapter(db, {
   usePlural: true,
 });
 
+export const isSignupEnabled = async (): Promise<boolean> => {
+  const existingUsers = await db.select({ id: users.id }).from(users).limit(1);
+  return existingUsers.length === 0;
+};
+
 export const options = {
   database: adapter,
   emailAndPassword: {
     enabled: true,
   },
-  // Without a string baseURL, Better Auth uses Secure-only cookies in production; http:// (Docker/LAN) rejects them.
   baseURL: env.BETTER_AUTH_URL ?? env.CLIENT_URL[0],
   trustedOrigins: env.CLIENT_URL,
   user: {
@@ -54,6 +60,13 @@ export const options = {
   databaseHooks: {
     user: {
       create: {
+        before: async () => {
+          if (!(await isSignupEnabled())) {
+            throw new APIError('BAD_REQUEST', {
+              message: 'Signup is disabled',
+            });
+          }
+        },
         after: async (user) => {
           dbWritesQueue.add(() =>
             createDocument(

--- a/apps/backend/src/middlewares/auth.ts
+++ b/apps/backend/src/middlewares/auth.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { NextFunction, Request, RequestHandler, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 import { auth } from '../lib/auth.js';
 import { fromNodeHeaders } from 'better-auth/node';
 import { HttpUnauthorized } from '@httpx/exception';
@@ -12,6 +12,7 @@ import { ExtendedError, Socket } from 'socket.io';
 type Session = typeof auth.$Infer.Session;
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Express {
     interface Request {
       user?: Session['user'];
@@ -29,7 +30,7 @@ declare module 'socket.io' {
 
 export const requireAuth = async <P, R, B, Q>(
   req: Request<P, R, B, Q>,
-  res: Response<R>,
+  _res: Response<R>,
   next: NextFunction,
 ) => {
   const headers = fromNodeHeaders(req.headers);

--- a/apps/backend/src/routes/auth-state.ts
+++ b/apps/backend/src/routes/auth-state.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Router } from 'express';
+import { isSignupEnabled } from '../lib/auth.js';
+
+export const authStateRouter = Router();
+
+authStateRouter.get('/signup-availability', async (_req, res, next) => {
+  try {
+    const signupEnabled = await isSignupEnabled();
+    res.setHeader('Cache-Control', 'no-store');
+    return res.status(200).json({ signupEnabled });
+  } catch (error) {
+    return next(error);
+  }
+});

--- a/apps/web/src/queries/auth.ts
+++ b/apps/web/src/queries/auth.ts
@@ -3,9 +3,17 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { useMutation } from '@tanstack/react-query';
-import { login, register } from '@repo/sdk/auth';
+import { useMutation, useQueryClient, type UseQueryOptions } from '@tanstack/react-query';
+import { getSignupAvailability, type SignupAvailability, login, register } from '@repo/sdk/auth';
 import { toast } from '@repo/ui/components/sonner';
+
+export const signupAvailabilityQueryKey = ['auth', 'signupAvailability'] as const;
+
+export const signupAvailabilityQueryOptions: UseQueryOptions<SignupAvailability, Error> = {
+  queryKey: signupAvailabilityQueryKey,
+  queryFn: getSignupAvailability,
+  staleTime: 60_000,
+};
 
 export function useLoginMutation() {
   return useMutation({
@@ -38,6 +46,7 @@ export function useLoginMutation() {
 }
 
 export function useRegisterMutation() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationKey: ['register'],
     mutationFn: async ({
@@ -63,6 +72,7 @@ export function useRegisterMutation() {
       return toast.loading('Creating account...');
     },
     onSuccess: (_, __, toastId) => {
+      void queryClient.invalidateQueries({ queryKey: signupAvailabilityQueryKey });
       toast.success('Account created successfully', {
         id: toastId,
       });

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -8,182 +8,183 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root';
-import { Route as UnauthedRouteImport } from './routes/_unauthed';
-import { Route as AuthedRouteImport } from './routes/_authed';
-import { Route as AuthedIndexRouteImport } from './routes/_authed/index';
-import { Route as UnauthedSignupRouteImport } from './routes/_unauthed/signup';
-import { Route as UnauthedLoginRouteImport } from './routes/_unauthed/login';
-import { Route as AuthedAttachmentRouteImport } from './routes/_authed/attachment';
-import { Route as AuthedSettingsRouteRouteImport } from './routes/_authed/settings/route';
-import { Route as AuthedSpacesIndexRouteImport } from './routes/_authed/spaces/index';
-import { Route as AuthedSettingsIndexRouteImport } from './routes/_authed/settings/index';
-import { Route as AuthedDocsIndexRouteImport } from './routes/_authed/docs/index';
-import { Route as AuthedViewHandleRouteImport } from './routes/_authed/view/$handle';
-import { Route as AuthedSpacesManageRouteImport } from './routes/_authed/spaces/manage';
-import { Route as AuthedSpacesFavoritesRouteImport } from './routes/_authed/spaces/favorites';
-import { Route as AuthedSettingsProfileRouteImport } from './routes/_authed/settings/profile';
-import { Route as AuthedSettingsPreferencesRouteImport } from './routes/_authed/settings/preferences';
-import { Route as AuthedEditHandleRouteImport } from './routes/_authed/edit/$handle';
-import { Route as AuthedDocsRecentViewedRouteImport } from './routes/_authed/docs/recent-viewed';
-import { Route as AuthedDocsManageRouteImport } from './routes/_authed/docs/manage';
-import { Route as AuthedDocsFavoritesRouteImport } from './routes/_authed/docs/favorites';
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as UnauthedRouteImport } from './routes/_unauthed'
+import { Route as AuthedRouteImport } from './routes/_authed'
+import { Route as AuthedIndexRouteImport } from './routes/_authed/index'
+import { Route as UnauthedSignupRouteImport } from './routes/_unauthed/signup'
+import { Route as UnauthedLoginRouteImport } from './routes/_unauthed/login'
+import { Route as AuthedAttachmentRouteImport } from './routes/_authed/attachment'
+import { Route as AuthedSettingsRouteRouteImport } from './routes/_authed/settings/route'
+import { Route as AuthedSpacesIndexRouteImport } from './routes/_authed/spaces/index'
+import { Route as AuthedSettingsIndexRouteImport } from './routes/_authed/settings/index'
+import { Route as AuthedDocsIndexRouteImport } from './routes/_authed/docs/index'
+import { Route as AuthedViewHandleRouteImport } from './routes/_authed/view/$handle'
+import { Route as AuthedSpacesManageRouteImport } from './routes/_authed/spaces/manage'
+import { Route as AuthedSpacesFavoritesRouteImport } from './routes/_authed/spaces/favorites'
+import { Route as AuthedSettingsProfileRouteImport } from './routes/_authed/settings/profile'
+import { Route as AuthedSettingsPreferencesRouteImport } from './routes/_authed/settings/preferences'
+import { Route as AuthedEditHandleRouteImport } from './routes/_authed/edit/$handle'
+import { Route as AuthedDocsRecentViewedRouteImport } from './routes/_authed/docs/recent-viewed'
+import { Route as AuthedDocsManageRouteImport } from './routes/_authed/docs/manage'
+import { Route as AuthedDocsFavoritesRouteImport } from './routes/_authed/docs/favorites'
 
 const UnauthedRoute = UnauthedRouteImport.update({
   id: '/_unauthed',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const AuthedRoute = AuthedRouteImport.update({
   id: '/_authed',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const AuthedIndexRoute = AuthedIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 const UnauthedSignupRoute = UnauthedSignupRouteImport.update({
   id: '/signup',
   path: '/signup',
   getParentRoute: () => UnauthedRoute,
-} as any);
+} as any)
 const UnauthedLoginRoute = UnauthedLoginRouteImport.update({
   id: '/login',
   path: '/login',
   getParentRoute: () => UnauthedRoute,
-} as any);
+} as any)
 const AuthedAttachmentRoute = AuthedAttachmentRouteImport.update({
   id: '/attachment',
   path: '/attachment',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 const AuthedSettingsRouteRoute = AuthedSettingsRouteRouteImport.update({
   id: '/settings',
   path: '/settings',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 const AuthedSpacesIndexRoute = AuthedSpacesIndexRouteImport.update({
   id: '/spaces/',
   path: '/spaces/',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 const AuthedSettingsIndexRoute = AuthedSettingsIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthedSettingsRouteRoute,
-} as any);
+} as any)
 const AuthedDocsIndexRoute = AuthedDocsIndexRouteImport.update({
   id: '/docs/',
   path: '/docs/',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 const AuthedViewHandleRoute = AuthedViewHandleRouteImport.update({
   id: '/view/$handle',
   path: '/view/$handle',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 const AuthedSpacesManageRoute = AuthedSpacesManageRouteImport.update({
   id: '/spaces/manage',
   path: '/spaces/manage',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 const AuthedSpacesFavoritesRoute = AuthedSpacesFavoritesRouteImport.update({
   id: '/spaces/favorites',
   path: '/spaces/favorites',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 const AuthedSettingsProfileRoute = AuthedSettingsProfileRouteImport.update({
   id: '/profile',
   path: '/profile',
   getParentRoute: () => AuthedSettingsRouteRoute,
-} as any);
-const AuthedSettingsPreferencesRoute = AuthedSettingsPreferencesRouteImport.update({
-  id: '/preferences',
-  path: '/preferences',
-  getParentRoute: () => AuthedSettingsRouteRoute,
-} as any);
+} as any)
+const AuthedSettingsPreferencesRoute =
+  AuthedSettingsPreferencesRouteImport.update({
+    id: '/preferences',
+    path: '/preferences',
+    getParentRoute: () => AuthedSettingsRouteRoute,
+  } as any)
 const AuthedEditHandleRoute = AuthedEditHandleRouteImport.update({
   id: '/edit/$handle',
   path: '/edit/$handle',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 const AuthedDocsRecentViewedRoute = AuthedDocsRecentViewedRouteImport.update({
   id: '/docs/recent-viewed',
   path: '/docs/recent-viewed',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 const AuthedDocsManageRoute = AuthedDocsManageRouteImport.update({
   id: '/docs/manage',
   path: '/docs/manage',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 const AuthedDocsFavoritesRoute = AuthedDocsFavoritesRouteImport.update({
   id: '/docs/favorites',
   path: '/docs/favorites',
   getParentRoute: () => AuthedRoute,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof AuthedIndexRoute;
-  '/settings': typeof AuthedSettingsRouteRouteWithChildren;
-  '/attachment': typeof AuthedAttachmentRoute;
-  '/login': typeof UnauthedLoginRoute;
-  '/signup': typeof UnauthedSignupRoute;
-  '/docs/favorites': typeof AuthedDocsFavoritesRoute;
-  '/docs/manage': typeof AuthedDocsManageRoute;
-  '/docs/recent-viewed': typeof AuthedDocsRecentViewedRoute;
-  '/edit/$handle': typeof AuthedEditHandleRoute;
-  '/settings/preferences': typeof AuthedSettingsPreferencesRoute;
-  '/settings/profile': typeof AuthedSettingsProfileRoute;
-  '/spaces/favorites': typeof AuthedSpacesFavoritesRoute;
-  '/spaces/manage': typeof AuthedSpacesManageRoute;
-  '/view/$handle': typeof AuthedViewHandleRoute;
-  '/docs/': typeof AuthedDocsIndexRoute;
-  '/settings/': typeof AuthedSettingsIndexRoute;
-  '/spaces/': typeof AuthedSpacesIndexRoute;
+  '/': typeof AuthedIndexRoute
+  '/settings': typeof AuthedSettingsRouteRouteWithChildren
+  '/attachment': typeof AuthedAttachmentRoute
+  '/login': typeof UnauthedLoginRoute
+  '/signup': typeof UnauthedSignupRoute
+  '/docs/favorites': typeof AuthedDocsFavoritesRoute
+  '/docs/manage': typeof AuthedDocsManageRoute
+  '/docs/recent-viewed': typeof AuthedDocsRecentViewedRoute
+  '/edit/$handle': typeof AuthedEditHandleRoute
+  '/settings/preferences': typeof AuthedSettingsPreferencesRoute
+  '/settings/profile': typeof AuthedSettingsProfileRoute
+  '/spaces/favorites': typeof AuthedSpacesFavoritesRoute
+  '/spaces/manage': typeof AuthedSpacesManageRoute
+  '/view/$handle': typeof AuthedViewHandleRoute
+  '/docs/': typeof AuthedDocsIndexRoute
+  '/settings/': typeof AuthedSettingsIndexRoute
+  '/spaces/': typeof AuthedSpacesIndexRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof AuthedIndexRoute;
-  '/attachment': typeof AuthedAttachmentRoute;
-  '/login': typeof UnauthedLoginRoute;
-  '/signup': typeof UnauthedSignupRoute;
-  '/docs/favorites': typeof AuthedDocsFavoritesRoute;
-  '/docs/manage': typeof AuthedDocsManageRoute;
-  '/docs/recent-viewed': typeof AuthedDocsRecentViewedRoute;
-  '/edit/$handle': typeof AuthedEditHandleRoute;
-  '/settings/preferences': typeof AuthedSettingsPreferencesRoute;
-  '/settings/profile': typeof AuthedSettingsProfileRoute;
-  '/spaces/favorites': typeof AuthedSpacesFavoritesRoute;
-  '/spaces/manage': typeof AuthedSpacesManageRoute;
-  '/view/$handle': typeof AuthedViewHandleRoute;
-  '/docs': typeof AuthedDocsIndexRoute;
-  '/settings': typeof AuthedSettingsIndexRoute;
-  '/spaces': typeof AuthedSpacesIndexRoute;
+  '/': typeof AuthedIndexRoute
+  '/attachment': typeof AuthedAttachmentRoute
+  '/login': typeof UnauthedLoginRoute
+  '/signup': typeof UnauthedSignupRoute
+  '/docs/favorites': typeof AuthedDocsFavoritesRoute
+  '/docs/manage': typeof AuthedDocsManageRoute
+  '/docs/recent-viewed': typeof AuthedDocsRecentViewedRoute
+  '/edit/$handle': typeof AuthedEditHandleRoute
+  '/settings/preferences': typeof AuthedSettingsPreferencesRoute
+  '/settings/profile': typeof AuthedSettingsProfileRoute
+  '/spaces/favorites': typeof AuthedSpacesFavoritesRoute
+  '/spaces/manage': typeof AuthedSpacesManageRoute
+  '/view/$handle': typeof AuthedViewHandleRoute
+  '/docs': typeof AuthedDocsIndexRoute
+  '/settings': typeof AuthedSettingsIndexRoute
+  '/spaces': typeof AuthedSpacesIndexRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  '/_authed': typeof AuthedRouteWithChildren;
-  '/_unauthed': typeof UnauthedRouteWithChildren;
-  '/_authed/settings': typeof AuthedSettingsRouteRouteWithChildren;
-  '/_authed/attachment': typeof AuthedAttachmentRoute;
-  '/_unauthed/login': typeof UnauthedLoginRoute;
-  '/_unauthed/signup': typeof UnauthedSignupRoute;
-  '/_authed/': typeof AuthedIndexRoute;
-  '/_authed/docs/favorites': typeof AuthedDocsFavoritesRoute;
-  '/_authed/docs/manage': typeof AuthedDocsManageRoute;
-  '/_authed/docs/recent-viewed': typeof AuthedDocsRecentViewedRoute;
-  '/_authed/edit/$handle': typeof AuthedEditHandleRoute;
-  '/_authed/settings/preferences': typeof AuthedSettingsPreferencesRoute;
-  '/_authed/settings/profile': typeof AuthedSettingsProfileRoute;
-  '/_authed/spaces/favorites': typeof AuthedSpacesFavoritesRoute;
-  '/_authed/spaces/manage': typeof AuthedSpacesManageRoute;
-  '/_authed/view/$handle': typeof AuthedViewHandleRoute;
-  '/_authed/docs/': typeof AuthedDocsIndexRoute;
-  '/_authed/settings/': typeof AuthedSettingsIndexRoute;
-  '/_authed/spaces/': typeof AuthedSpacesIndexRoute;
+  __root__: typeof rootRouteImport
+  '/_authed': typeof AuthedRouteWithChildren
+  '/_unauthed': typeof UnauthedRouteWithChildren
+  '/_authed/settings': typeof AuthedSettingsRouteRouteWithChildren
+  '/_authed/attachment': typeof AuthedAttachmentRoute
+  '/_unauthed/login': typeof UnauthedLoginRoute
+  '/_unauthed/signup': typeof UnauthedSignupRoute
+  '/_authed/': typeof AuthedIndexRoute
+  '/_authed/docs/favorites': typeof AuthedDocsFavoritesRoute
+  '/_authed/docs/manage': typeof AuthedDocsManageRoute
+  '/_authed/docs/recent-viewed': typeof AuthedDocsRecentViewedRoute
+  '/_authed/edit/$handle': typeof AuthedEditHandleRoute
+  '/_authed/settings/preferences': typeof AuthedSettingsPreferencesRoute
+  '/_authed/settings/profile': typeof AuthedSettingsProfileRoute
+  '/_authed/spaces/favorites': typeof AuthedSpacesFavoritesRoute
+  '/_authed/spaces/manage': typeof AuthedSpacesManageRoute
+  '/_authed/view/$handle': typeof AuthedViewHandleRoute
+  '/_authed/docs/': typeof AuthedDocsIndexRoute
+  '/_authed/settings/': typeof AuthedSettingsIndexRoute
+  '/_authed/spaces/': typeof AuthedSpacesIndexRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/settings'
@@ -201,8 +202,8 @@ export interface FileRouteTypes {
     | '/view/$handle'
     | '/docs/'
     | '/settings/'
-    | '/spaces/';
-  fileRoutesByTo: FileRoutesByTo;
+    | '/spaces/'
+  fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/attachment'
@@ -219,7 +220,7 @@ export interface FileRouteTypes {
     | '/view/$handle'
     | '/docs'
     | '/settings'
-    | '/spaces';
+    | '/spaces'
   id:
     | '__root__'
     | '/_authed'
@@ -240,181 +241,180 @@ export interface FileRouteTypes {
     | '/_authed/view/$handle'
     | '/_authed/docs/'
     | '/_authed/settings/'
-    | '/_authed/spaces/';
-  fileRoutesById: FileRoutesById;
+    | '/_authed/spaces/'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  AuthedRoute: typeof AuthedRouteWithChildren;
-  UnauthedRoute: typeof UnauthedRouteWithChildren;
+  AuthedRoute: typeof AuthedRouteWithChildren
+  UnauthedRoute: typeof UnauthedRouteWithChildren
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/_unauthed': {
-      id: '/_unauthed';
-      path: '';
-      fullPath: '/';
-      preLoaderRoute: typeof UnauthedRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/_unauthed'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof UnauthedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_authed': {
-      id: '/_authed';
-      path: '';
-      fullPath: '/';
-      preLoaderRoute: typeof AuthedRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/_authed'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof AuthedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_authed/': {
-      id: '/_authed/';
-      path: '/';
-      fullPath: '/';
-      preLoaderRoute: typeof AuthedIndexRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof AuthedIndexRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_unauthed/signup': {
-      id: '/_unauthed/signup';
-      path: '/signup';
-      fullPath: '/signup';
-      preLoaderRoute: typeof UnauthedSignupRouteImport;
-      parentRoute: typeof UnauthedRoute;
-    };
+      id: '/_unauthed/signup'
+      path: '/signup'
+      fullPath: '/signup'
+      preLoaderRoute: typeof UnauthedSignupRouteImport
+      parentRoute: typeof UnauthedRoute
+    }
     '/_unauthed/login': {
-      id: '/_unauthed/login';
-      path: '/login';
-      fullPath: '/login';
-      preLoaderRoute: typeof UnauthedLoginRouteImport;
-      parentRoute: typeof UnauthedRoute;
-    };
+      id: '/_unauthed/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof UnauthedLoginRouteImport
+      parentRoute: typeof UnauthedRoute
+    }
     '/_authed/attachment': {
-      id: '/_authed/attachment';
-      path: '/attachment';
-      fullPath: '/attachment';
-      preLoaderRoute: typeof AuthedAttachmentRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/attachment'
+      path: '/attachment'
+      fullPath: '/attachment'
+      preLoaderRoute: typeof AuthedAttachmentRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/settings': {
-      id: '/_authed/settings';
-      path: '/settings';
-      fullPath: '/settings';
-      preLoaderRoute: typeof AuthedSettingsRouteRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof AuthedSettingsRouteRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/spaces/': {
-      id: '/_authed/spaces/';
-      path: '/spaces';
-      fullPath: '/spaces/';
-      preLoaderRoute: typeof AuthedSpacesIndexRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/spaces/'
+      path: '/spaces'
+      fullPath: '/spaces/'
+      preLoaderRoute: typeof AuthedSpacesIndexRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/settings/': {
-      id: '/_authed/settings/';
-      path: '/';
-      fullPath: '/settings/';
-      preLoaderRoute: typeof AuthedSettingsIndexRouteImport;
-      parentRoute: typeof AuthedSettingsRouteRoute;
-    };
+      id: '/_authed/settings/'
+      path: '/'
+      fullPath: '/settings/'
+      preLoaderRoute: typeof AuthedSettingsIndexRouteImport
+      parentRoute: typeof AuthedSettingsRouteRoute
+    }
     '/_authed/docs/': {
-      id: '/_authed/docs/';
-      path: '/docs';
-      fullPath: '/docs/';
-      preLoaderRoute: typeof AuthedDocsIndexRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/docs/'
+      path: '/docs'
+      fullPath: '/docs/'
+      preLoaderRoute: typeof AuthedDocsIndexRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/view/$handle': {
-      id: '/_authed/view/$handle';
-      path: '/view/$handle';
-      fullPath: '/view/$handle';
-      preLoaderRoute: typeof AuthedViewHandleRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/view/$handle'
+      path: '/view/$handle'
+      fullPath: '/view/$handle'
+      preLoaderRoute: typeof AuthedViewHandleRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/spaces/manage': {
-      id: '/_authed/spaces/manage';
-      path: '/spaces/manage';
-      fullPath: '/spaces/manage';
-      preLoaderRoute: typeof AuthedSpacesManageRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/spaces/manage'
+      path: '/spaces/manage'
+      fullPath: '/spaces/manage'
+      preLoaderRoute: typeof AuthedSpacesManageRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/spaces/favorites': {
-      id: '/_authed/spaces/favorites';
-      path: '/spaces/favorites';
-      fullPath: '/spaces/favorites';
-      preLoaderRoute: typeof AuthedSpacesFavoritesRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/spaces/favorites'
+      path: '/spaces/favorites'
+      fullPath: '/spaces/favorites'
+      preLoaderRoute: typeof AuthedSpacesFavoritesRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/settings/profile': {
-      id: '/_authed/settings/profile';
-      path: '/profile';
-      fullPath: '/settings/profile';
-      preLoaderRoute: typeof AuthedSettingsProfileRouteImport;
-      parentRoute: typeof AuthedSettingsRouteRoute;
-    };
+      id: '/_authed/settings/profile'
+      path: '/profile'
+      fullPath: '/settings/profile'
+      preLoaderRoute: typeof AuthedSettingsProfileRouteImport
+      parentRoute: typeof AuthedSettingsRouteRoute
+    }
     '/_authed/settings/preferences': {
-      id: '/_authed/settings/preferences';
-      path: '/preferences';
-      fullPath: '/settings/preferences';
-      preLoaderRoute: typeof AuthedSettingsPreferencesRouteImport;
-      parentRoute: typeof AuthedSettingsRouteRoute;
-    };
+      id: '/_authed/settings/preferences'
+      path: '/preferences'
+      fullPath: '/settings/preferences'
+      preLoaderRoute: typeof AuthedSettingsPreferencesRouteImport
+      parentRoute: typeof AuthedSettingsRouteRoute
+    }
     '/_authed/edit/$handle': {
-      id: '/_authed/edit/$handle';
-      path: '/edit/$handle';
-      fullPath: '/edit/$handle';
-      preLoaderRoute: typeof AuthedEditHandleRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/edit/$handle'
+      path: '/edit/$handle'
+      fullPath: '/edit/$handle'
+      preLoaderRoute: typeof AuthedEditHandleRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/docs/recent-viewed': {
-      id: '/_authed/docs/recent-viewed';
-      path: '/docs/recent-viewed';
-      fullPath: '/docs/recent-viewed';
-      preLoaderRoute: typeof AuthedDocsRecentViewedRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/docs/recent-viewed'
+      path: '/docs/recent-viewed'
+      fullPath: '/docs/recent-viewed'
+      preLoaderRoute: typeof AuthedDocsRecentViewedRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/docs/manage': {
-      id: '/_authed/docs/manage';
-      path: '/docs/manage';
-      fullPath: '/docs/manage';
-      preLoaderRoute: typeof AuthedDocsManageRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/docs/manage'
+      path: '/docs/manage'
+      fullPath: '/docs/manage'
+      preLoaderRoute: typeof AuthedDocsManageRouteImport
+      parentRoute: typeof AuthedRoute
+    }
     '/_authed/docs/favorites': {
-      id: '/_authed/docs/favorites';
-      path: '/docs/favorites';
-      fullPath: '/docs/favorites';
-      preLoaderRoute: typeof AuthedDocsFavoritesRouteImport;
-      parentRoute: typeof AuthedRoute;
-    };
+      id: '/_authed/docs/favorites'
+      path: '/docs/favorites'
+      fullPath: '/docs/favorites'
+      preLoaderRoute: typeof AuthedDocsFavoritesRouteImport
+      parentRoute: typeof AuthedRoute
+    }
   }
 }
 
 interface AuthedSettingsRouteRouteChildren {
-  AuthedSettingsPreferencesRoute: typeof AuthedSettingsPreferencesRoute;
-  AuthedSettingsProfileRoute: typeof AuthedSettingsProfileRoute;
-  AuthedSettingsIndexRoute: typeof AuthedSettingsIndexRoute;
+  AuthedSettingsPreferencesRoute: typeof AuthedSettingsPreferencesRoute
+  AuthedSettingsProfileRoute: typeof AuthedSettingsProfileRoute
+  AuthedSettingsIndexRoute: typeof AuthedSettingsIndexRoute
 }
 
 const AuthedSettingsRouteRouteChildren: AuthedSettingsRouteRouteChildren = {
   AuthedSettingsPreferencesRoute: AuthedSettingsPreferencesRoute,
   AuthedSettingsProfileRoute: AuthedSettingsProfileRoute,
   AuthedSettingsIndexRoute: AuthedSettingsIndexRoute,
-};
+}
 
-const AuthedSettingsRouteRouteWithChildren = AuthedSettingsRouteRoute._addFileChildren(
-  AuthedSettingsRouteRouteChildren,
-);
+const AuthedSettingsRouteRouteWithChildren =
+  AuthedSettingsRouteRoute._addFileChildren(AuthedSettingsRouteRouteChildren)
 
 interface AuthedRouteChildren {
-  AuthedSettingsRouteRoute: typeof AuthedSettingsRouteRouteWithChildren;
-  AuthedAttachmentRoute: typeof AuthedAttachmentRoute;
-  AuthedIndexRoute: typeof AuthedIndexRoute;
-  AuthedDocsFavoritesRoute: typeof AuthedDocsFavoritesRoute;
-  AuthedDocsManageRoute: typeof AuthedDocsManageRoute;
-  AuthedDocsRecentViewedRoute: typeof AuthedDocsRecentViewedRoute;
-  AuthedEditHandleRoute: typeof AuthedEditHandleRoute;
-  AuthedSpacesFavoritesRoute: typeof AuthedSpacesFavoritesRoute;
-  AuthedSpacesManageRoute: typeof AuthedSpacesManageRoute;
-  AuthedViewHandleRoute: typeof AuthedViewHandleRoute;
-  AuthedDocsIndexRoute: typeof AuthedDocsIndexRoute;
-  AuthedSpacesIndexRoute: typeof AuthedSpacesIndexRoute;
+  AuthedSettingsRouteRoute: typeof AuthedSettingsRouteRouteWithChildren
+  AuthedAttachmentRoute: typeof AuthedAttachmentRoute
+  AuthedIndexRoute: typeof AuthedIndexRoute
+  AuthedDocsFavoritesRoute: typeof AuthedDocsFavoritesRoute
+  AuthedDocsManageRoute: typeof AuthedDocsManageRoute
+  AuthedDocsRecentViewedRoute: typeof AuthedDocsRecentViewedRoute
+  AuthedEditHandleRoute: typeof AuthedEditHandleRoute
+  AuthedSpacesFavoritesRoute: typeof AuthedSpacesFavoritesRoute
+  AuthedSpacesManageRoute: typeof AuthedSpacesManageRoute
+  AuthedViewHandleRoute: typeof AuthedViewHandleRoute
+  AuthedDocsIndexRoute: typeof AuthedDocsIndexRoute
+  AuthedSpacesIndexRoute: typeof AuthedSpacesIndexRoute
 }
 
 const AuthedRouteChildren: AuthedRouteChildren = {
@@ -430,26 +430,29 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedViewHandleRoute: AuthedViewHandleRoute,
   AuthedDocsIndexRoute: AuthedDocsIndexRoute,
   AuthedSpacesIndexRoute: AuthedSpacesIndexRoute,
-};
+}
 
-const AuthedRouteWithChildren = AuthedRoute._addFileChildren(AuthedRouteChildren);
+const AuthedRouteWithChildren =
+  AuthedRoute._addFileChildren(AuthedRouteChildren)
 
 interface UnauthedRouteChildren {
-  UnauthedLoginRoute: typeof UnauthedLoginRoute;
-  UnauthedSignupRoute: typeof UnauthedSignupRoute;
+  UnauthedLoginRoute: typeof UnauthedLoginRoute
+  UnauthedSignupRoute: typeof UnauthedSignupRoute
 }
 
 const UnauthedRouteChildren: UnauthedRouteChildren = {
   UnauthedLoginRoute: UnauthedLoginRoute,
   UnauthedSignupRoute: UnauthedSignupRoute,
-};
+}
 
-const UnauthedRouteWithChildren = UnauthedRoute._addFileChildren(UnauthedRouteChildren);
+const UnauthedRouteWithChildren = UnauthedRoute._addFileChildren(
+  UnauthedRouteChildren,
+)
 
 const rootRouteChildren: RootRouteChildren = {
   AuthedRoute: AuthedRouteWithChildren,
   UnauthedRoute: UnauthedRouteWithChildren,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()

--- a/apps/web/src/routes/_unauthed/login.tsx
+++ b/apps/web/src/routes/_unauthed/login.tsx
@@ -30,7 +30,8 @@ import {
   InputGroupButton,
   InputGroupAddon,
 } from '@repo/ui/components/input-group';
-import { useLoginMutation } from '@/queries/auth';
+import { signupAvailabilityQueryOptions, useLoginMutation } from '@/queries/auth';
+import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 
 const loginSchema = z.object({
@@ -46,6 +47,7 @@ export const Route = createFileRoute('/_unauthed/login')({
 
 function RouteComponent() {
   const loginMutation = useLoginMutation();
+  const { data: signupAvailability } = useQuery(signupAvailabilityQueryOptions);
   const [showPassword, setShowPassword] = useState(false);
 
   const form = useForm<LoginFormValues>({
@@ -138,12 +140,14 @@ function RouteComponent() {
                   'Sign in'
                 )}
               </Button>
-              <div className="text-center text-sm text-muted-foreground">
-                Don't have an account?{' '}
-                <Link to="/signup" className="text-primary hover:underline font-medium">
-                  Sign up
-                </Link>
-              </div>
+              {signupAvailability?.signupEnabled ? (
+                <div className="text-center text-sm text-muted-foreground">
+                  Don't have an account?{' '}
+                  <Link to="/signup" className="text-primary hover:underline font-medium">
+                    Sign up
+                  </Link>
+                </div>
+              ) : null}
             </form>
           </Form>
         </CardContent>

--- a/apps/web/src/routes/_unauthed/signup.tsx
+++ b/apps/web/src/routes/_unauthed/signup.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute, Link, redirect } from '@tanstack/react-router';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import z from 'zod';
@@ -30,7 +30,7 @@ import {
   InputGroupButton,
   InputGroupAddon,
 } from '@repo/ui/components/input-group';
-import { useRegisterMutation } from '@/queries/auth';
+import { signupAvailabilityQueryOptions, useRegisterMutation } from '@/queries/auth';
 import { useState } from 'react';
 
 const signupSchema = z
@@ -48,6 +48,12 @@ const signupSchema = z
 type SignupFormValues = z.infer<typeof signupSchema>;
 
 export const Route = createFileRoute('/_unauthed/signup')({
+  beforeLoad: async ({ context: { queryClient } }) => {
+    const { signupEnabled } = await queryClient.ensureQueryData(signupAvailabilityQueryOptions);
+    if (!signupEnabled) {
+      throw redirect({ to: '/login' });
+    }
+  },
   component: RouteComponent,
 });
 

--- a/packages/sdk/src/auth/index.ts
+++ b/packages/sdk/src/auth/index.ts
@@ -10,6 +10,11 @@ import {
 } from 'better-auth/client/plugins';
 import { createAuthClient } from 'better-auth/react';
 import { type auth } from '@repo/backend/auth';
+import { get } from '../app/client.js';
+
+export type SignupAvailability = {
+  signupEnabled: boolean;
+};
 
 export const authClient = createAuthClient({
   // $InferAuth: options,
@@ -36,5 +41,13 @@ export const logout = async () => {
 export const getSession = async () => {
   return await authClient.getSession();
 };
+
+export const getSignupAvailability = async (): Promise<SignupAvailability> => {
+  const { data, error } = await get<SignupAvailability>('/auth-state/signup-availability');
+  if (error) throw error;
+  if (data === null) throw new Error('Signup availability unavailable');
+  return data;
+};
+
 export type SessionData = Awaited<ReturnType<typeof getSession>>['data'];
 export const useSession = authClient.useSession;

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turborepo.com/schema.json",
+  "globalEnv": ["VITE_BACKEND_URL"],
   "ui": "tui",
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

Single-admin bootstrap for auth: signups are only allowed until the first user exists. The web app gates `/signup`, hides the signup link on login when closed, and reads availability from the backend via the SDK. `VITE_BACKEND_URL` is declared in `turbo.json` for caching and ESLint.

## Related Issues

Fixes #TEA-69

## Type of Change

New feature

## Changes

- Backend: signup availability at `GET /api/auth-state/signup-availability` (`signupEnabled`); auth rejects additional registrations once a user exists.
- SDK: `getSignupAvailability()` uses the shared API client and returns `{ signupEnabled }`.
- Web: `signupAvailabilityQueryOptions`; `/signup` redirects in `beforeLoad` when disabled; login hides the signup link; invalidate availability after successful registration.
- Turbo: `globalEnv: ["VITE_BACKEND_URL"]`.

## How to Test

1. Fresh DB (no users): `/signup` shows the form; login shows the signup link.
2. After the first account: `/signup` redirects to `/login`; signup link hidden; first user can still sign in.
3. Confirm a second signup fails via the API and the UI stays locked.

**Expected result:** At most one self-serve signup; returning users can log in; no signup path in the UI when the system is locked.