### PR TITLE
chore(TEA-74): upgrade to TypeScript 6 and fix migration regressions

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -50,6 +50,6 @@
     "drizzle-kit": "^0.31.9",
     "eslint": "^10.1.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   }
 }

--- a/apps/backend/src/services/attachments.ts
+++ b/apps/backend/src/services/attachments.ts
@@ -39,7 +39,7 @@ export const copyDocumentAttachments = async (
     .catch(() => false);
 
   if (!sourceExists) {
-    return [];
+    return;
   }
 
   await cp(sourceDirectory, targetDirectory, {

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@repo/typescript-config/node.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["./src/**/*"]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -71,7 +71,7 @@
     "cross-env": "^10.1.0",
     "eslint": "^10.1.0",
     "jsdom": "^28.1.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "vite": "^8.0.5",
     "vite-bundle-analyzer": "^1.3.6",
     "vite-plugin-pwa": "^1.2.0",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,9 +4,8 @@
     "jsx": "react-jsx",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"]

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prettier": "^3.8.1",
     "release-it": "^19.2.4",
     "turbo": "^2.9.3",
-    "typescript": "5.9.3"
+    "typescript": "^6.0.2"
   },
   "packageManager": "pnpm@10.27.0",
   "engines": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -52,7 +52,7 @@
     "@types/react-dom": "^19.2.3",
     "eslint": "^10.1.0",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "typescript-eslint": "^8.57.0"
   },
   "exports": {

--- a/packages/editor/src/assets.d.ts
+++ b/packages/editor/src/assets.d.ts
@@ -1,3 +1,5 @@
+declare module '*.css';
+
 declare module '*.svg' {
   const src: string;
   export default src;

--- a/packages/embed-pdf/package.json
+++ b/packages/embed-pdf/package.json
@@ -48,7 +48,7 @@
     "@types/react-dom": "^19.2.3",
     "eslint": "^10.1.0",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "typescript-eslint": "^8.54.0"
   },
   "peerDependencies": {

--- a/packages/embed-pdf/src/components/page-controls.tsx
+++ b/packages/embed-pdf/src/components/page-controls.tsx
@@ -20,7 +20,7 @@ export function PageControls({ documentId }: PageControlsProps) {
   } = useScroll(documentId);
   const [isVisible, setIsVisible] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
-  const hideTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [inputValue, setInputValue] = useState<string>(currentPage.toString());
 
   useEffect(() => {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-turbo": "^2.8.16",
     "globals": "^17.4.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "typescript-eslint": "^8.57.0"
   }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -15,7 +15,7 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "eslint": "^10.1.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "typescript-eslint": "^8.57.0"
   },
   "dependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -21,7 +21,7 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "eslint": "^10.1.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   },
   "dependencies": {
     "axios": "^1.15.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,7 +13,7 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "eslint": "^10.1.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "typescript-eslint": "^8.57.0"
   },
   "dependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,6 +15,6 @@
     "@repo/typescript-config": "workspace:*",
     "eslint": "^10.1.0",
     "lexical": "^0.41.0",
-    "typescript": "5.9.3"
+    "typescript": "^6.0.2"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -60,7 +60,7 @@
     "@types/react-dom": "^19.2.3",
     "eslint": "^10.1.0",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "typescript-eslint": "^8.57.0"
   },
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^2.9.3
         version: 2.9.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
   apps/backend:
     dependencies:
@@ -71,7 +71,7 @@ importers:
         version: 0.9.3
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(mongodb@7.1.0(socks@2.8.7))(mysql2@3.15.3)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)))(vue@3.5.30(typescript@5.9.3))
+        version: 1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)))(mongodb@7.1.0(socks@2.8.7))(mysql2@3.15.3)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)))(vue@3.5.30(typescript@6.0.2))
       cors:
         specifier: ^2.8.6
         version: 2.8.6
@@ -80,10 +80,10 @@ importers:
         version: 17.3.1
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
+        version: 0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(zod@4.3.6)
+        version: 0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)))(zod@4.3.6)
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -146,8 +146,8 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
   apps/web:
     dependencies:
@@ -289,7 +289,7 @@ importers:
         version: link:../../packages/typescript-config
       '@tanstack/eslint-plugin-query':
         specifier: ^5.91.4
-        version: 5.91.4(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 5.91.4(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -321,8 +321,8 @@ importers:
         specifier: ^28.1.0
         version: 28.1.0(@noble/hashes@2.0.1)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       vite:
         specifier: ^8.0.5
         version: 8.0.8(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
@@ -472,20 +472,20 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       typescript-eslint:
         specifier: ^8.57.0
-        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
 
   packages/embed-pdf:
     dependencies:
       '@embedpdf/core':
         specifier: ^2.8.0
-        version: 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/engines':
         specifier: ^2.8.0
-        version: 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models':
         specifier: ^2.8.0
         version: 2.8.0
@@ -494,79 +494,79 @@ importers:
         version: 2.8.0
       '@embedpdf/plugin-annotation':
         specifier: ^2.8.0
-        version: 2.8.0(f9bb5d9a56043e4157573ca782ebb0b6)
+        version: 2.8.0(fef73aa11fba567b674d7736b7fb6c5f)
       '@embedpdf/plugin-capture':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-render@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-render@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-commands':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-document-manager':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-export':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-fullscreen':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-history':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-i18n':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-interaction-manager':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-pan':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-print':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-redaction':
         specifier: ^2.8.0
-        version: 2.8.0(cdcd8a9170be86712711f7f991038595)
+        version: 2.8.0(adff6cbcb95edcef92a16e1e42db2bb4)
       '@embedpdf/plugin-render':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-rotate':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-scroll':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-search':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-selection':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-spread':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-thumbnail':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-render@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-render@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-tiling':
         specifier: ^2.8.0
-        version: 2.8.0(21ff4140acb66d8c9a72896fa1b1013e)
+        version: 2.8.0(67a03d010ea659c828ddf539cadc364e)
       '@embedpdf/plugin-ui':
         specifier: ^2.8.0
-        version: 2.8.0(21ff4140acb66d8c9a72896fa1b1013e)
+        version: 2.8.0(67a03d010ea659c828ddf539cadc364e)
       '@embedpdf/plugin-view-manager':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-viewport':
         specifier: ^2.8.0
-        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/plugin-zoom':
         specifier: ^2.8.0
-        version: 2.8.0(b909b1dc572213059306fbe0d7c538db)
+        version: 2.8.0(af6efc4908f4334d59150340b9639c85)
       '@embedpdf/utils':
         specifier: ^2.8.0
-        version: 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+        version: 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@repo/ui':
         specifier: workspace:*
         version: link:../ui
@@ -605,11 +605,11 @@ importers:
         specifier: ^4.1.18
         version: 4.2.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       typescript-eslint:
         specifier: ^8.54.0
-        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
 
   packages/eslint-config:
     devDependencies:
@@ -641,11 +641,11 @@ importers:
         specifier: ^17.4.0
         version: 17.4.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       typescript-eslint:
         specifier: ^8.57.0
-        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
 
   packages/lib:
     dependencies:
@@ -663,11 +663,11 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(jiti@2.6.1)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       typescript-eslint:
         specifier: ^8.57.0
-        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
 
   packages/sdk:
     dependencies:
@@ -676,7 +676,7 @@ importers:
         version: 1.15.0
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(mongodb@7.1.0(socks@2.8.7))(mysql2@3.15.3)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)))(vue@3.5.30(typescript@5.9.3))
+        version: 1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)))(mongodb@7.1.0(socks@2.8.7))(mysql2@3.15.3)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)))(vue@3.5.30(typescript@6.0.2))
       socket.io-client:
         specifier: ^4.8.3
         version: 4.8.3
@@ -694,8 +694,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(jiti@2.6.1)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
   packages/shared:
     dependencies:
@@ -713,11 +713,11 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(jiti@2.6.1)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       typescript-eslint:
         specifier: ^8.57.0
-        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
 
   packages/types:
     devDependencies:
@@ -734,8 +734,8 @@ importers:
         specifier: ^0.41.0
         version: 0.41.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
   packages/typescript-config: {}
 
@@ -896,11 +896,11 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       typescript-eslint:
         specifier: ^8.57.0
-        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
 
 packages:
 
@@ -8602,8 +8602,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -9874,12 +9874,12 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))':
+  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
     optionalDependencies:
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))
 
   '@better-auth/kysely-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.15)':
     dependencies:
@@ -9900,12 +9900,12 @@ snapshots:
     optionalDependencies:
       mongodb: 7.1.0(socks@2.8.7)
 
-  '@better-auth/prisma-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))':
+  '@better-auth/prisma-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
     optionalDependencies:
-      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)
 
   '@better-auth/telemetry@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))':
     dependencies:
@@ -10086,17 +10086,17 @@ snapshots:
   '@electric-sql/pglite@0.3.15':
     optional: true
 
-  '@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/engines': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/engines': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/engines@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/engines@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
       '@embedpdf/fonts-arabic': 1.0.0
       '@embedpdf/fonts-hebrew': 1.0.0
@@ -10111,7 +10111,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
   '@embedpdf/fonts-arabic@1.0.0': {}
 
@@ -10131,278 +10131,278 @@ snapshots:
 
   '@embedpdf/pdfium@2.8.0': {}
 
-  '@embedpdf/plugin-annotation@2.8.0(f9bb5d9a56043e4157573ca782ebb0b6)':
+  '@embedpdf/plugin-annotation@2.8.0(fef73aa11fba567b674d7736b7fb6c5f)':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
-      '@embedpdf/plugin-history': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/plugin-interaction-manager': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/plugin-selection': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/utils': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/plugin-history': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/plugin-interaction-manager': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/plugin-selection': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/utils': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-capture@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-render@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-capture@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-render@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
-      '@embedpdf/plugin-interaction-manager': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/plugin-render': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/plugin-interaction-manager': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/plugin-render': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-commands@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-commands@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/models': 2.8.0
-      preact: 10.29.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
-
-  '@embedpdf/plugin-document-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-export@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-document-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-fullscreen@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-export@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-history@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-fullscreen@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-i18n@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-history@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-i18n@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-pan@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/models': 2.8.0
-      '@embedpdf/plugin-interaction-manager': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/plugin-viewport': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      preact: 10.29.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
-
-  '@embedpdf/plugin-print@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-redaction@2.8.0(cdcd8a9170be86712711f7f991038595)':
+  '@embedpdf/plugin-pan@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
-      '@embedpdf/plugin-annotation': 2.8.0(f9bb5d9a56043e4157573ca782ebb0b6)
-      '@embedpdf/plugin-history': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/plugin-interaction-manager': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/plugin-selection': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/utils': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/plugin-interaction-manager': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/plugin-viewport': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-render@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-print@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-rotate@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-redaction@2.8.0(adff6cbcb95edcef92a16e1e42db2bb4)':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/models': 2.8.0
+      '@embedpdf/plugin-annotation': 2.8.0(fef73aa11fba567b674d7736b7fb6c5f)
+      '@embedpdf/plugin-history': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/plugin-interaction-manager': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/plugin-selection': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/utils': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      preact: 10.29.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      svelte: 5.53.12
+      vue: 3.5.30(typescript@6.0.2)
+
+  '@embedpdf/plugin-render@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-scroll@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-rotate@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/models': 2.8.0
-      '@embedpdf/plugin-viewport': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      preact: 10.29.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
-
-  '@embedpdf/plugin-search@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-selection@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-scroll@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
-      '@embedpdf/plugin-interaction-manager': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/utils': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/plugin-viewport': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-spread@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-search@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/models': 2.8.0
-      preact: 10.29.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
-
-  '@embedpdf/plugin-thumbnail@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-render@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/models': 2.8.0
-      '@embedpdf/plugin-render': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      preact: 10.29.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
-
-  '@embedpdf/plugin-tiling@2.8.0(21ff4140acb66d8c9a72896fa1b1013e)':
-    dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/models': 2.8.0
-      '@embedpdf/plugin-render': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/plugin-scroll': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/plugin-viewport': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      preact: 10.29.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
-
-  '@embedpdf/plugin-ui@2.8.0(21ff4140acb66d8c9a72896fa1b1013e)':
-    dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/models': 2.8.0
-      '@embedpdf/plugin-render': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/plugin-scroll': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/plugin-viewport': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      preact: 10.29.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
-
-  '@embedpdf/plugin-view-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-selection@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-interaction-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/models': 2.8.0
+      '@embedpdf/plugin-interaction-manager': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/utils': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      preact: 10.29.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      svelte: 5.53.12
+      vue: 3.5.30(typescript@6.0.2)
+
+  '@embedpdf/plugin-spread@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/plugin-zoom@2.8.0(b909b1dc572213059306fbe0d7c538db)':
+  '@embedpdf/plugin-thumbnail@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-render@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       '@embedpdf/models': 2.8.0
-      '@embedpdf/plugin-scroll': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
-      '@embedpdf/plugin-viewport': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))
+      '@embedpdf/plugin-render': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
-  '@embedpdf/utils@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@5.9.3))':
+  '@embedpdf/plugin-tiling@2.8.0(67a03d010ea659c828ddf539cadc364e)':
+    dependencies:
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/models': 2.8.0
+      '@embedpdf/plugin-render': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/plugin-scroll': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/plugin-viewport': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      preact: 10.29.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      svelte: 5.53.12
+      vue: 3.5.30(typescript@6.0.2)
+
+  '@embedpdf/plugin-ui@2.8.0(67a03d010ea659c828ddf539cadc364e)':
+    dependencies:
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/models': 2.8.0
+      '@embedpdf/plugin-render': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/plugin-scroll': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/plugin-viewport': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      preact: 10.29.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      svelte: 5.53.12
+      vue: 3.5.30(typescript@6.0.2)
+
+  '@embedpdf/plugin-view-manager@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/models': 2.8.0
+      preact: 10.29.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      svelte: 5.53.12
+      vue: 3.5.30(typescript@6.0.2)
+
+  '@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/models': 2.8.0
+      preact: 10.29.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      svelte: 5.53.12
+      vue: 3.5.30(typescript@6.0.2)
+
+  '@embedpdf/plugin-zoom@2.8.0(af6efc4908f4334d59150340b9639c85)':
+    dependencies:
+      '@embedpdf/core': 2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/models': 2.8.0
+      '@embedpdf/plugin-scroll': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(@embedpdf/plugin-viewport@2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      '@embedpdf/plugin-viewport': 2.8.0(@embedpdf/core@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2)))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))
+      preact: 10.29.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      svelte: 5.53.12
+      vue: 3.5.30(typescript@6.0.2)
+
+  '@embedpdf/utils@2.8.0(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vue@3.5.30(typescript@6.0.2))':
     dependencies:
       preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
   '@emnapi/core@1.9.2':
     dependencies:
@@ -11255,7 +11255,7 @@ snapshots:
   '@prisma/debug@7.4.2':
     optional: true
 
-  '@prisma/dev@0.20.0(typescript@5.9.3)':
+  '@prisma/dev@0.20.0(typescript@6.0.2)':
     dependencies:
       '@electric-sql/pglite': 0.3.15
       '@electric-sql/pglite-socket': 0.0.20(@electric-sql/pglite@0.3.15)
@@ -11272,7 +11272,7 @@ snapshots:
       proper-lockfile: 4.1.2
       remeda: 2.33.4
       std-env: 3.10.0
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.2.0(typescript@6.0.2)
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
@@ -12631,12 +12631,12 @@ snapshots:
       tailwindcss: 4.2.1
       vite: 8.0.8(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
 
-  '@tanstack/eslint-plugin-query@5.91.4(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@tanstack/eslint-plugin-query@5.91.4(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
       eslint: 10.1.0(jiti@2.6.1)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13004,40 +13004,40 @@ snapshots:
     dependencies:
       '@types/node': 25.5.0
 
-  '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
       '@typescript-eslint/scope-manager': 8.57.1
-      '@typescript-eslint/type-utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.57.1
       eslint: 10.1.0(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.57.1
       '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.1(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.57.1
       debug: 4.4.3
       eslint: 10.1.0(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.57.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.57.1(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@6.0.2)
       '@typescript-eslint/types': 8.57.2
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13046,19 +13046,19 @@ snapshots:
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/visitor-keys': 8.57.1
 
-  '@typescript-eslint/tsconfig-utils@8.57.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.57.1(typescript@6.0.2)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
-  '@typescript-eslint/type-utils@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.1(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
       debug: 4.4.3
       eslint: 10.1.0(jiti@2.6.1)
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13068,29 +13068,29 @@ snapshots:
 
   '@typescript-eslint/types@8.58.1': {}
 
-  '@typescript-eslint/typescript-estree@8.57.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.57.1(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.57.1(typescript@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@6.0.2)
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/visitor-keys': 8.57.1
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.16
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.57.1
       '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.1(typescript@6.0.2)
       eslint: 10.1.0(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13236,11 +13236,11 @@ snapshots:
       '@vue/shared': 3.5.30
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.30(vue@3.5.30(typescript@5.9.3))':
+  '@vue/server-renderer@3.5.30(vue@3.5.30(typescript@6.0.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.30
       '@vue/shared': 3.5.30
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
   '@vue/shared@3.5.30': {}
 
@@ -13471,14 +13471,14 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(mongodb@7.1.0(socks@2.8.7))(mysql2@3.15.3)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)))(vue@3.5.30(typescript@5.9.3)):
+  better-auth@1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)))(mongodb@7.1.0(socks@2.8.7))(mysql2@3.15.3)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.12)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)))(vue@3.5.30(typescript@6.0.2)):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))
+      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)))
       '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.15)
       '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
       '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(mongodb@7.1.0(socks@2.8.7))
-      '@better-auth/prisma-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
+      '@better-auth/prisma-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))
       '@better-auth/telemetry': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.15)(nanostores@1.2.0))
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
@@ -13492,15 +13492,15 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.9
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))
       mongodb: 7.1.0(socks@2.8.7)
       mysql2: 3.15.3
-      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.12
       vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@25.5.0)(esbuild@0.25.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -14299,7 +14299,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.17.0(encoding@0.1.13)
@@ -14307,11 +14307,11 @@ snapshots:
       kysely: 0.28.15
       mysql2: 3.15.3
       postgres: 3.4.7
-      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)
 
-  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(zod@4.3.6):
+  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)))(zod@4.3.6):
     dependencies:
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0(encoding@0.1.13))(@opentelemetry/api@1.9.1)(kysely@0.28.15)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))
       zod: 4.3.6
 
   dunder-proto@1.0.1:
@@ -16539,16 +16539,16 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2):
     dependencies:
       '@prisma/config': 7.4.2
-      '@prisma/dev': 0.20.0(typescript@5.9.3)
+      '@prisma/dev': 0.20.0(typescript@6.0.2)
       '@prisma/engines': 7.4.2
       '@prisma/studio-core': 0.13.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       mysql2: 3.15.3
       postgres: 3.4.7
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@types/react'
       - magicast
@@ -17529,9 +17529,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  ts-api-utils@2.4.0(typescript@5.9.3):
+  ts-api-utils@2.4.0(typescript@6.0.2):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   ts-dedent@2.2.0: {}
 
@@ -17632,18 +17632,18 @@ snapshots:
 
   typescript-collections@1.3.3: {}
 
-  typescript-eslint@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.57.1(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
       eslint: 10.1.0(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   uglify-js@3.19.3:
     optional: true
@@ -17759,9 +17759,9 @@ snapshots:
       kleur: 4.1.5
       sade: 1.8.1
 
-  valibot@1.2.0(typescript@5.9.3):
+  valibot@1.2.0(typescript@6.0.2):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     optional: true
 
   validate-npm-package-license@3.0.4:
@@ -17839,15 +17839,15 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vue@3.5.30(typescript@5.9.3):
+  vue@3.5.30(typescript@6.0.2):
     dependencies:
       '@vue/compiler-dom': 3.5.30
       '@vue/compiler-sfc': 3.5.30
       '@vue/runtime-dom': 3.5.30
-      '@vue/server-renderer': 3.5.30(vue@3.5.30(typescript@5.9.3))
+      '@vue/server-renderer': 3.5.30(vue@3.5.30(typescript@6.0.2))
       '@vue/shared': 3.5.30
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Upgrades the monorepo from TypeScript 5.9 to TypeScript 6 and fixes the typecheck and build issues that appeared after the upgrade. Keeps root `typescript` so every package uses the same compiler version.

## Related Issues

Fixes # [TEA-74](https://linear.app/teamcoderz/issue/TEA-74/upgrade-to-typescript-6-and-fix-migration-regressions)

## Type of Change

Improvement (tooling upgrade)

## Changes

- Set `typescript` to `^6.0.2` in the root and all workspace packages that run `tsc`, and updated `pnpm-lock.yaml`.
- Web: removed deprecated `baseUrl`; `@/*` maps to `./src/*` only.
- Backend: set `rootDir` to `./src` alongside `outDir` so `tsc` emit satisfies TypeScript 6 (TS5011).
- Editor: added ambient `declare module '*.css'` for side-effect CSS imports (TS2882).
- embed-pdf: timer ref uses `ReturnType<typeof setTimeout>` instead of `NodeJS.Timeout`.
- attachments: `copyDocumentAttachments` is `Promise<void>` with an early `return` so all paths return (TS7030) when web typechecks backend code.

## How to Test

1. From repo root: `pnpm install`
2. `pnpm run check-types` — completes with no errors for packages that define `check-types`.
3. `pnpm run build` — backend `tsc` and web `vite build` succeed.

**Expected result:** TypeScript 6 is in use repo-wide, Turbo type checks pass, and production builds pass without migration-related TS errors.