### PR TITLE
fix(TEA-75): import space request limit and refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,44 +4,44 @@
 
 ### Features
 
-* create document search index table and related triggers ([1bb9484](https://github.com/TeamCoderz/WordyMe/commit/1bb948422b2fda7334958df7d4578548e41ce218))
-* **database:** implement full-text search for documents with FTS5 ([0f4274e](https://github.com/TeamCoderz/WordyMe/commit/0f4274e254d044b29681f89b589bddba88336fa3))
-* **search-ui:** match Wordy search dialog UI and wire global document search ([7927120](https://github.com/TeamCoderz/WordyMe/commit/7927120af656fb238e34067950935da3f7c6023b))
-* **search:** add full-text search endpoint for user documents ([dc46805](https://github.com/TeamCoderz/WordyMe/commit/dc46805206e6ca970bc6d76ebb4a9c55705f81ed))
-* **search:** add searchDocuments function the SDK ([1554477](https://github.com/TeamCoderz/WordyMe/commit/15544774fcd1c71350b5ca5a902fb5f55850cd8c))
-* **search:** enhance full-text search to support optional spaceId filtering ([c8f59e7](https://github.com/TeamCoderz/WordyMe/commit/c8f59e7317e6841ecbc3da864d7592a68db00698))
-* **search:** implement full-text search functionality and query utilities ([a899896](https://github.com/TeamCoderz/WordyMe/commit/a899896bf9fee8e39d1ab6ff82bbaf202cf918ce))
-* **search:** pass spaceId through search query options ([eabdd9b](https://github.com/TeamCoderz/WordyMe/commit/eabdd9bbed37e5f5b5ab62fe4a9000c6a337945a))
-* **space-switcher:** add hover card showing full breadcrumb path for nested spaces ([e4c82ba](https://github.com/TeamCoderz/WordyMe/commit/e4c82ba540dfbc1366c214c2b767c908102dc76b))
-* **TEA-69:** disable signups after the first account exists ([#33](https://github.com/TeamCoderz/WordyMe/issues/33)) ([bc0bfe9](https://github.com/TeamCoderz/WordyMe/commit/bc0bfe9c4858946a30264b35219a2e570e861dbc))
+- create document search index table and related triggers ([1bb9484](https://github.com/TeamCoderz/WordyMe/commit/1bb948422b2fda7334958df7d4578548e41ce218))
+- **database:** implement full-text search for documents with FTS5 ([0f4274e](https://github.com/TeamCoderz/WordyMe/commit/0f4274e254d044b29681f89b589bddba88336fa3))
+- **search-ui:** match Wordy search dialog UI and wire global document search ([7927120](https://github.com/TeamCoderz/WordyMe/commit/7927120af656fb238e34067950935da3f7c6023b))
+- **search:** add full-text search endpoint for user documents ([dc46805](https://github.com/TeamCoderz/WordyMe/commit/dc46805206e6ca970bc6d76ebb4a9c55705f81ed))
+- **search:** add searchDocuments function the SDK ([1554477](https://github.com/TeamCoderz/WordyMe/commit/15544774fcd1c71350b5ca5a902fb5f55850cd8c))
+- **search:** enhance full-text search to support optional spaceId filtering ([c8f59e7](https://github.com/TeamCoderz/WordyMe/commit/c8f59e7317e6841ecbc3da864d7592a68db00698))
+- **search:** implement full-text search functionality and query utilities ([a899896](https://github.com/TeamCoderz/WordyMe/commit/a899896bf9fee8e39d1ab6ff82bbaf202cf918ce))
+- **search:** pass spaceId through search query options ([eabdd9b](https://github.com/TeamCoderz/WordyMe/commit/eabdd9bbed37e5f5b5ab62fe4a9000c6a337945a))
+- **space-switcher:** add hover card showing full breadcrumb path for nested spaces ([e4c82ba](https://github.com/TeamCoderz/WordyMe/commit/e4c82ba540dfbc1366c214c2b767c908102dc76b))
+- **TEA-69:** disable signups after the first account exists ([#33](https://github.com/TeamCoderz/WordyMe/issues/33)) ([bc0bfe9](https://github.com/TeamCoderz/WordyMe/commit/bc0bfe9c4858946a30264b35219a2e570e861dbc))
 
 ### Bug Fixes
 
-* **deps:** resolve 5 CVEs via dependency upgrades and pnpm overrides ([6f6a649](https://github.com/TeamCoderz/WordyMe/commit/6f6a64969d5fe077329daed0e13236b6e311c02e))
-* **docker:** run database migrations at container startup instead of build time ([a64c4b9](https://github.com/TeamCoderz/WordyMe/commit/a64c4b973f269189e854360b3500b780d1170a83))
-* **editor:** refresh checksum event deps ([e24969a](https://github.com/TeamCoderz/WordyMe/commit/e24969a1e0ecad017ba86dc9f67f5ba7a138621c))
-* **inputs:** prevent Firefox double-submit on inline create/rename inputs ([73d9a65](https://github.com/TeamCoderz/WordyMe/commit/73d9a651f5141033568ac1bd552f0eb542184e73))
-* **layout:** responsive on small screens ([7758824](https://github.com/TeamCoderz/WordyMe/commit/77588240e5c507358811812ec697f86c5c21914b))
-* **search:** pass spaceId to SDK, singleton hotkey, and safe cloneElement ([acaaf55](https://github.com/TeamCoderz/WordyMe/commit/acaaf55054a33e3a912c067b962bb246d57fe449))
-* **security:** resolve transitive vulnerabilities via pnpm overrides ([dee948e](https://github.com/TeamCoderz/WordyMe/commit/dee948e41d3803e6c7e0ea6ffaf1d4d980c3b9fa))
-* **tabs:** fix tabs save button error ([674f781](https://github.com/TeamCoderz/WordyMe/commit/674f781a711d74105ed790063d9639942f1b40b6))
-* **web:** allow empty last name and guard invalid profile section ([544950f](https://github.com/TeamCoderz/WordyMe/commit/544950ffd9cf1ce9f37a17bf66abaeca3463cf9f))
-* **web:** improve settings tab reuse and close user menu on navigation ([35bf4b2](https://github.com/TeamCoderz/WordyMe/commit/35bf4b2172161d91a5be02b299773fe67e5f928d))
+- **deps:** resolve 5 CVEs via dependency upgrades and pnpm overrides ([6f6a649](https://github.com/TeamCoderz/WordyMe/commit/6f6a64969d5fe077329daed0e13236b6e311c02e))
+- **docker:** run database migrations at container startup instead of build time ([a64c4b9](https://github.com/TeamCoderz/WordyMe/commit/a64c4b973f269189e854360b3500b780d1170a83))
+- **editor:** refresh checksum event deps ([e24969a](https://github.com/TeamCoderz/WordyMe/commit/e24969a1e0ecad017ba86dc9f67f5ba7a138621c))
+- **inputs:** prevent Firefox double-submit on inline create/rename inputs ([73d9a65](https://github.com/TeamCoderz/WordyMe/commit/73d9a651f5141033568ac1bd552f0eb542184e73))
+- **layout:** responsive on small screens ([7758824](https://github.com/TeamCoderz/WordyMe/commit/77588240e5c507358811812ec697f86c5c21914b))
+- **search:** pass spaceId to SDK, singleton hotkey, and safe cloneElement ([acaaf55](https://github.com/TeamCoderz/WordyMe/commit/acaaf55054a33e3a912c067b962bb246d57fe449))
+- **security:** resolve transitive vulnerabilities via pnpm overrides ([dee948e](https://github.com/TeamCoderz/WordyMe/commit/dee948e41d3803e6c7e0ea6ffaf1d4d980c3b9fa))
+- **tabs:** fix tabs save button error ([674f781](https://github.com/TeamCoderz/WordyMe/commit/674f781a711d74105ed790063d9639942f1b40b6))
+- **web:** allow empty last name and guard invalid profile section ([544950f](https://github.com/TeamCoderz/WordyMe/commit/544950ffd9cf1ce9f37a17bf66abaeca3463cf9f))
+- **web:** improve settings tab reuse and close user menu on navigation ([35bf4b2](https://github.com/TeamCoderz/WordyMe/commit/35bf4b2172161d91a5be02b299773fe67e5f928d))
 
 ## [0.1.1-beta.0](https://github.com/TeamCoderz/WordyMe/compare/v0.1.0-beta.0...v0.1.1-beta.0) (2026-03-29)
 
 ### Features
 
-* add embed-pdf package and refactor state management ([#17](https://github.com/TeamCoderz/WordyMe/issues/17)) ([166c14c](https://github.com/TeamCoderz/WordyMe/commit/166c14c442a6fd884124389668f18fdb5fa2f7df))
-* add useDocumentActions and refine various components ([b921984](https://github.com/TeamCoderz/WordyMe/commit/b92198441de59dec0d13342622218bdf2b1f8511))
-* enhance bug report template with issue scope and detailed environment info ([07a7c2d](https://github.com/TeamCoderz/WordyMe/commit/07a7c2dd63bbca4276e58c3ecf571c5c47d19049))
-* split view ([#15](https://github.com/TeamCoderz/WordyMe/issues/15)) ([055b78a](https://github.com/TeamCoderz/WordyMe/commit/055b78aced3783b5df3a3e2dd31f38c05958731a)), closes [#16](https://github.com/TeamCoderz/WordyMe/issues/16)
+- add embed-pdf package and refactor state management ([#17](https://github.com/TeamCoderz/WordyMe/issues/17)) ([166c14c](https://github.com/TeamCoderz/WordyMe/commit/166c14c442a6fd884124389668f18fdb5fa2f7df))
+- add useDocumentActions and refine various components ([b921984](https://github.com/TeamCoderz/WordyMe/commit/b92198441de59dec0d13342622218bdf2b1f8511))
+- enhance bug report template with issue scope and detailed environment info ([07a7c2d](https://github.com/TeamCoderz/WordyMe/commit/07a7c2dd63bbca4276e58c3ecf571c5c47d19049))
+- split view ([#15](https://github.com/TeamCoderz/WordyMe/issues/15)) ([055b78a](https://github.com/TeamCoderz/WordyMe/commit/055b78aced3783b5df3a3e2dd31f38c05958731a)), closes [#16](https://github.com/TeamCoderz/WordyMe/issues/16)
 
 ### Bug Fixes
 
-* add canBeEmpty method to PageContentNode and enhance stray child handling in PaginationPlugin ([bfe7560](https://github.com/TeamCoderz/WordyMe/commit/bfe75608ea7bf1deb8a8a8c677fd2031cadbea5d))
-* **auth,editor:** HTTP session cookies, compose env, and IndexedDB AES without Web Crypto ([a78963c](https://github.com/TeamCoderz/WordyMe/commit/a78963c590cfab1b2a369facc55e1233b9deb91d))
-* update image zoom logic and table of contents scrolling ([3503c1c](https://github.com/TeamCoderz/WordyMe/commit/3503c1c4af3a5e0feb7c4c045db3a376c365df54))
+- add canBeEmpty method to PageContentNode and enhance stray child handling in PaginationPlugin ([bfe7560](https://github.com/TeamCoderz/WordyMe/commit/bfe75608ea7bf1deb8a8a8c677fd2031cadbea5d))
+- **auth,editor:** HTTP session cookies, compose env, and IndexedDB AES without Web Crypto ([a78963c](https://github.com/TeamCoderz/WordyMe/commit/a78963c590cfab1b2a369facc55e1233b9deb91d))
+- update image zoom logic and table of contents scrolling ([3503c1c](https://github.com/TeamCoderz/WordyMe/commit/3503c1c4af3a5e0feb7c4c045db3a376c365df54))
 
 ## [0.1.1-beta.0](https://github.com/TeamCoderz/WordyMe/compare/v0.1.0-beta.0...v0.1.0-beta.0) (2026-03-29)
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -41,7 +41,7 @@ app.use(
 app.all('/api/auth/{*any}', toNodeHandler(auth));
 
 app.use(morgan('dev'));
-app.use(express.json());
+app.use(express.json({ limit: '5mb' }));
 
 app.use('/api/documents', documentsRouter);
 app.use('/api/revisions', revisionsRouter);

--- a/apps/backend/src/utils/errors.ts
+++ b/apps/backend/src/utils/errors.ts
@@ -8,10 +8,12 @@ import { HttpError } from 'http-errors';
 import { ZodError } from 'zod';
 
 function isExpressError(err: unknown): err is HttpError {
+  return err instanceof Error && ('status' in err || 'statusCode' in err);
+}
+
+function isPayloadTooLargeError(err: unknown): err is Error & { type?: string } {
   return (
-    err instanceof Error &&
-    Object.keys(err).includes('expose') &&
-    Object.keys(err).includes('status')
+    err instanceof Error && 'type' in err && (err as { type?: string }).type === 'entity.too.large'
   );
 }
 
@@ -20,9 +22,16 @@ export const toHttpException = (error: unknown): HttpException => {
     return error;
   }
 
-  // Convert express errors to HttpException
+  if (isPayloadTooLargeError(error)) {
+    return new HttpException(
+      413,
+      'Request body is too large. Maximum allowed payload is 5MB. Please reduce the import size and try again.',
+    );
+  }
+
   if (isExpressError(error)) {
-    return new HttpException(error.status, error.message);
+    const status = typeof error.status === 'number' ? error.status : error.statusCode;
+    return new HttpException(status ?? 500, error.message);
   }
 
   if (error instanceof ZodError) {

--- a/apps/web/src/components/Layout/tabs/useTabMetadata.ts
+++ b/apps/web/src/components/Layout/tabs/useTabMetadata.ts
@@ -1,6 +1,7 @@
 import { keepPreviousData, skipToken, useQuery } from '@tanstack/react-query';
 import type { Tab, TabMetadata } from '@repo/types';
 import { useEffect } from 'react';
+import { TABS_QUERY_KEYS } from '@/queries/query-keys';
 import { useSelector } from '@/store';
 import { resolveTabMetadata } from './resolveTabMetadata';
 
@@ -25,7 +26,7 @@ export function useTabMetadata(tab: Tab): TabMetadata {
 
   const { data, isError } = useQuery({
     ...resolved.queryOption,
-    queryKey: resolved.queryOption?.queryKey ?? ['tab-metadata-noop', tab.id],
+    queryKey: resolved.queryOption?.queryKey ?? TABS_QUERY_KEYS.METADATA_NOOP(tab.id),
     queryFn: resolved.queryOption?.queryFn ?? skipToken,
     placeholderData: keepPreviousData,
     retry: 1,

--- a/apps/web/src/queries/auth.ts
+++ b/apps/web/src/queries/auth.ts
@@ -6,11 +6,10 @@
 import { useMutation, useQueryClient, type UseQueryOptions } from '@tanstack/react-query';
 import { getSignupAvailability, type SignupAvailability, login, register } from '@repo/sdk/auth';
 import { toast } from '@repo/ui/components/sonner';
-
-export const signupAvailabilityQueryKey = ['auth', 'signupAvailability'] as const;
+import { AUTH_QUERY_KEYS } from './query-keys';
 
 export const signupAvailabilityQueryOptions: UseQueryOptions<SignupAvailability, Error> = {
-  queryKey: signupAvailabilityQueryKey,
+  queryKey: AUTH_QUERY_KEYS.SIGNUP_AVAILABILITY,
   queryFn: getSignupAvailability,
   staleTime: 60_000,
 };
@@ -72,7 +71,7 @@ export function useRegisterMutation() {
       return toast.loading('Creating account...');
     },
     onSuccess: (_, __, toastId) => {
-      void queryClient.invalidateQueries({ queryKey: signupAvailabilityQueryKey });
+      void queryClient.invalidateQueries({ queryKey: AUTH_QUERY_KEYS.SIGNUP_AVAILABILITY });
       toast.success('Account created successfully', {
         id: toastId,
       });

--- a/apps/web/src/queries/documents.ts
+++ b/apps/web/src/queries/documents.ts
@@ -1258,8 +1258,8 @@ export function useExportDocumentMutation(itemId: string, documentName?: string)
     onMutate() {
       return toast.loading('Exporting document...');
     },
-    onError(_, __, context) {
-      toast.error('Failed to export document', { id: context });
+    onError(error, __, context) {
+      toast.error(error.message || 'Failed to export document', { id: context });
     },
     onSuccess(_, __, context) {
       toast.success('Document exported successfully', { id: context });

--- a/apps/web/src/queries/documents.ts
+++ b/apps/web/src/queries/documents.ts
@@ -90,7 +90,7 @@ export const searchDocumentsQueryOptions = (search: string, spaceId?: string, li
 
 export function getAllDocumentsQueryOptions(spaceID: string): UseQueryOptions<ListDocumentResult> {
   return {
-    queryKey: ['documents', spaceID],
+    queryKey: DOCUMENTS_QUERY_KEYS.LIST_BY_SPACE(spaceID),
     queryFn: async () => {
       const { data, error } = await listDocuments({ spaceId: spaceID });
       if (error) {
@@ -943,7 +943,7 @@ export function useDuplicateDocumentMutation({
 
 export const getDocumentByIdQueryOptions = (id: string, queryClient?: QueryClient) => {
   return {
-    queryKey: ['document', id, { id: true }],
+    queryKey: DOCUMENTS_QUERY_KEYS.DETAIL_BY_ID(id),
     queryFn: async () => {
       const { data: document, error: documentError } = await getDocumentById(id, {
         updateLastViewed: true,
@@ -967,7 +967,7 @@ export const getDocumentByIdQueryOptions = (id: string, queryClient?: QueryClien
 
 export const getDocumentByHandleQueryOptions = (handle: string) => {
   return {
-    queryKey: ['document', handle],
+    queryKey: DOCUMENTS_QUERY_KEYS.DETAIL_BY_HANDLE(handle),
     queryFn: async () => {
       const { data: document, error: documentError } = await getDocumentByHandle(handle, {
         updateLastViewed: true,
@@ -1297,7 +1297,7 @@ export function useImportDocumentMutation(parentId?: string | null, spaceId?: st
       // Invalidate the documents query for the space
       if (spaceId) {
         queryClient.invalidateQueries({
-          queryKey: ['documents', spaceId],
+          queryKey: DOCUMENTS_QUERY_KEYS.LIST_BY_SPACE(spaceId),
         });
       }
       return data;

--- a/apps/web/src/queries/profile.ts
+++ b/apps/web/src/queries/profile.ts
@@ -67,8 +67,8 @@ export function useChangeAvatarMutation() {
         });
       }
     },
-    onError: (_, __, toastId) => {
-      toast.error('Failed to upload avatar', {
+    onError: (error, __, toastId) => {
+      toast.error(error.message || 'Failed to upload avatar', {
         id: toastId ?? undefined,
       });
     },
@@ -130,8 +130,8 @@ export function useChangeCoverMutation() {
         });
       }
     },
-    onError: (_, __, toastId) => {
-      toast.error('Failed to upload cover', {
+    onError: (error, __, toastId) => {
+      toast.error(error.message || 'Failed to upload cover', {
         id: toastId ?? undefined,
       });
     },
@@ -160,8 +160,8 @@ export function useUpdateCoverMetadataMutation() {
         id: toastId ?? undefined,
       });
     },
-    onError: (_, __, toastId) => {
-      toast.error('Failed to update cover metadata', {
+    onError: (error, __, toastId) => {
+      toast.error(error.message || 'Failed to update cover metadata', {
         id: toastId ?? undefined,
       });
     },
@@ -191,8 +191,8 @@ export function useUpdateAvatarMetadataMutation() {
         id: toastId ?? undefined,
       });
     },
-    onError: (_, __, toastId) => {
-      toast.error('Failed to update avatar metadata', {
+    onError: (error, __, toastId) => {
+      toast.error(error.message || 'Failed to update avatar metadata', {
         id: toastId ?? undefined,
       });
     },
@@ -220,8 +220,8 @@ export function useDeleteAvatarMutation() {
         setUser({ ...user, avatar_image: undefined });
       }
     },
-    onError: (_, __, toastId) => {
-      toast.error('Failed to delete avatar', {
+    onError: (error, __, toastId) => {
+      toast.error(error.message || 'Failed to delete avatar', {
         id: toastId ?? undefined,
       });
     },
@@ -246,8 +246,8 @@ export function useDeleteProfileMutation() {
       });
       await logout();
     },
-    onError: (_, __, toastId) => {
-      toast.error('Failed to delete account', {
+    onError: (error, __, toastId) => {
+      toast.error(error.message || 'Failed to delete account', {
         id: toastId ?? undefined,
       });
     },
@@ -282,8 +282,8 @@ export function useUpdateProfileMutation() {
         id: toastId ?? undefined,
       });
     },
-    onError: (_, __, toastId) => {
-      toast.error('Failed to update profile', {
+    onError: (error, __, toastId) => {
+      toast.error(error.message || 'Failed to update profile', {
         id: toastId ?? undefined,
       });
     },
@@ -316,8 +316,8 @@ export function useToggleKeepPreviousRevisionMutation() {
         });
       }
     },
-    onError: (_err, __, toastId) => {
-      toast.error('Failed to update editor preferences', {
+    onError: (error, __, toastId) => {
+      toast.error(error.message || 'Failed to update editor preferences', {
         id: toastId ?? undefined,
       });
     },
@@ -350,8 +350,8 @@ export function useToggleAutosaveMutation() {
         });
       }
     },
-    onError: (_err, __, toastId) => {
-      toast.error('Failed to update editor preferences', {
+    onError: (error, __, toastId) => {
+      toast.error(error.message || 'Failed to update editor preferences', {
         id: toastId ?? undefined,
       });
     },

--- a/apps/web/src/queries/query-keys.ts
+++ b/apps/web/src/queries/query-keys.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-//documents query keys
+/** Document-related React Query keys (single source of truth). */
 export const DOCUMENTS_QUERY_KEYS = {
   FAVORITES: ['docs', 'favorites'],
   HOME: {
@@ -14,13 +14,40 @@ export const DOCUMENTS_QUERY_KEYS = {
   },
   RECENT_VIEWS: ['docs', 'recent-viewed'],
   SEARCH_DOCUMENTS: (search: string, spaceId?: string) => ['docs', 'search', { search, spaceId }],
+
+  /** Full hierarchy for a space (`listDocuments`). */
+  LIST_BY_SPACE: (spaceId: string) => ['documents', spaceId] as const,
+
+  /** One document loaded by id (third segment distinguishes from handle). */
+  DETAIL_BY_ID: (id: string) => ['document', id, { id: true as const }] as const,
+
+  /** One document loaded by handle. */
+  DETAIL_BY_HANDLE: (handle: string) => ['document', handle] as const,
 };
 
-//spaces query keys
+/** Space document (space entity) query keys. */
 export const SPACES_QUERY_KEYS = {
   FAVORITES: ['spaces', 'favorites'],
   HOME: {
     BASE: ['home', 'spaces'],
     FAVORITES: ['home', 'spaces', 'favorites'],
   },
+};
+
+/** Revision / local revision query keys. */
+export const REVISIONS_QUERY_KEYS = {
+  BY_DOCUMENT_ID: (documentId: string) => ['revisions', documentId] as const,
+  BY_ID: (revisionId: string) => ['revision', revisionId] as const,
+  LOCAL_BY_DOCUMENT_ID: (documentId: string) => ['localDocumentRevision', documentId] as const,
+};
+
+/** Auth-related query keys. */
+export const AUTH_QUERY_KEYS = {
+  SIGNUP_AVAILABILITY: ['auth', 'signupAvailability'] as const,
+};
+
+/** Tab / layout query keys. */
+export const TABS_QUERY_KEYS = {
+  /** Placeholder key when a tab has no registered metadata query. */
+  METADATA_NOOP: (tabId: string) => ['tab-metadata-noop', tabId] as const,
 };

--- a/apps/web/src/queries/revisions.ts
+++ b/apps/web/src/queries/revisions.ts
@@ -19,13 +19,14 @@ import { keepPreviousData, useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useAllQueriesInvalidate } from './utils';
 import { getDocumentByHandleQueryOptions } from './documents';
+import { REVISIONS_QUERY_KEYS } from './query-keys';
 import type { Document } from '@repo/types';
 import type { SerializedEditorState } from '@repo/editor/types';
 import { getLocalDocument, saveLocalDocument } from '@repo/editor/indexeddb';
 
 export const getRevisionsByDocumentIdQueryOptions = (documentId: string) => {
   return {
-    queryKey: ['revisions', documentId],
+    queryKey: REVISIONS_QUERY_KEYS.BY_DOCUMENT_ID(documentId),
     queryFn: async () => {
       if (!documentId) return [];
       const { data, error } = await getRevisionsByDocumentId(documentId);
@@ -245,7 +246,7 @@ export function useSaveDocumentMutation({
 
 export function getRevisionByIdQueryOptions(revisionId: string, enabled: boolean) {
   return {
-    queryKey: ['revision', revisionId],
+    queryKey: REVISIONS_QUERY_KEYS.BY_ID(revisionId),
     queryFn: async () => {
       const { data: revision, error: revisionError } = await getRevisionById(revisionId);
       if (revisionError) throw revisionError;
@@ -262,7 +263,7 @@ export function getLocalRevisionByDocumentIdQueryOptions(
   enabled?: boolean,
 ) {
   return {
-    queryKey: ['localDocumentRevision', documentId!],
+    queryKey: REVISIONS_QUERY_KEYS.LOCAL_BY_DOCUMENT_ID(documentId!),
     queryFn: async () => {
       if (!documentId || !head) return null;
       try {

--- a/apps/web/src/queries/spaces.ts
+++ b/apps/web/src/queries/spaces.ts
@@ -53,7 +53,7 @@ export type ListSpaceResultItem = NonNullable<
 export type ListSpaceResult = ListSpaceResultItem[];
 
 export const getAllSpacesQueryOptions: UseSuspenseQueryOptions<ListSpaceResult> = {
-  queryKey: ['spaces'],
+  queryKey: SPACES_QUERY_KEYS.HOME.BASE,
   queryFn: async () => {
     const { data, error } = await listSpaces();
     if (error) throw error;

--- a/apps/web/src/queries/spaces.ts
+++ b/apps/web/src/queries/spaces.ts
@@ -921,8 +921,8 @@ export function useExportSpaceMutation(itemId: string, spaceName?: string) {
     onMutate() {
       return toast.loading('Exporting space...');
     },
-    onError(_, __, context) {
-      toast.error('Failed to export space', { id: context });
+    onError(error, __, context) {
+      toast.error(error.message || 'Failed to export space', { id: context });
     },
     onSuccess(_, __, context) {
       toast.success('Space exported successfully', { id: context });

--- a/apps/web/src/queries/utils.ts
+++ b/apps/web/src/queries/utils.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, type QueryKey } from '@tanstack/react-query';
 
 export function getDescendants<T extends { id: string; parentId?: string | null }>(
   items: T[],
@@ -37,11 +37,9 @@ export function getDescendants<T extends { id: string; parentId?: string | null 
 
 export function useAllQueriesInvalidate() {
   const queryClient = useQueryClient();
-  const invalidate = (queryKeys: string[][]) => {
+  const invalidate = (queryKeys: QueryKey[]) => {
     for (const queryKey of queryKeys) {
-      queryClient.invalidateQueries({
-        queryKey: queryKey,
-      });
+      queryClient.invalidateQueries({ queryKey });
     }
   };
   return invalidate;

--- a/packages/sdk/src/app/axios-backend-message.ts
+++ b/packages/sdk/src/app/axios-backend-message.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { HttpException } from '@repo/backend/errors.js';
+import { isAxiosError, type AxiosError } from 'axios';
+
+/** Mutates AxiosError.message when the response body includes a server message (e.g. @httpx/exception JSON). */
+export function applyBackendMessageToAxiosError(
+  error: unknown,
+): AxiosError<HttpException> | unknown {
+  if (!isAxiosError<HttpException>(error)) {
+    return error;
+  }
+  const body = error.response?.data;
+  const serverMessage = body && typeof body.message === 'string' ? body.message.trim() : '';
+  if (serverMessage) {
+    error.message = serverMessage;
+  }
+  return error;
+}

--- a/packages/sdk/src/app/client.ts
+++ b/packages/sdk/src/app/client.ts
@@ -5,6 +5,7 @@
 
 import type { HttpException } from '@repo/backend/errors.js';
 import axios, { AxiosError } from 'axios';
+import { applyBackendMessageToAxiosError } from './axios-backend-message.js';
 
 export const client = axios.create({
   baseURL: import.meta.env.VITE_BACKEND_URL + '/api',
@@ -17,7 +18,10 @@ export const get = async <T>(url: string, params?: Record<string, unknown>) => {
     const response = await client.get<T>(url, { params });
     return { data: response.data, error: null };
   } catch (error) {
-    return { data: null, error: error as AxiosError<HttpException> };
+    return {
+      data: null,
+      error: applyBackendMessageToAxiosError(error) as AxiosError<HttpException>,
+    };
   }
 };
 
@@ -26,7 +30,10 @@ export const post = async <T>(url: string, data?: unknown) => {
     const response = await client.post<T>(url, data);
     return { data: response.data, error: null };
   } catch (error) {
-    return { data: null, error: error as AxiosError<HttpException> };
+    return {
+      data: null,
+      error: applyBackendMessageToAxiosError(error) as AxiosError<HttpException>,
+    };
   }
 };
 
@@ -35,7 +42,10 @@ export const patch = async <T>(url: string, data?: unknown) => {
     const response = await client.patch<T>(url, data);
     return { data: response.data, error: null };
   } catch (error) {
-    return { data: null, error: error as AxiosError<HttpException> };
+    return {
+      data: null,
+      error: applyBackendMessageToAxiosError(error) as AxiosError<HttpException>,
+    };
   }
 };
 
@@ -44,6 +54,6 @@ export const del = async (url: string) => {
     await client.delete(url);
     return { error: null };
   } catch (error) {
-    return { error: error as AxiosError<HttpException> };
+    return { error: applyBackendMessageToAxiosError(error) as AxiosError<HttpException> };
   }
 };

--- a/packages/sdk/src/app/storage.ts
+++ b/packages/sdk/src/app/storage.ts
@@ -6,6 +6,7 @@
 import { HttpException } from '@repo/backend/errors.js';
 import { ImageMeta } from '@repo/backend/images.js';
 import axios, { AxiosError } from 'axios';
+import { applyBackendMessageToAxiosError } from './axios-backend-message.js';
 
 const storageClient = axios.create({
   baseURL: import.meta.env.VITE_BACKEND_URL + '/storage',
@@ -17,7 +18,10 @@ export const getFile = async (url: string, responseType: 'text' | 'blob' = 'text
     const response = await storageClient.get(url, { responseType });
     return { data: response.data, error: null };
   } catch (error) {
-    return { data: null, error: error as AxiosError<HttpException> };
+    return {
+      data: null,
+      error: applyBackendMessageToAxiosError(error) as AxiosError<HttpException>,
+    };
   }
 };
 
@@ -30,7 +34,10 @@ export const uploadFormData = async <T>(
     const response = await storageClient[method]<T>(url, formData, {});
     return { data: response.data, error: null };
   } catch (error) {
-    return { data: null, error: error as AxiosError<HttpException> };
+    return {
+      data: null,
+      error: applyBackendMessageToAxiosError(error) as AxiosError<HttpException>,
+    };
   }
 };
 
@@ -39,7 +46,7 @@ export const deleteFile = async (url: string) => {
     await storageClient.delete(url);
     return { error: null };
   } catch (error) {
-    return { error: error as AxiosError<HttpException> };
+    return { error: applyBackendMessageToAxiosError(error) as AxiosError<HttpException> };
   }
 };
 


### PR DESCRIPTION
## Summary

Fixes space import failing on the server when the JSON body exceeds Express’s default JSON size cap, and fixes the space sidebar not updating after a successful import because the spaces list query used a different cache key than the invalidation paths.

## Related Issues

Fixes [#TEA-75](https://linear.app/teamcoderz/issue/TEA-75/importing-a-space-leads-to-a-server-error)

## Type of Change

Bug fix, Refactor

## Changes

- Raise `express.json` body size limit (e.g. 5MB) so typical space import payloads are accepted.
- Return **413** with a clear message when the body is still too large; tighten Express error detection (`status` / `statusCode`).
- Use **`SPACES_QUERY_KEYS.HOME.BASE`** for `getAllSpacesQueryOptions.queryKey` so post-import invalidation targets the same key as the rest of the app (fixes list not updating until refresh).
- Centralize document, revision, auth, and tab noop query keys in **`query-keys.ts`**; type **`useAllQueriesInvalidate`** with **`QueryKey[]`**.

## How to Test

1. Import a space JSON that is **larger than 100KB** (previously failed): confirm import **succeeds** and no 500 from body parser.
2. Import a space from the sidebar/context menu: confirm **success toast** and the **new space appears under the workspace** without a full page reload.
3. Smoke-test other JSON APIs (e.g. small mutations) to ensure nothing regresses with the new body limit.

**Expected result:** Large imports no longer hit a generic server error from the default limit; after import, the space list updates immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API now enforces a 5MB request body size limit for JSON payloads.

* **Bug Fixes**
  * Improved error messaging to display actual server error details instead of generic fallback messages across API requests and operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->