### PR TITLE
feat(tabs): add generic LinkButton and fix tab/dropdown navigation

### DIFF
--- a/apps/web/src/components/Layout/space-switcher/SpaceSwitcher.tsx
+++ b/apps/web/src/components/Layout/space-switcher/SpaceSwitcher.tsx
@@ -462,7 +462,7 @@ export function SpaceSwitcher() {
                   <DropdownMenuItem asChild disabled={shouldDisableManage}>
                     <LinkButton
                       to="/spaces/manage"
-                      className="flex h-8 w-full items-center gap-2 overflow-hidden rounded-md border border-dashed p-2 text-sm select-none bg-accent/50 data-highlighted:bg-accent/70 text-muted-foreground shrink-0 mb-1 cursor-pointer"
+                      className="flex h-8 w-full items-center gap-2 overflow-hidden rounded-md border border-dashed p-2 text-sm select-none bg-accent/50 data-highlighted:bg-accent/70 text-muted-foreground shrink-0 mb-1 cursor-pointer data-disabled:pointer-events-none"
                       newTab
                     >
                       <Settings2 className="h-4 w-4 shrink-0" />

--- a/apps/web/src/components/Layout/space-switcher/SpaceSwitcher.tsx
+++ b/apps/web/src/components/Layout/space-switcher/SpaceSwitcher.tsx
@@ -45,7 +45,7 @@ import { SpaceItem } from './SpaceItem';
 import { useSpaceSwitcher } from './hooks';
 import { SpaceData, SpaceItemProps } from './types';
 import { useNavigate } from '@tanstack/react-router';
-import { Link } from '@tanstack/react-router';
+import { LinkButton } from '@/components/Layout/tabs';
 import {
   ContextMenu,
   ContextMenuContent,
@@ -65,7 +65,6 @@ import {
 import { getSiblings, sortByPosition, generatePositionKeyBetween } from '@repo/lib/utils/position';
 import { toast } from 'sonner';
 import { ScrollArea } from '@repo/ui/components/scroll-area';
-import { cn } from '@repo/ui/lib/utils';
 import { v4 as uuidv4 } from 'uuid';
 
 export function SpaceSwitcher() {
@@ -461,25 +460,14 @@ export function SpaceSwitcher() {
               >
                 <ContextMenuTrigger>
                   <DropdownMenuItem asChild disabled={shouldDisableManage}>
-                    <SidebarMenuButton
-                      className="border border-dashed rounded-md select-none bg-accent/50 hover:bg-accent/70 flex items-center gap-2 text-muted-foreground"
-                      asChild
+                    <LinkButton
+                      to="/spaces/manage"
+                      className="flex h-8 w-full items-center gap-2 overflow-hidden rounded-md border border-dashed p-2 text-sm select-none bg-accent/50 data-highlighted:bg-accent/70 text-muted-foreground shrink-0 mb-1 cursor-pointer"
+                      newTab
                     >
-                      <Link
-                        to="/spaces/manage"
-                        data-new-tab="true"
-                        className={cn('shrink-0 mb-1 cursor-pointer', {
-                          'cursor-default pointer-events-none': shouldDisableManage,
-                        })}
-                        tabIndex={shouldDisableManage ? -1 : 0}
-                        onMouseDown={(e) => {
-                          if (shouldDisableManage) e.preventDefault();
-                        }}
-                      >
-                        <Settings2 className="mr-2 h-4 w-4" />
-                        Manage Spaces
-                      </Link>
-                    </SidebarMenuButton>
+                      <Settings2 className="h-4 w-4 shrink-0" />
+                      Manage Spaces
+                    </LinkButton>
                   </DropdownMenuItem>
 
                   {/* Scrollable space items */}

--- a/apps/web/src/components/Layout/tabs/LinkButton.tsx
+++ b/apps/web/src/components/Layout/tabs/LinkButton.tsx
@@ -1,0 +1,186 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import * as React from 'react';
+import {
+  useNavigate,
+  useRouter,
+  type AnyRouter,
+  type RegisteredRouter,
+  type LinkOptions,
+} from '@tanstack/react-router';
+import { useSelector, useActions } from '@/store';
+import { matchTabLocation, findGroupTab } from './utils';
+
+type ValidRouteProps<
+  TRouter extends AnyRouter = RegisteredRouter,
+  TFrom extends string = string,
+  TTo extends string | undefined = undefined,
+> = Pick<LinkOptions<TRouter, TFrom, TTo>, 'to' | 'params' | 'search' | 'hash'>;
+
+export interface LinkButtonProps<
+  TRouter extends AnyRouter = RegisteredRouter,
+  TFrom extends string = string,
+  TTo extends string | undefined = undefined,
+>
+  extends
+    Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'>,
+    Omit<ValidRouteProps<TRouter, TFrom, TTo>, 'to'> {
+  /** Route path — validated against all registered routes at compile time */
+  to: NonNullable<ValidRouteProps<TRouter, TFrom, TTo>['to']>;
+  className?: string;
+  /** Force open in a new tab in the same pane — equivalent to Ctrl/Cmd+Click */
+  newTab?: boolean;
+  /** Force open in the opposite (split) pane — equivalent to Shift+Click */
+  newSplitTab?: boolean;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+/**
+ * A button that navigates with the same tab-aware logic as intercepted <a> links in TabSync.
+ *
+ * Behaviour matrix (mirrors TabSync.handleLinkClick):
+ *   Default click     → navigate current tab in place (or switch to existing tab)
+ *   Ctrl/Cmd+Click    → open new tab in same pane
+ *   Shift+Click       → open in opposite (split) pane
+ *   newTab prop       → always open new tab (like data-new-tab="true" on <a>)
+ *   newSplitTab prop  → always open in split pane (like data-new-split-tab="true" on <a>)
+ *
+ * Uses React.forwardRef so Radix's Slot (e.g. DropdownMenuItem asChild) can merge
+ * its own event handlers. Unlike <Link>, this button never calls e.preventDefault(),
+ * which means Radix's composeEventHandlers correctly fires its close/select logic.
+ */
+function LinkButtonFn<
+  TRouter extends AnyRouter = RegisteredRouter,
+  TFrom extends string = string,
+  TTo extends string | undefined = undefined,
+>(
+  {
+    to,
+    params,
+    search,
+    hash,
+    newTab = false,
+    newSplitTab = false,
+    onClick,
+    className,
+    type = 'button',
+    children,
+    ...props
+  }: LinkButtonProps<TRouter, TFrom, TTo>,
+  ref: React.ForwardedRef<HTMLButtonElement>,
+) {
+  const navigate = useNavigate();
+  const router = useRouter();
+  const { openTab, updateTab, setActiveTab } = useActions();
+
+  const activeTab = useSelector((state) =>
+    state.tabs.tabList.find((t) => t.id === state.tabs.activeTabId[state.tabs.activePane]),
+  );
+  const activePane = useSelector((state) => state.tabs.activePane);
+  const primaryTabList = useSelector((state) =>
+    state.tabs.tabList.filter((t) => state.tabs.paneTabIds.primary.includes(t.id)),
+  );
+  const secondaryTabList = useSelector((state) =>
+    state.tabs.tabList.filter((t) => state.tabs.paneTabIds.secondary.includes(t.id)),
+  );
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+
+    const resolved = router.buildLocation({
+      to,
+      params,
+      search,
+      hash,
+    } as Parameters<typeof router.buildLocation>[0]);
+    const toStr = resolved.pathname;
+    const targetSearch = resolved.search as Record<string, unknown>;
+    const targetHash = resolved.hash ?? '';
+
+    const isModifierHeld = event.metaKey || event.ctrlKey;
+    const isShiftHeld = event.shiftKey;
+
+    const activePaneTabList = activePane === 'secondary' ? secondaryTabList : primaryTabList;
+    const oppositePaneTabList = activePane === 'secondary' ? primaryTabList : secondaryTabList;
+    const targetTabList = isShiftHeld ? oppositePaneTabList : activePaneTabList;
+    const allTabs = [...primaryTabList, ...secondaryTabList];
+
+    const shouldOpenNewTab = isModifierHeld || newTab;
+    const shouldSplitTab = isShiftHeld || newSplitTab;
+    const isViewLink = toStr.startsWith('/view/');
+    const isPreviewEligible =
+      isViewLink && !isModifierHeld && !isShiftHeld && !newTab && !newSplitTab;
+
+    const existingTab = targetTabList.find((t) =>
+      matchTabLocation(t, toStr, targetSearch, targetHash),
+    );
+    const existingGroupTab = !existingTab ? findGroupTab(allTabs, toStr) : null;
+    const existingTabSamePath =
+      !existingTab && !existingGroupTab
+        ? (allTabs.find((t) => t.pathname === toStr) ?? null)
+        : null;
+
+    if (existingGroupTab && !isModifierHeld && !shouldSplitTab) {
+      setActiveTab(existingGroupTab.id);
+      updateTab(existingGroupTab.id, {
+        pathname: toStr,
+        search: targetSearch,
+        hash: targetHash,
+      });
+    } else if (existingTabSamePath && !isModifierHeld && !shouldSplitTab) {
+      setActiveTab(existingTabSamePath.id);
+      updateTab(existingTabSamePath.id, { search: targetSearch, hash: targetHash });
+    } else if (existingTab && !isModifierHeld) {
+      setActiveTab(existingTab.id);
+    } else if (isPreviewEligible) {
+      openTab({
+        pathname: toStr,
+        search: targetSearch,
+        hash: targetHash,
+        pane: activePane,
+        preview: true,
+      });
+    } else if (!(shouldOpenNewTab || shouldSplitTab) && activeTab) {
+      const isDocumentLink = toStr.startsWith('/edit/') || toStr.startsWith('/view/');
+      const isLeavingDirtyEditTab =
+        activeTab.pathname.startsWith('/edit/') &&
+        activeTab.isDirty &&
+        toStr !== activeTab.pathname;
+      if (isLeavingDirtyEditTab) {
+        window.dispatchEvent(
+          new CustomEvent('save-request', { detail: { tabId: activeTab.id, isAutosave: true } }),
+        );
+      }
+      updateTab(activeTab.id, {
+        pathname: toStr,
+        search: targetSearch,
+        hash: targetHash,
+        isDirty: isDocumentLink ? undefined : activeTab.isDirty,
+      });
+      navigate({ to: toStr, search: targetSearch, hash: targetHash });
+    } else {
+      const pane = shouldSplitTab ? 'opposite' : activePane;
+      openTab({ pathname: toStr, search: targetSearch, hash: targetHash, pane });
+    }
+  };
+
+  return (
+    <button ref={ref} type={type} className={className} {...props} onClick={handleClick}>
+      {children}
+    </button>
+  );
+}
+
+export const LinkButton = React.forwardRef(LinkButtonFn) as unknown as <
+  TRouter extends AnyRouter = RegisteredRouter,
+  TFrom extends string = string,
+  TTo extends string | undefined = undefined,
+>(
+  props: LinkButtonProps<TRouter, TFrom, TTo> & { ref?: React.Ref<HTMLButtonElement> },
+) => React.ReactElement;
+
+(LinkButton as { displayName?: string }).displayName = 'LinkButton';

--- a/apps/web/src/components/Layout/tabs/LinkButton.tsx
+++ b/apps/web/src/components/Layout/tabs/LinkButton.tsx
@@ -86,10 +86,10 @@ function LinkButtonFn<
   );
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    onClick?.(event);
-    if (event.defaultPrevented) return;
     // Respect Radix's disabled state when this button is a Slot child (asChild)
     if (event.currentTarget.hasAttribute('data-disabled')) return;
+    onClick?.(event);
+    if (event.defaultPrevented) return;
 
     const resolved = router.buildLocation({
       to,

--- a/apps/web/src/components/Layout/tabs/LinkButton.tsx
+++ b/apps/web/src/components/Layout/tabs/LinkButton.tsx
@@ -5,7 +5,6 @@
 
 import * as React from 'react';
 import {
-  useNavigate,
   useRouter,
   type AnyRouter,
   type RegisteredRouter,
@@ -72,7 +71,6 @@ function LinkButtonFn<
   }: LinkButtonProps<TRouter, TFrom, TTo>,
   ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
-  const navigate = useNavigate();
   const router = useRouter();
   const { openTab, updateTab, setActiveTab } = useActions();
 
@@ -150,7 +148,7 @@ function LinkButtonFn<
           hash: action.hash,
           isDirty: action.isDirty,
         });
-        navigate({ to: action.pathname, search: action.search, hash: action.hash });
+        // No explicit navigate() — the Tab→URL sync effect handles navigation
         break;
       case 'open-new':
         openTab({

--- a/apps/web/src/components/Layout/tabs/LinkButton.tsx
+++ b/apps/web/src/components/Layout/tabs/LinkButton.tsx
@@ -12,7 +12,7 @@ import {
   type LinkOptions,
 } from '@tanstack/react-router';
 import { useSelector, useActions } from '@/store';
-import { matchTabLocation, findGroupTab } from './utils';
+import { resolveTabAction } from './utils';
 
 type ValidRouteProps<
   TRouter extends AnyRouter = RegisteredRouter,
@@ -90,6 +90,8 @@ function LinkButtonFn<
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     onClick?.(event);
     if (event.defaultPrevented) return;
+    // Respect Radix's disabled state when this button is a Slot child (asChild)
+    if (event.currentTarget.hasAttribute('data-disabled')) return;
 
     const resolved = router.buildLocation({
       to,
@@ -101,70 +103,63 @@ function LinkButtonFn<
     const targetSearch = resolved.search as Record<string, unknown>;
     const targetHash = resolved.hash ?? '';
 
-    const isModifierHeld = event.metaKey || event.ctrlKey;
-    const isShiftHeld = event.shiftKey;
+    const action = resolveTabAction({
+      pathname: toStr,
+      search: targetSearch,
+      hash: targetHash,
+      primaryTabList,
+      secondaryTabList,
+      activePane,
+      activeTab,
+      isModifierHeld: event.metaKey || event.ctrlKey,
+      isShiftHeld: event.shiftKey,
+      newTab,
+      newSplitTab,
+    });
 
-    const activePaneTabList = activePane === 'secondary' ? secondaryTabList : primaryTabList;
-    const oppositePaneTabList = activePane === 'secondary' ? primaryTabList : secondaryTabList;
-    const targetTabList = isShiftHeld ? oppositePaneTabList : activePaneTabList;
-    const allTabs = [...primaryTabList, ...secondaryTabList];
-
-    const shouldOpenNewTab = isModifierHeld || newTab;
-    const shouldSplitTab = isShiftHeld || newSplitTab;
-    const isViewLink = toStr.startsWith('/view/');
-    const isPreviewEligible =
-      isViewLink && !isModifierHeld && !isShiftHeld && !newTab && !newSplitTab;
-
-    const existingTab = targetTabList.find((t) =>
-      matchTabLocation(t, toStr, targetSearch, targetHash),
-    );
-    const existingGroupTab = !existingTab ? findGroupTab(allTabs, toStr) : null;
-    const existingTabSamePath =
-      !existingTab && !existingGroupTab
-        ? (allTabs.find((t) => t.pathname === toStr) ?? null)
-        : null;
-
-    if (existingGroupTab && !isModifierHeld && !shouldSplitTab) {
-      setActiveTab(existingGroupTab.id);
-      updateTab(existingGroupTab.id, {
-        pathname: toStr,
-        search: targetSearch,
-        hash: targetHash,
-      });
-    } else if (existingTabSamePath && !isModifierHeld && !shouldSplitTab) {
-      setActiveTab(existingTabSamePath.id);
-      updateTab(existingTabSamePath.id, { search: targetSearch, hash: targetHash });
-    } else if (existingTab && !isModifierHeld) {
-      setActiveTab(existingTab.id);
-    } else if (isPreviewEligible) {
-      openTab({
-        pathname: toStr,
-        search: targetSearch,
-        hash: targetHash,
-        pane: activePane,
-        preview: true,
-      });
-    } else if (!(shouldOpenNewTab || shouldSplitTab) && activeTab) {
-      const isDocumentLink = toStr.startsWith('/edit/') || toStr.startsWith('/view/');
-      const isLeavingDirtyEditTab =
-        activeTab.pathname.startsWith('/edit/') &&
-        activeTab.isDirty &&
-        toStr !== activeTab.pathname;
-      if (isLeavingDirtyEditTab) {
-        window.dispatchEvent(
-          new CustomEvent('save-request', { detail: { tabId: activeTab.id, isAutosave: true } }),
-        );
-      }
-      updateTab(activeTab.id, {
-        pathname: toStr,
-        search: targetSearch,
-        hash: targetHash,
-        isDirty: isDocumentLink ? undefined : activeTab.isDirty,
-      });
-      navigate({ to: toStr, search: targetSearch, hash: targetHash });
-    } else {
-      const pane = shouldSplitTab ? 'opposite' : activePane;
-      openTab({ pathname: toStr, search: targetSearch, hash: targetHash, pane });
+    switch (action.type) {
+      case 'activate':
+        setActiveTab(action.tabId);
+        break;
+      case 'activate-and-update':
+        setActiveTab(action.tabId);
+        updateTab(action.tabId, {
+          pathname: action.pathname,
+          search: action.search,
+          hash: action.hash,
+        });
+        break;
+      case 'preview':
+        openTab({
+          pathname: action.pathname,
+          search: action.search,
+          hash: action.hash,
+          pane: action.pane,
+          preview: true,
+        });
+        break;
+      case 'navigate-in-place':
+        if (action.requiresAutosave) {
+          window.dispatchEvent(
+            new CustomEvent('save-request', { detail: { tabId: action.tabId, isAutosave: true } }),
+          );
+        }
+        updateTab(action.tabId, {
+          pathname: action.pathname,
+          search: action.search,
+          hash: action.hash,
+          isDirty: action.isDirty,
+        });
+        navigate({ to: action.pathname, search: action.search, hash: action.hash });
+        break;
+      case 'open-new':
+        openTab({
+          pathname: action.pathname,
+          search: action.search,
+          hash: action.hash,
+          pane: action.pane,
+        });
+        break;
     }
   };
 

--- a/apps/web/src/components/Layout/tabs/PaneTabBar.tsx
+++ b/apps/web/src/components/Layout/tabs/PaneTabBar.tsx
@@ -13,7 +13,7 @@ import { useDroppable } from '@dnd-kit/core';
 import type { Tab as TabType } from '@repo/types';
 import { Button } from '@repo/ui/components/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@repo/ui/components/tooltip';
-import { matchTabLocation } from './utils';
+import { findTabInPane } from './utils';
 import {
   PanelRightCloseIcon,
   PanelTopCloseIcon,
@@ -104,10 +104,12 @@ export function PaneTabBar({ pane, className }: PaneTabBarProps) {
   const handleOpenInSplit = useCallback(() => {
     if (!activeTab) return;
     // If the same location already exists in the target pane, just switch to it
-    const existing = tabList.find(
-      (t) =>
-        targetPaneTabIds.includes(t.id) &&
-        matchTabLocation(t, activeTab.pathname, activeTab.search ?? {}, activeTab.hash ?? ''),
+    const existing = findTabInPane(
+      tabList,
+      targetPaneTabIds,
+      activeTab.pathname,
+      activeTab.search ?? {},
+      activeTab.hash ?? '',
     );
     if (existing) {
       setActiveTab(existing.id);

--- a/apps/web/src/components/Layout/tabs/PaneTabBar.tsx
+++ b/apps/web/src/components/Layout/tabs/PaneTabBar.tsx
@@ -92,7 +92,8 @@ export function PaneTabBar({ pane, className }: PaneTabBarProps) {
     }
   }, [activeTab]);
 
-  const { openTab, closeSplit } = useActions();
+  const { openTab, closeSplit, setActiveTab } = useActions();
+  const tabs = useSelector((state) => state.tabs);
   const isPortrait = useMediaQuery('(orientation: portrait)');
   const targetPane = pane === 'primary' ? 'secondary' : 'primary';
   const splitLabel =
@@ -100,13 +101,21 @@ export function PaneTabBar({ pane, className }: PaneTabBarProps) {
 
   const handleOpenInSplit = useCallback(() => {
     if (!activeTab) return;
+    // If the same pathname already exists in the target pane, just switch to it
+    const existing = tabs.tabList.find(
+      (t) => tabs.paneTabIds[targetPane].includes(t.id) && t.pathname === activeTab.pathname,
+    );
+    if (existing) {
+      setActiveTab(existing.id);
+      return;
+    }
     openTab({
       pathname: activeTab.pathname,
       search: activeTab.search,
       hash: activeTab.hash,
       pane: targetPane,
     });
-  }, [activeTab, openTab, targetPane]);
+  }, [activeTab, openTab, targetPane, tabs, setActiveTab]);
 
   // Copy link with search params and hash
   const handleCopyPath = useCallback(() => {

--- a/apps/web/src/components/Layout/tabs/PaneTabBar.tsx
+++ b/apps/web/src/components/Layout/tabs/PaneTabBar.tsx
@@ -13,6 +13,7 @@ import { useDroppable } from '@dnd-kit/core';
 import type { Tab as TabType } from '@repo/types';
 import { Button } from '@repo/ui/components/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@repo/ui/components/tooltip';
+import { matchTabLocation } from './utils';
 import {
   PanelRightCloseIcon,
   PanelTopCloseIcon,
@@ -102,9 +103,11 @@ export function PaneTabBar({ pane, className }: PaneTabBarProps) {
 
   const handleOpenInSplit = useCallback(() => {
     if (!activeTab) return;
-    // If the same pathname already exists in the target pane, just switch to it
+    // If the same location already exists in the target pane, just switch to it
     const existing = tabList.find(
-      (t) => targetPaneTabIds.includes(t.id) && t.pathname === activeTab.pathname,
+      (t) =>
+        targetPaneTabIds.includes(t.id) &&
+        matchTabLocation(t, activeTab.pathname, activeTab.search ?? {}, activeTab.hash ?? ''),
     );
     if (existing) {
       setActiveTab(existing.id);

--- a/apps/web/src/components/Layout/tabs/PaneTabBar.tsx
+++ b/apps/web/src/components/Layout/tabs/PaneTabBar.tsx
@@ -93,17 +93,18 @@ export function PaneTabBar({ pane, className }: PaneTabBarProps) {
   }, [activeTab]);
 
   const { openTab, closeSplit, setActiveTab } = useActions();
-  const tabs = useSelector((state) => state.tabs);
-  const isPortrait = useMediaQuery('(orientation: portrait)');
   const targetPane = pane === 'primary' ? 'secondary' : 'primary';
+  const tabList = useSelector((state) => state.tabs.tabList);
+  const targetPaneTabIds = useSelector((state) => state.tabs.paneTabIds[targetPane]);
+  const isPortrait = useMediaQuery('(orientation: portrait)');
   const splitLabel =
     pane === 'primary' ? (isPortrait ? 'Split Bottom' : 'Split Right') : 'Close Split View';
 
   const handleOpenInSplit = useCallback(() => {
     if (!activeTab) return;
     // If the same pathname already exists in the target pane, just switch to it
-    const existing = tabs.tabList.find(
-      (t) => tabs.paneTabIds[targetPane].includes(t.id) && t.pathname === activeTab.pathname,
+    const existing = tabList.find(
+      (t) => targetPaneTabIds.includes(t.id) && t.pathname === activeTab.pathname,
     );
     if (existing) {
       setActiveTab(existing.id);
@@ -115,7 +116,7 @@ export function PaneTabBar({ pane, className }: PaneTabBarProps) {
       hash: activeTab.hash,
       pane: targetPane,
     });
-  }, [activeTab, openTab, targetPane, tabs, setActiveTab]);
+  }, [activeTab, openTab, targetPane, tabList, targetPaneTabIds, setActiveTab]);
 
   // Copy link with search params and hash
   const handleCopyPath = useCallback(() => {

--- a/apps/web/src/components/Layout/tabs/TabBarContextMenu.tsx
+++ b/apps/web/src/components/Layout/tabs/TabBarContextMenu.tsx
@@ -27,7 +27,7 @@ export interface TabBarContextMenuProps {
 }
 
 export function TabBarContextMenu({ pane, children }: TabBarContextMenuProps) {
-  const { openTab, closeAllTabs, closeSplit } = useActions();
+  const { openTab, closeAllTabs, closeSplit, setActiveTab } = useActions();
   const tabs = useSelector((state) => state.tabs);
   const activeTabId = tabs.activeTabId[pane];
   const activeTab = tabs.tabList.find((t) => t.id === activeTabId);
@@ -49,13 +49,21 @@ export function TabBarContextMenu({ pane, children }: TabBarContextMenuProps) {
 
   const handleOpenInSplit = useCallback(() => {
     if (!activeTab) return;
+    // If the same pathname already exists in the target pane, just switch to it
+    const existing = tabs.tabList.find(
+      (t) => tabs.paneTabIds[targetPane].includes(t.id) && t.pathname === activeTab.pathname,
+    );
+    if (existing) {
+      setActiveTab(existing.id);
+      return;
+    }
     openTab({
       pathname: activeTab.pathname,
       search: activeTab.search,
       hash: activeTab.hash,
       pane: targetPane,
     });
-  }, [activeTab, openTab, targetPane]);
+  }, [activeTab, openTab, targetPane, tabs, setActiveTab]);
 
   const handleNewTab = useCallback(() => {
     openTab({ pathname: '/', pane });

--- a/apps/web/src/components/Layout/tabs/TabBarContextMenu.tsx
+++ b/apps/web/src/components/Layout/tabs/TabBarContextMenu.tsx
@@ -20,7 +20,7 @@ import {
   PanelTopCloseIcon,
 } from '@repo/ui/components/icons';
 import { useMediaQuery } from '@repo/ui/hooks/use-media-query';
-import { matchTabLocation } from './utils';
+import { findTabInPane } from './utils';
 
 export interface TabBarContextMenuProps {
   pane: 'primary' | 'secondary';
@@ -51,10 +51,12 @@ export function TabBarContextMenu({ pane, children }: TabBarContextMenuProps) {
   const handleOpenInSplit = useCallback(() => {
     if (!activeTab) return;
     // If the same location already exists in the target pane, just switch to it
-    const existing = tabs.tabList.find(
-      (t) =>
-        tabs.paneTabIds[targetPane].includes(t.id) &&
-        matchTabLocation(t, activeTab.pathname, activeTab.search ?? {}, activeTab.hash ?? ''),
+    const existing = findTabInPane(
+      tabs.tabList,
+      tabs.paneTabIds[targetPane],
+      activeTab.pathname,
+      activeTab.search ?? {},
+      activeTab.hash ?? '',
     );
     if (existing) {
       setActiveTab(existing.id);

--- a/apps/web/src/components/Layout/tabs/TabBarContextMenu.tsx
+++ b/apps/web/src/components/Layout/tabs/TabBarContextMenu.tsx
@@ -20,6 +20,7 @@ import {
   PanelTopCloseIcon,
 } from '@repo/ui/components/icons';
 import { useMediaQuery } from '@repo/ui/hooks/use-media-query';
+import { matchTabLocation } from './utils';
 
 export interface TabBarContextMenuProps {
   pane: 'primary' | 'secondary';
@@ -49,9 +50,11 @@ export function TabBarContextMenu({ pane, children }: TabBarContextMenuProps) {
 
   const handleOpenInSplit = useCallback(() => {
     if (!activeTab) return;
-    // If the same pathname already exists in the target pane, just switch to it
+    // If the same location already exists in the target pane, just switch to it
     const existing = tabs.tabList.find(
-      (t) => tabs.paneTabIds[targetPane].includes(t.id) && t.pathname === activeTab.pathname,
+      (t) =>
+        tabs.paneTabIds[targetPane].includes(t.id) &&
+        matchTabLocation(t, activeTab.pathname, activeTab.search ?? {}, activeTab.hash ?? ''),
     );
     if (existing) {
       setActiveTab(existing.id);

--- a/apps/web/src/components/Layout/tabs/TabContextMenu.tsx
+++ b/apps/web/src/components/Layout/tabs/TabContextMenu.tsx
@@ -67,7 +67,8 @@ export function TabContextMenu({ tab, pane, children }: TabContextMenuProps) {
   } = useActions();
   const isActive = useSelector((state) => state.tabs.activeTabId[pane] === tab.id);
   const hasMultipleTabs = useSelector((state) => state.tabs.paneTabIds[pane].length > 1);
-  const tabs = useSelector((state) => state.tabs);
+  const tabList = useSelector((state) => state.tabs.tabList);
+  const paneTabIds = useSelector((state) => state.tabs.paneTabIds);
   const hasTabsToRight = useSelector((state) => {
     const paneTabIds = state.tabs.paneTabIds[pane];
     const tabIndex = paneTabIds.indexOf(tab.id);
@@ -128,8 +129,8 @@ export function TabContextMenu({ tab, pane, children }: TabContextMenuProps) {
 
   const handleOpenInSplit = useCallback(() => {
     // If the same pathname already exists in the target pane, just switch to it
-    const existing = tabs.tabList.find(
-      (t) => tabs.paneTabIds[targetPane].includes(t.id) && t.pathname === tab.pathname,
+    const existing = tabList.find(
+      (t) => paneTabIds[targetPane].includes(t.id) && t.pathname === tab.pathname,
     );
     if (existing) {
       setActiveTab(existing.id);
@@ -141,7 +142,7 @@ export function TabContextMenu({ tab, pane, children }: TabContextMenuProps) {
       hash: tab.hash,
       pane: targetPane,
     });
-  }, [tab, openTab, targetPane, tabs, setActiveTab]);
+  }, [tab, openTab, targetPane, tabList, paneTabIds, setActiveTab]);
 
   const moveLabel =
     pane === 'primary'

--- a/apps/web/src/components/Layout/tabs/TabContextMenu.tsx
+++ b/apps/web/src/components/Layout/tabs/TabContextMenu.tsx
@@ -67,6 +67,7 @@ export function TabContextMenu({ tab, pane, children }: TabContextMenuProps) {
   } = useActions();
   const isActive = useSelector((state) => state.tabs.activeTabId[pane] === tab.id);
   const hasMultipleTabs = useSelector((state) => state.tabs.paneTabIds[pane].length > 1);
+  const tabs = useSelector((state) => state.tabs);
   const hasTabsToRight = useSelector((state) => {
     const paneTabIds = state.tabs.paneTabIds[pane];
     const tabIndex = paneTabIds.indexOf(tab.id);
@@ -126,13 +127,21 @@ export function TabContextMenu({ tab, pane, children }: TabContextMenuProps) {
         : 'Split Left';
 
   const handleOpenInSplit = useCallback(() => {
+    // If the same pathname already exists in the target pane, just switch to it
+    const existing = tabs.tabList.find(
+      (t) => tabs.paneTabIds[targetPane].includes(t.id) && t.pathname === tab.pathname,
+    );
+    if (existing) {
+      setActiveTab(existing.id);
+      return;
+    }
     openTab({
       pathname: tab.pathname,
       search: tab.search,
       hash: tab.hash,
       pane: targetPane,
     });
-  }, [tab, openTab, targetPane]);
+  }, [tab, openTab, targetPane, tabs, setActiveTab]);
 
   const moveLabel =
     pane === 'primary'

--- a/apps/web/src/components/Layout/tabs/TabContextMenu.tsx
+++ b/apps/web/src/components/Layout/tabs/TabContextMenu.tsx
@@ -15,6 +15,7 @@ import { useActions, useSelector } from '@/store';
 import { useCallback, type ReactNode } from 'react';
 import { toast } from 'sonner';
 import type { Tab } from '@repo/types';
+import { matchTabLocation } from './utils';
 import {
   X,
   XCircle,
@@ -128,9 +129,11 @@ export function TabContextMenu({ tab, pane, children }: TabContextMenuProps) {
         : 'Split Left';
 
   const handleOpenInSplit = useCallback(() => {
-    // If the same pathname already exists in the target pane, just switch to it
+    // If the same location already exists in the target pane, just switch to it
     const existing = tabList.find(
-      (t) => paneTabIds[targetPane].includes(t.id) && t.pathname === tab.pathname,
+      (t) =>
+        paneTabIds[targetPane].includes(t.id) &&
+        matchTabLocation(t, tab.pathname, tab.search ?? {}, tab.hash ?? ''),
     );
     if (existing) {
       setActiveTab(existing.id);

--- a/apps/web/src/components/Layout/tabs/TabContextMenu.tsx
+++ b/apps/web/src/components/Layout/tabs/TabContextMenu.tsx
@@ -15,7 +15,7 @@ import { useActions, useSelector } from '@/store';
 import { useCallback, type ReactNode } from 'react';
 import { toast } from 'sonner';
 import type { Tab } from '@repo/types';
-import { matchTabLocation } from './utils';
+import { findTabInPane } from './utils';
 import {
   X,
   XCircle,
@@ -130,10 +130,12 @@ export function TabContextMenu({ tab, pane, children }: TabContextMenuProps) {
 
   const handleOpenInSplit = useCallback(() => {
     // If the same location already exists in the target pane, just switch to it
-    const existing = tabList.find(
-      (t) =>
-        paneTabIds[targetPane].includes(t.id) &&
-        matchTabLocation(t, tab.pathname, tab.search ?? {}, tab.hash ?? ''),
+    const existing = findTabInPane(
+      tabList,
+      paneTabIds[targetPane],
+      tab.pathname,
+      tab.search ?? {},
+      tab.hash ?? '',
     );
     if (existing) {
       setActiveTab(existing.id);

--- a/apps/web/src/components/Layout/tabs/TabSync.tsx
+++ b/apps/web/src/components/Layout/tabs/TabSync.tsx
@@ -7,7 +7,7 @@ import { useSelector, useActions } from '@/store';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import { useEffect, useRef } from 'react';
 import { resolveModifier, useKeyHold } from '@tanstack/react-hotkeys';
-import { matchTabLocation, findGroupTab } from './utils';
+import { matchTabLocation, findGroupTab, resolveTabAction } from './utils';
 
 /**
  * Headless component that handles:
@@ -66,74 +66,69 @@ export function TabSync() {
       if (origin !== location.origin) return;
       if (link.download) return;
       const search = Object.fromEntries(searchParams.entries());
-      const primaryTabList = primaryTabListRef.current;
-      const secondaryTabList = secondaryTabListRef.current;
-      const activePane = activePaneRef.current;
-      const activePaneTabList = activePane === 'secondary' ? secondaryTabList : primaryTabList;
-      const oppositePaneTabList = activePane === 'secondary' ? primaryTabList : secondaryTabList;
-      const activeTab = activeTabRef.current;
-      const isModifierHeld = isModifierHeldRef.current;
-      const isShiftHeld = isShiftHeldRef.current;
-      const targetTabList = isShiftHeld ? oppositePaneTabList : activePaneTabList;
-      const allTabs = [...primaryTabListRef.current, ...secondaryTabListRef.current];
-      const existingTab = targetTabList.find((t) => matchTabLocation(t, pathname, search, hash));
-      const existingGroupTab = !existingTab ? findGroupTab(allTabs, pathname) : null;
-      const existingTabSamePath =
-        !existingTab && !existingGroupTab && allTabs.find((t) => t.pathname === pathname);
-      const shouldOpenNewTab = isModifierHeld || link.dataset.newTab === 'true';
-      const shouldSplitTab = isShiftHeld || link.dataset.newSplitTab === 'true';
-      const isViewLink = pathname.startsWith('/view/');
-      const isPreviewEligible =
-        isViewLink &&
-        !isModifierHeld &&
-        !isShiftHeld &&
-        link.dataset.newTab !== 'true' &&
-        link.dataset.newSplitTab !== 'true';
+      const normalizedHash = hash.slice(1);
+
+      const action = resolveTabAction({
+        pathname,
+        search,
+        hash: normalizedHash,
+        primaryTabList: primaryTabListRef.current,
+        secondaryTabList: secondaryTabListRef.current,
+        activePane: activePaneRef.current,
+        activeTab: activeTabRef.current,
+        isModifierHeld: isModifierHeldRef.current,
+        isShiftHeld: isShiftHeldRef.current,
+        newTab: link.dataset.newTab === 'true',
+        newSplitTab: link.dataset.newSplitTab === 'true',
+      });
+
       event.preventDefault();
-      if (existingGroupTab && !isModifierHeld && !shouldSplitTab) {
-        setActiveTab(existingGroupTab.id);
-        updateTab(existingGroupTab.id, { pathname, search, hash: hash.slice(1) });
-      } else if (existingTabSamePath && !isModifierHeld && !shouldSplitTab) {
-        setActiveTab(existingTabSamePath.id);
-        updateTab(existingTabSamePath.id, { search, hash: hash.slice(1) });
-      } else if (existingTab && !isModifierHeld) {
-        setActiveTab(existingTab.id);
-      } else if (isPreviewEligible) {
-        openTab({
-          pathname,
-          search,
-          hash: hash.slice(1),
-          pane: activePane,
-          preview: true,
-        });
-      } else if (!(shouldOpenNewTab || shouldSplitTab) && activeTab) {
-        const isDocumentLink = pathname.startsWith('/edit/') || pathname.startsWith('/view/');
-        // Path-C: autosave if leaving a dirty edit tab for a different location
-        const isLeavingDirtyEditTab =
-          activeTab.pathname.startsWith('/edit/') &&
-          activeTab.isDirty &&
-          pathname !== activeTab.pathname;
-        if (isLeavingDirtyEditTab) {
-          window.dispatchEvent(
-            new CustomEvent('save-request', {
-              detail: { tabId: activeTab.id, isAutosave: true },
-            }),
-          );
-        }
-        updateTab(activeTab.id, {
-          pathname,
-          search,
-          hash: hash.slice(1),
-          isDirty: isDocumentLink ? undefined : activeTab.isDirty,
-        });
-      } else {
-        const pane = shouldSplitTab ? 'opposite' : activePane;
-        openTab({
-          pathname,
-          search,
-          hash: hash.slice(1),
-          pane,
-        });
+
+      switch (action.type) {
+        case 'activate':
+          setActiveTab(action.tabId);
+          break;
+        case 'activate-and-update':
+          setActiveTab(action.tabId);
+          updateTab(action.tabId, {
+            pathname: action.pathname,
+            search: action.search,
+            hash: action.hash,
+          });
+          break;
+        case 'preview':
+          openTab({
+            pathname: action.pathname,
+            search: action.search,
+            hash: action.hash,
+            pane: action.pane,
+            preview: true,
+          });
+          break;
+        case 'navigate-in-place':
+          if (action.requiresAutosave) {
+            window.dispatchEvent(
+              new CustomEvent('save-request', {
+                detail: { tabId: action.tabId, isAutosave: true },
+              }),
+            );
+          }
+          updateTab(action.tabId, {
+            pathname: action.pathname,
+            search: action.search,
+            hash: action.hash,
+            isDirty: action.isDirty,
+          });
+          // No explicit navigate() — the Tab→URL sync effect handles navigation
+          break;
+        case 'open-new':
+          openTab({
+            pathname: action.pathname,
+            search: action.search,
+            hash: action.hash,
+            pane: action.pane,
+          });
+          break;
       }
     };
 

--- a/apps/web/src/components/Layout/tabs/TabSync.tsx
+++ b/apps/web/src/components/Layout/tabs/TabSync.tsx
@@ -208,7 +208,6 @@ export function TabSync() {
           search,
           hash,
           pane: activePane,
-          index: 0,
         });
       });
       return () => cancelAnimationFrame(rafId);

--- a/apps/web/src/components/Layout/tabs/index.ts
+++ b/apps/web/src/components/Layout/tabs/index.ts
@@ -4,6 +4,8 @@
  */
 
 export { Tab } from './Tab';
+export { LinkButton } from './LinkButton';
+export type { LinkButtonProps } from './LinkButton';
 export { TabSync } from './TabSync';
 export { TabAutoSave } from './TabAutoSave';
 export { TabDndProvider } from './TabDndProvider';

--- a/apps/web/src/components/Layout/tabs/utils.ts
+++ b/apps/web/src/components/Layout/tabs/utils.ts
@@ -81,3 +81,135 @@ export const matchAppLink = (tab: Tab, pathname: string) => {
 export const matchAppLocation = (tab: Tab, pathname: string) => {
   return tab.pathname.split('/')[1] === pathname.split('/')[1];
 };
+
+// ---------------------------------------------------------------------------
+// resolveTabAction — shared tab-routing decision logic
+// Used by both LinkButton and TabSync so behaviour stays in sync.
+// ---------------------------------------------------------------------------
+
+export interface ResolveTabActionInput {
+  pathname: string;
+  search: Record<string, unknown>;
+  hash: string;
+  primaryTabList: Tab[];
+  secondaryTabList: Tab[];
+  activePane: 'primary' | 'secondary';
+  activeTab: Tab | undefined;
+  isModifierHeld: boolean;
+  isShiftHeld: boolean;
+  newTab: boolean;
+  newSplitTab: boolean;
+}
+
+export type TabAction =
+  | { type: 'activate'; tabId: string }
+  | {
+      type: 'activate-and-update';
+      tabId: string;
+      pathname: string;
+      search: Record<string, unknown>;
+      hash: string;
+    }
+  | {
+      type: 'preview';
+      pane: 'primary' | 'secondary';
+      pathname: string;
+      search: Record<string, unknown>;
+      hash: string;
+    }
+  | {
+      type: 'navigate-in-place';
+      tabId: string;
+      pathname: string;
+      search: Record<string, unknown>;
+      hash: string;
+      isDirty: boolean | undefined;
+      requiresAutosave: boolean;
+    }
+  | {
+      type: 'open-new';
+      pane: 'primary' | 'secondary' | 'opposite';
+      pathname: string;
+      search: Record<string, unknown>;
+      hash: string;
+    };
+
+/**
+ * Pure function that resolves which tab action should be taken for a given
+ * navigation intent. Contains the single source of truth for all tab routing
+ * decisions — used by both LinkButton and TabSync.
+ *
+ * Fixes applied relative to the original per-callsite logic:
+ * - `targetTabList` is derived from `shouldSplitTab` (not bare `isShiftHeld`)
+ *   so the `newSplitTab` prop correctly influences which pane is searched.
+ * - All three existing-tab reuse branches are gated on `!shouldOpenNewTab &&
+ *   !shouldSplitTab` so `newTab`/`newSplitTab` props always force new-tab
+ *   creation even when a matching tab already exists.
+ */
+export const resolveTabAction = ({
+  pathname,
+  search,
+  hash,
+  primaryTabList,
+  secondaryTabList,
+  activePane,
+  activeTab,
+  isModifierHeld,
+  isShiftHeld,
+  newTab,
+  newSplitTab,
+}: ResolveTabActionInput): TabAction => {
+  const shouldOpenNewTab = isModifierHeld || newTab;
+  const shouldSplitTab = isShiftHeld || newSplitTab;
+
+  const activePaneTabList = activePane === 'secondary' ? secondaryTabList : primaryTabList;
+  const oppositePaneTabList = activePane === 'secondary' ? primaryTabList : secondaryTabList;
+  // Fix: use shouldSplitTab so newSplitTab prop influences which pane is searched
+  const targetTabList = shouldSplitTab ? oppositePaneTabList : activePaneTabList;
+
+  const isViewLink = pathname.startsWith('/view/');
+  const isPreviewEligible = isViewLink && !shouldOpenNewTab && !shouldSplitTab;
+
+  const existingTab =
+    targetTabList.find((t) => matchTabLocation(t, pathname, search, hash)) ?? null;
+  // Prioritise the target pane when looking for group / same-path tabs so that
+  // navigation in the secondary pane doesn't accidentally update a primary-pane tab.
+  const existingGroupTab = !existingTab
+    ? (findGroupTab(targetTabList, pathname) ?? findGroupTab(oppositePaneTabList, pathname))
+    : null;
+  const existingTabSamePath =
+    !existingTab && !existingGroupTab
+      ? (targetTabList.find((t) => t.pathname === pathname) ??
+        oppositePaneTabList.find((t) => t.pathname === pathname) ??
+        null)
+      : null;
+
+  // Fix: gate all reuse branches on !shouldOpenNewTab so newTab prop is honoured
+  if (existingGroupTab && !shouldOpenNewTab && !shouldSplitTab) {
+    return { type: 'activate-and-update', tabId: existingGroupTab.id, pathname, search, hash };
+  } else if (existingTabSamePath && !shouldOpenNewTab && !shouldSplitTab) {
+    return { type: 'activate-and-update', tabId: existingTabSamePath.id, pathname, search, hash };
+  } else if (existingTab && !shouldOpenNewTab && !shouldSplitTab) {
+    return { type: 'activate', tabId: existingTab.id };
+  } else if (isPreviewEligible) {
+    return { type: 'preview', pane: activePane, pathname, search, hash };
+  } else if (!(shouldOpenNewTab || shouldSplitTab) && activeTab) {
+    const isDocumentLink = pathname.startsWith('/edit/') || pathname.startsWith('/view/');
+    const requiresAutosave =
+      activeTab.pathname.startsWith('/edit/') &&
+      !!activeTab.isDirty &&
+      pathname !== activeTab.pathname;
+    return {
+      type: 'navigate-in-place',
+      tabId: activeTab.id,
+      pathname,
+      search,
+      hash,
+      isDirty: isDocumentLink ? undefined : activeTab.isDirty,
+      requiresAutosave,
+    };
+  } else {
+    const pane = shouldSplitTab ? 'opposite' : activePane;
+    return { type: 'open-new', pane, pathname, search, hash };
+  }
+};

--- a/apps/web/src/components/Layout/tabs/utils.ts
+++ b/apps/web/src/components/Layout/tabs/utils.ts
@@ -21,6 +21,10 @@ export const matchTabLocation = (
   );
 };
 
+/** Compare two Tab objects by full location (pathname + search + hash). */
+export const tabsMatchLocation = (a: Tab, b: Tab): boolean =>
+  matchTabLocation(a, b.pathname, b.search ?? {}, b.hash ?? '');
+
 export const getLocationFromDragEvent = (event: React.DragEvent | DragEvent) => {
   const target = event.target as HTMLElement | null;
   if (!target) return null;
@@ -184,7 +188,9 @@ export const resolveTabAction = ({
         null)
       : null;
 
-  // Fix: gate all reuse branches on !shouldOpenNewTab so newTab prop is honoured
+  // Honor new-tab/new-split-tab requests across group and same-path reuse branches.
+  // Exact-match tabs may still be activated when splitting — only forced new-tab (Ctrl/newTab)
+  // blocks that, because the existing tab is already in the target pane.
   if (existingGroupTab && !shouldOpenNewTab && !shouldSplitTab) {
     return { type: 'activate-and-update', tabId: existingGroupTab.id, pathname, search, hash };
   } else if (existingTabSamePath && !shouldOpenNewTab && !shouldSplitTab) {

--- a/apps/web/src/components/Layout/tabs/utils.ts
+++ b/apps/web/src/components/Layout/tabs/utils.ts
@@ -25,6 +25,16 @@ export const matchTabLocation = (
 export const tabsMatchLocation = (a: Tab, b: Tab): boolean =>
   matchTabLocation(a, b.pathname, b.search ?? {}, b.hash ?? '');
 
+/** Find a tab in a specific pane that matches a full location. */
+export const findTabInPane = (
+  tabList: Tab[],
+  paneTabIds: string[],
+  pathname: string,
+  search: Record<string, unknown> = {},
+  hash: string = '',
+): Tab | undefined =>
+  tabList.find((t) => paneTabIds.includes(t.id) && matchTabLocation(t, pathname, search, hash));
+
 export const getLocationFromDragEvent = (event: React.DragEvent | DragEvent) => {
   const target = event.target as HTMLElement | null;
   if (!target) return null;
@@ -176,16 +186,12 @@ export const resolveTabAction = ({
 
   const existingTab =
     targetTabList.find((t) => matchTabLocation(t, pathname, search, hash)) ?? null;
-  // Prioritise the target pane when looking for group / same-path tabs so that
-  // navigation in the secondary pane doesn't accidentally update a primary-pane tab.
-  const existingGroupTab = !existingTab
-    ? (findGroupTab(targetTabList, pathname) ?? findGroupTab(oppositePaneTabList, pathname))
-    : null;
+  // Restrict group / same-path reuse to targetTabList only so that a normal click
+  // never activates-and-updates a tab in the opposite pane.
+  const existingGroupTab = !existingTab ? findGroupTab(targetTabList, pathname) : null;
   const existingTabSamePath =
     !existingTab && !existingGroupTab
-      ? (targetTabList.find((t) => t.pathname === pathname) ??
-        oppositePaneTabList.find((t) => t.pathname === pathname) ??
-        null)
+      ? (targetTabList.find((t) => t.pathname === pathname) ?? null)
       : null;
 
   // Honor new-tab/new-split-tab requests across group and same-path reuse branches.

--- a/apps/web/src/components/Layout/tabs/utils.ts
+++ b/apps/web/src/components/Layout/tabs/utils.ts
@@ -156,9 +156,12 @@ export type TabAction =
  * Fixes applied relative to the original per-callsite logic:
  * - `targetTabList` is derived from `shouldSplitTab` (not bare `isShiftHeld`)
  *   so the `newSplitTab` prop correctly influences which pane is searched.
- * - All three existing-tab reuse branches are gated on `!shouldOpenNewTab &&
+ * - Group and same-path reuse branches are gated on `!shouldOpenNewTab &&
  *   !shouldSplitTab` so `newTab`/`newSplitTab` props always force new-tab
  *   creation even when a matching tab already exists.
+ * - The exact-match (`existingTab`) branch is only gated on `!shouldOpenNewTab`,
+ *   allowing split navigation to activate an existing tab in the target pane
+ *   rather than creating a duplicate.
  */
 export const resolveTabAction = ({
   pathname,

--- a/apps/web/src/components/Layout/tabs/utils.ts
+++ b/apps/web/src/components/Layout/tabs/utils.ts
@@ -189,7 +189,7 @@ export const resolveTabAction = ({
     return { type: 'activate-and-update', tabId: existingGroupTab.id, pathname, search, hash };
   } else if (existingTabSamePath && !shouldOpenNewTab && !shouldSplitTab) {
     return { type: 'activate-and-update', tabId: existingTabSamePath.id, pathname, search, hash };
-  } else if (existingTab && !shouldOpenNewTab && !shouldSplitTab) {
+  } else if (existingTab && !shouldOpenNewTab) {
     return { type: 'activate', tabId: existingTab.id };
   } else if (isPreviewEligible) {
     return { type: 'preview', pane: activePane, pathname, search, hash };

--- a/apps/web/src/store/tabs-slice.ts
+++ b/apps/web/src/store/tabs-slice.ts
@@ -598,12 +598,13 @@ export const createTabsSlice: StateCreator<
           const secondaryIds = state.tabs.paneTabIds.secondary;
           const primaryTabs = state.tabs.tabList.filter((t) => primaryIds.includes(t.id));
 
-          // Drop secondary tabs whose full location already exists in primary to avoid true duplicates
+          // Drop secondary tabs whose full location already exists in primary to avoid true duplicates.
+          // Preserve dirty secondary tabs so unsaved work is not silently lost.
           const duplicateSecondaryIds = new Set<string>();
           for (const secId of secondaryIds) {
             const secTab = state.tabs.tabList.find((t) => t.id === secId);
             if (!secTab) continue;
-            if (primaryTabs.some((pt) => tabsMatchLocation(pt, secTab))) {
+            if (!secTab.isDirty && primaryTabs.some((pt) => tabsMatchLocation(pt, secTab))) {
               duplicateSecondaryIds.add(secId);
             }
           }

--- a/apps/web/src/store/tabs-slice.ts
+++ b/apps/web/src/store/tabs-slice.ts
@@ -6,6 +6,7 @@
 import { StateCreator } from 'zustand/vanilla';
 import type { Tab } from '@repo/types';
 import type { Store } from './store';
+import { tabsMatchLocation } from '@/components/Layout/tabs/utils';
 /**
  * State for the tabs system with VS Code-like editor groups (panes).
  * Tabs live in a single flat array. Pane membership and order are tracked
@@ -597,12 +598,12 @@ export const createTabsSlice: StateCreator<
           const secondaryIds = state.tabs.paneTabIds.secondary;
           const primaryTabs = state.tabs.tabList.filter((t) => primaryIds.includes(t.id));
 
-          // Drop secondary tabs whose pathname already exists in primary to avoid duplicates
+          // Drop secondary tabs whose full location already exists in primary to avoid true duplicates
           const duplicateSecondaryIds = new Set<string>();
           for (const secId of secondaryIds) {
             const secTab = state.tabs.tabList.find((t) => t.id === secId);
             if (!secTab) continue;
-            if (primaryTabs.some((pt) => pt.pathname === secTab.pathname)) {
+            if (primaryTabs.some((pt) => tabsMatchLocation(pt, secTab))) {
               duplicateSecondaryIds.add(secId);
             }
           }
@@ -620,7 +621,7 @@ export const createTabsSlice: StateCreator<
             // Active secondary was a duplicate — switch to its primary counterpart
             const secTab = state.tabs.tabList.find((t) => t.id === activeSecondary);
             if (secTab) {
-              const match = primaryTabs.find((pt) => pt.pathname === secTab.pathname);
+              const match = primaryTabs.find((pt) => tabsMatchLocation(pt, secTab));
               if (match) newActivePrimary = match.id;
             }
           } else if (activeSecondary && !duplicateSecondaryIds.has(activeSecondary)) {

--- a/apps/web/src/store/tabs-slice.ts
+++ b/apps/web/src/store/tabs-slice.ts
@@ -596,13 +596,16 @@ export const createTabsSlice: StateCreator<
         set((state) => {
           const primaryIds = state.tabs.paneTabIds.primary;
           const secondaryIds = state.tabs.paneTabIds.secondary;
-          const primaryTabs = state.tabs.tabList.filter((t) => primaryIds.includes(t.id));
+          const tabById = new Map(state.tabs.tabList.map((t) => [t.id, t] as const));
+          const primaryTabs = primaryIds
+            .map((id) => tabById.get(id))
+            .filter((t): t is Tab => Boolean(t));
 
           // Drop secondary tabs whose full location already exists in primary to avoid true duplicates.
           // Preserve dirty secondary tabs so unsaved work is not silently lost.
           const duplicateSecondaryIds = new Set<string>();
           for (const secId of secondaryIds) {
-            const secTab = state.tabs.tabList.find((t) => t.id === secId);
+            const secTab = tabById.get(secId);
             if (!secTab) continue;
             if (!secTab.isDirty && primaryTabs.some((pt) => tabsMatchLocation(pt, secTab))) {
               duplicateSecondaryIds.add(secId);
@@ -620,7 +623,7 @@ export const createTabsSlice: StateCreator<
           let newActivePrimary = state.tabs.activeTabId.primary;
           if (activeSecondary && duplicateSecondaryIds.has(activeSecondary)) {
             // Active secondary was a duplicate — switch to its primary counterpart
-            const secTab = state.tabs.tabList.find((t) => t.id === activeSecondary);
+            const secTab = tabById.get(activeSecondary);
             if (secTab) {
               const match = primaryTabs.find((pt) => tabsMatchLocation(pt, secTab));
               if (match) newActivePrimary = match.id;

--- a/apps/web/src/store/tabs-slice.ts
+++ b/apps/web/src/store/tabs-slice.ts
@@ -592,20 +592,52 @@ export const createTabsSlice: StateCreator<
       },
 
       closeSplit: () => {
-        set((state) => ({
-          tabs: {
-            ...state.tabs,
-            paneTabIds: {
-              primary: [...state.tabs.paneTabIds.primary, ...state.tabs.paneTabIds.secondary],
-              secondary: [],
+        set((state) => {
+          const primaryIds = state.tabs.paneTabIds.primary;
+          const secondaryIds = state.tabs.paneTabIds.secondary;
+          const primaryTabs = state.tabs.tabList.filter((t) => primaryIds.includes(t.id));
+
+          // Drop secondary tabs whose pathname already exists in primary to avoid duplicates
+          const duplicateSecondaryIds = new Set<string>();
+          for (const secId of secondaryIds) {
+            const secTab = state.tabs.tabList.find((t) => t.id === secId);
+            if (!secTab) continue;
+            if (primaryTabs.some((pt) => pt.pathname === secTab.pathname)) {
+              duplicateSecondaryIds.add(secId);
+            }
+          }
+
+          const mergedIds = [
+            ...primaryIds,
+            ...secondaryIds.filter((id) => !duplicateSecondaryIds.has(id)),
+          ];
+          const newTabList = state.tabs.tabList.filter((t) => !duplicateSecondaryIds.has(t.id));
+
+          // Resolve which primary tab to activate
+          const activeSecondary = state.tabs.activeTabId.secondary;
+          let newActivePrimary = state.tabs.activeTabId.primary;
+          if (activeSecondary && duplicateSecondaryIds.has(activeSecondary)) {
+            // Active secondary was a duplicate — switch to its primary counterpart
+            const secTab = state.tabs.tabList.find((t) => t.id === activeSecondary);
+            if (secTab) {
+              const match = primaryTabs.find((pt) => pt.pathname === secTab.pathname);
+              if (match) newActivePrimary = match.id;
+            }
+          } else if (activeSecondary && !duplicateSecondaryIds.has(activeSecondary)) {
+            // Active secondary survived the merge — make it the active primary tab
+            newActivePrimary = activeSecondary;
+          }
+
+          return {
+            tabs: {
+              ...state.tabs,
+              tabList: newTabList,
+              paneTabIds: { primary: mergedIds, secondary: [] },
+              activeTabId: { primary: newActivePrimary, secondary: null },
+              activePane: 'primary',
             },
-            activeTabId: {
-              ...state.tabs.activeTabId,
-              secondary: null,
-            },
-            activePane: 'primary',
-          },
-        }));
+          };
+        });
       },
 
       setSplitRatio: (ratio: number) => {


### PR DESCRIPTION
- Add LinkButton: a type-safe button with full TabSync click logic (Ctrl→new tab, Shift→split pane, newTab/newSplitTab props), using router.buildLocation() for params support and forwardRef for Radix asChild
- Use LinkButton in SpaceSwitcher's Manage Spaces item so the dropdown closes correctly (button never calls preventDefault, unlike <Link>)
- Fix TabSync URL→Tab sync inserting new tabs at index 0 instead of end



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter link/navigation button: tab-aware navigation supporting open-in-new-tab and open-in-split behaviors.

* **Improvements**
  * "Manage Spaces" menu now uses the new navigation behavior.
  * Opening in split now reuses matching tabs in the target pane instead of creating duplicates.
  * Improved tab/URL synchronization and split-close merging to avoid duplicate tabs; in-place navigations now better handle autosave/dirty state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->