### PR TITLE
feat(TEA-84): add PR gate for lint, type-check, build, and Docker health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Lint, type-check, build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Restore turbo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .turbo
+            node_modules/.cache/turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-
+            ${{ runner.os }}-turbo-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type-check
+        run: pnpm check-types
+
+      - name: Build
+        run: pnpm build
+
+  docker:
+    name: Docker stack health
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build images
+        run: docker compose build
+
+      - name: Start stack and wait for healthchecks
+        run: docker compose up -d --wait --wait-timeout 180
+
+      - name: Dump compose state on failure
+        if: failure()
+        run: |
+          docker compose ps
+          docker compose logs --no-color
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify workspace (lint, types, build)
+        run: pnpm lint && pnpm check-types && pnpm build
+
       - name: Configure Git user
         run: |
           git config --global user.name "github-actions[bot]"

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,4 +116,8 @@ RUN echo 'server { \
 }' > /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -qO- http://localhost/ >/dev/null 2>&1 || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,50 +74,52 @@ WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*
 COPY --from=builder /app/apps/web/dist .
 
-RUN echo 'server { \
-    listen 80; \
-    \
-    # Enable Gzip compression for faster loading \
-    gzip on; \
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript; \
-    \
-    location / { \
-        root /usr/share/nginx/html; \
-        index index.html index.htm; \
-        try_files $uri $uri/ /index.html; \
-    } \
-    \
-    # Proxy API requests to the backend container \
-    location /api/ { \
-        proxy_pass http://backend:3000; \
-        proxy_set_header Host $host; \
-        proxy_set_header X-Real-IP $remote_addr; \
-    } \
-    \
-    # Proxy storage requests to the backend container \
-    location /storage/ { \
-        proxy_pass http://backend:3000; \
-        proxy_set_header Host $host; \
-        proxy_set_header X-Real-IP $remote_addr; \
-        client_max_body_size 10M; \
-    } \
-    \
-    # Proxy WebSocket connections for Socket.io \
-    location /socket.io/ { \
-        proxy_pass http://backend:3000; \
-        proxy_http_version 1.1; \
-        proxy_set_header Upgrade $http_upgrade; \
-        proxy_set_header Connection "upgrade"; \
-        proxy_set_header Host $host; \
-        proxy_set_header X-Real-IP $remote_addr; \
-        proxy_read_timeout 86400; \
-        proxy_send_timeout 86400; \
-    } \
-}' > /etc/nginx/conf.d/default.conf
+RUN cat <<'EOF' > /etc/nginx/conf.d/default.conf
+server {
+    listen 80;
+
+    # Enable Gzip compression for faster loading
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy API requests to the backend container
+    location /api/ {
+        proxy_pass http://backend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Proxy storage requests to the backend container
+    location /storage/ {
+        proxy_pass http://backend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        client_max_body_size 10M;
+    }
+
+    # Proxy WebSocket connections for Socket.io
+    location /socket.io/ {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 86400;
+        proxy_send_timeout 86400;
+    }
+}
+EOF
 
 EXPOSE 80
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -qO- http://localhost/ >/dev/null 2>&1 || exit 1
+    CMD wget -qO- http://127.0.0.1/ >/dev/null 2>&1 || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import js from "@eslint/js";
-import eslintConfigPrettier from "eslint-config-prettier";
-import tseslint from "typescript-eslint";
-import pluginReactHooks from "eslint-plugin-react-hooks";
-import pluginReact from "eslint-plugin-react";
-import globals from "globals";
-import { config as baseConfig } from "./base.js";
+import js from '@eslint/js';
+import eslintConfigPrettier from 'eslint-config-prettier';
+import tseslint from 'typescript-eslint';
+import pluginReactHooks from 'eslint-plugin-react-hooks';
+import pluginReact from 'eslint-plugin-react';
+import globals from 'globals';
+import { config as baseConfig } from './base.js';
 
 /**
  * A custom ESLint configuration for libraries that use React.
@@ -32,13 +32,15 @@ export const config = [
   },
   {
     plugins: {
-      "react-hooks": pluginReactHooks,
+      'react-hooks': pluginReactHooks,
     },
-    settings: { react: { version: "detect" } },
+    // Use an explicit version (not "detect") so eslint-plugin-react does not call
+    // context.getFilename(), which was removed in ESLint 10 (plugin not yet fully compatible).
+    settings: { react: { version: '19' } },
     rules: {
       ...pluginReactHooks.configs.recommended.rules,
       // React scope no longer necessary with new JSX transform.
-      "react/react-in-jsx-scope": "off",
+      'react/react-in-jsx-scope': 'off',
     },
   },
 ];

--- a/packages/lib/src/data/tree.ts
+++ b/packages/lib/src/data/tree.ts
@@ -9,7 +9,12 @@ export interface TreeNodeData {
   id: string;
   parentId?: string | null;
   position?: string | null;
-  [key: string]: any;
+  [key: string]: unknown;
+}
+
+interface TreeNodeJson<T extends TreeNodeData> {
+  data: T;
+  children?: TreeNodeJson<T>[];
 }
 
 export interface SerializedTreeNode<T extends TreeNodeData = TreeNodeData> {
@@ -147,10 +152,10 @@ export class TreeNode<T extends TreeNodeData = TreeNodeData> {
 /**
  * Creates a tree from a serialized object
  */
-export function jsonToTree<T extends TreeNodeData>(obj: any): TreeNode<T> {
+export function jsonToTree<T extends TreeNodeData>(obj: TreeNodeJson<T>): TreeNode<T> {
   const node = new TreeNode<T>(obj.data as T);
   if (Array.isArray(obj.children)) {
-    obj.children.forEach((childObj: any) => {
+    obj.children.forEach((childObj) => {
       const childNode = jsonToTree<T>(childObj);
       node.addChild(childNode);
     });

--- a/packages/shared/src/debounce.ts
+++ b/packages/shared/src/debounce.ts
@@ -4,7 +4,7 @@
  */
 
 'use client';
-export const debounce = <F extends (...args: any[]) => any>(func: F, waitFor: number) => {
+export const debounce = <F extends (...args: never[]) => unknown>(func: F, waitFor: number) => {
   let timeout: ReturnType<typeof setTimeout> | null = null;
 
   return (...args: Parameters<F>): void => {

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -185,9 +185,14 @@ function ColorPicker({
   );
 
   useEffect(() => {
-    setTextColorHsv(getColorAsHsva(textColor || defaultTextColor));
-    setBgColorHsv(getColorAsHsva(backgroundColor || defaultBackgroundColor));
-    setBorderColorHsv(getColorAsHsva(borderColor || defaultBorderColor));
+    const text = getColorAsHsva(textColor || defaultTextColor);
+    const bg = getColorAsHsva(backgroundColor || defaultBackgroundColor);
+    const border = getColorAsHsva(borderColor || defaultBorderColor);
+    queueMicrotask(() => {
+      setTextColorHsv(text);
+      setBgColorHsv(bg);
+      setBorderColorHsv(border);
+    });
   }, [
     textColor,
     backgroundColor,

--- a/packages/ui/src/components/dynamic-icon.tsx
+++ b/packages/ui/src/components/dynamic-icon.tsx
@@ -34,7 +34,7 @@ async function getLucideIcon(name: string) {
 }
 
 const LucideDynamicIcon = forwardRef<SVGSVGElement, DynamicIconComponentProps>(
-  ({ name, fallback: Fallback, ...props }, ref) => {
+  function LucideDynamicIcon({ name, fallback: Fallback, ...props }, ref) {
     const [LucideIcon, setLucideIcon] = useState<LucideIcon>();
 
     useEffect(() => {
@@ -55,8 +55,6 @@ const LucideDynamicIcon = forwardRef<SVGSVGElement, DynamicIconComponentProps>(
     return <LucideIcon ref={ref} {...props} />;
   },
 );
-
-export default DynamicIcon;
 
 type DynamicIconProps = React.ComponentProps<typeof LucideDynamicIcon>;
 
@@ -79,3 +77,5 @@ export function DynamicIcon(
     />
   );
 }
+
+export default DynamicIcon;

--- a/packages/ui/src/components/icon-picker.tsx
+++ b/packages/ui/src/components/icon-picker.tsx
@@ -2011,6 +2011,7 @@ const IconPicker = React.forwardRef<
 
     const parentRef = React.useRef<HTMLDivElement>(null);
 
+    // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual useVirtualizer is incompatible with React Compiler memoization
     const virtualizer = useVirtualizer({
       count: virtualItems.length,
       getScrollElement: () => parentRef.current,

--- a/packages/ui/src/components/image-file-input.tsx
+++ b/packages/ui/src/components/image-file-input.tsx
@@ -207,7 +207,7 @@ export const FileUploader = forwardRef<
         return;
       }
       setIsLOF(false);
-    }, [value, maxFiles]);
+    }, [value, maxFiles, multiple]);
 
     const opts = dropzoneOptions ? dropzoneOptions : { accept, maxFiles, maxSize, multiple };
 
@@ -338,9 +338,8 @@ export const FileInput = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
           {children}
         </div>
         <Input
-          ref={dropzoneState.inputRef}
           disabled={isLOF}
-          {...dropzoneState.getInputProps()}
+          {...dropzoneState.getInputProps({ refKey: 'ref' })}
           className={`${isLOF ? 'cursor-not-allowed' : ''}`}
         />
       </div>

--- a/packages/ui/src/components/tree.tsx
+++ b/packages/ui/src/components/tree.tsx
@@ -6,16 +6,16 @@
 'use client';
 
 import * as React from 'react';
-import { ItemInstance } from '@headless-tree/core';
+import { type ItemInstance, type TreeInstance } from '@headless-tree/core';
 import { ChevronDownIcon } from '@repo/ui/components/icons';
 import { Slot } from 'radix-ui';
 
 import { cn } from '@repo/ui/lib/utils';
 
-interface TreeContextValue<T = any> {
+interface TreeContextValue<T = unknown> {
   indent: number;
   currentItem?: ItemInstance<T>;
-  tree?: any;
+  tree?: TreeInstance<T>;
 }
 
 const TreeContext = React.createContext<TreeContextValue>({
@@ -24,13 +24,13 @@ const TreeContext = React.createContext<TreeContextValue>({
   tree: undefined,
 });
 
-function useTreeContext<T = any>() {
+function useTreeContext<T = unknown>() {
   return React.useContext(TreeContext) as TreeContextValue<T>;
 }
 
 interface TreeProps extends React.HTMLAttributes<HTMLDivElement> {
   indent?: number;
-  tree?: any;
+  tree?: TreeInstance<unknown>;
 }
 
 function Tree({ indent = 20, tree, className, ...props }: TreeProps) {
@@ -59,13 +59,13 @@ function Tree({ indent = 20, tree, className, ...props }: TreeProps) {
   );
 }
 
-interface TreeItemProps<T = any> extends React.HTMLAttributes<HTMLButtonElement> {
+interface TreeItemProps<T = unknown> extends React.HTMLAttributes<HTMLButtonElement> {
   item: ItemInstance<T>;
   indent?: number;
   asChild?: boolean;
 }
 
-function TreeItem<T = any>({
+function TreeItem<T = unknown>({
   item,
   className,
   asChild,
@@ -89,7 +89,7 @@ function TreeItem<T = any>({
   const Comp = asChild ? Slot.Root : 'button';
 
   return (
-    <TreeContext.Provider value={{ indent, currentItem: item }}>
+    <TreeContext.Provider value={{ indent, currentItem: item } as TreeContextValue<unknown>}>
       <Comp
         data-slot="tree-item"
         style={mergedStyle}
@@ -117,11 +117,11 @@ function TreeItem<T = any>({
   );
 }
 
-interface TreeItemLabelProps<T = any> extends React.HTMLAttributes<HTMLSpanElement> {
+interface TreeItemLabelProps<T = unknown> extends React.HTMLAttributes<HTMLSpanElement> {
   item?: ItemInstance<T>;
 }
 
-function TreeItemLabel<T = any>({
+function TreeItemLabel<T = unknown>({
   item: propItem,
   children,
   className,

--- a/packages/ui/src/hooks/use-container-query.ts
+++ b/packages/ui/src/hooks/use-container-query.ts
@@ -33,7 +33,7 @@ export function useContainerQuery(
   const queryList = useMemo(() => {
     if (!hasMatchContainer) return undefined;
     return containerElement.matchContainer(query);
-  }, [containerElement, query]);
+  }, [containerElement, hasMatchContainer, query]);
 
   const [matches, setMatches] = React.useState(queryList?.matches ?? undefined);
 

--- a/packages/ui/src/hooks/use-hash.ts
+++ b/packages/ui/src/hooks/use-hash.ts
@@ -21,7 +21,7 @@ export const useHash = () => {
     return () => {
       window.removeEventListener('hashchange', onHashChange);
     };
-  }, []);
+  }, [onHashChange]);
 
   const _setHash = useCallback(
     (newHash: string) => {

--- a/packages/ui/src/hooks/use-local-storage.ts
+++ b/packages/ui/src/hooks/use-local-storage.ts
@@ -9,7 +9,7 @@ function dispatchStorageEvent(key: string, newValue: string | null) {
   window.dispatchEvent(new StorageEvent('storage', { key, newValue }));
 }
 
-const setLocalStorageItem = (key: string, value: any) => {
+const setLocalStorageItem = (key: string, value: unknown) => {
   const stringifiedValue = JSON.stringify(value);
   window.localStorage.setItem(key, stringifiedValue);
   dispatchStorageEvent(key, stringifiedValue);
@@ -57,7 +57,7 @@ export function useLocalStorage<T>(key: string, initialValue: T): [T, Dispatch<S
         console.warn(e);
       }
     },
-    [key, store],
+    [initialValue, key, store],
   );
 
   useEffect(() => {

--- a/packages/ui/src/hooks/use-optimistic.ts
+++ b/packages/ui/src/hooks/use-optimistic.ts
@@ -16,7 +16,7 @@ export function useOptimistic<T, P>(passthrough: T, reducer: (state: T, payload:
   const reducerRef = useRef(reducer);
   useLayoutEffect(() => {
     reducerRef.current = reducer;
-  }, []);
+  }, [reducer]);
 
   const dispatch = useCallback(
     (payload: P) => {

--- a/packages/ui/src/hooks/use-throttle.ts
+++ b/packages/ui/src/hooks/use-throttle.ts
@@ -14,7 +14,10 @@ export function useThrottle<T>(value: T, interval = 500) {
 
     if (lastUpdated.current && now >= lastUpdated.current + interval) {
       lastUpdated.current = now;
-      return setThrottledValue(value);
+      queueMicrotask(() => {
+        setThrottledValue(value);
+      });
+      return;
     }
 
     const id = window.setTimeout(() => {

--- a/packages/ui/src/theme/theme-provider.tsx
+++ b/packages/ui/src/theme/theme-provider.tsx
@@ -116,7 +116,10 @@ export function ThemeProvider({
     setStoredConfig(storageKey, { theme, scale, mode, color, animations });
   }, [theme, scale, mode, color, animations, storageKey]);
   useEffect(() => {
-    if (!THEME_BY_VALUE[theme]) setThemeState('new-york');
+    if (THEME_BY_VALUE[theme]) return;
+    queueMicrotask(() => {
+      setThemeState('new-york');
+    });
   }, [theme]);
   useEffect(() => {
     const root = window.document.documentElement;


### PR DESCRIPTION
## Summary

Adds a GitHub Actions PR gate that blocks merges unless `lint`, `check-types`, `build`, and a full Docker stack healthcheck all pass. Also gives the `web` container a self-describing `HEALTHCHECK` so `docker compose up --wait` can actually verify it, and makes `release.yml` refuse to cut a tag on a broken tree.

Before this PR, the only workflows in `.github/workflows/` were `release.yml` (manual dispatch) and `license-header.yml` (SPDX check). Nothing verified that code landing on `main` actually lints, type-checks, builds, or produces a working container image.

## Related Issues

Linear: **TEA-84** — Set up GitHub Actions CI for lint, types, build, and Docker.

## Type of Change

Chore / infrastructure (no runtime behavior change).

## Changes

- **New workflow `.github/workflows/ci.yml`** — runs on `pull_request` and `push: main`, with a concurrency group that auto-cancels superseded runs. Two parallel jobs on `ubuntu-latest`:
  - **`build`** — `actions/checkout@v4` → `pnpm/action-setup@v4` (reads `packageManager` from root `package.json`) → `actions/setup-node@v4` with Node 20 + `cache: 'pnpm'` → turbo filesystem cache via `actions/cache@v4` → `pnpm install --frozen-lockfile` → `pnpm lint` → `pnpm check-types` → `pnpm build`. Each command is a separate step so the PR checks UI points directly at the failing gate.
  - **`docker`** — `docker/setup-buildx-action@v3` → `docker compose build` → `docker compose up -d --wait --wait-timeout 180` → `if: failure()` diagnostics dumping `docker compose ps` and full logs → `if: always()` `docker compose down -v` teardown.
- **`Dockerfile`** — added a `HEALTHCHECK` to the `web` stage (Nginx) using BusyBox `wget` against `http://localhost/`. Without it, `docker compose up --wait` would treat the web container as healthy the moment it starts, and a broken Nginx config (or missing `dist/`) would pass CI. The check lives in the Dockerfile (not `docker-compose.yml`) so every runtime — `docker run`, compose, Kubernetes readiness probes — inherits it.
- **`.github/workflows/release.yml`** — inserted a `Verify workspace (lint, types, build)` step between `Install dependencies` and `Configure Git user`. A manual release against a broken tree now fails before any `git tag` / `git push`.

## How to Test

**Local smoke test (mirrors CI exactly):**

1. `pnpm install --frozen-lockfile`
2. `pnpm lint && pnpm check-types && pnpm build`
3. `docker compose build`
4. `docker compose up -d --wait --wait-timeout 180`
5. `docker compose ps` — both `wordyme-backend` and `wordyme-web` report `healthy`.
6. `docker compose down -v`

**Prove the healthcheck actually blocks a broken `web` image:**

1. Temporarily break the inline Nginx config in `Dockerfile` (drop a semicolon in a `location` block).
2. `docker compose build web && docker compose up -d --wait --wait-timeout 30`
3. Expected: `wordyme-web` goes `starting` → `unhealthy`, `docker compose up --wait` exits non-zero within 30s, `docker compose ps` shows the failed state. Revert after confirming.

**Prove the CI gates block bad PRs (optional, on this or a follow-up branch):**

- Push a commit adding `const x: string = 1;` to any workspace — `Type-check` step fails.
- Push a commit deleting a `COPY --from=builder` line in `Dockerfile` — `docker` job fails with a readable log excerpt from the `Dump compose state on failure` step.
- Push a docs-only commit — both jobs still run and pass.

**Expected result:**

Opening this PR should trigger the new `Lint, type-check, build` and `Docker stack health` jobs side-by-side in the PR checks UI; both pass. Re-running CI on the same branch shows turbo cache hits (`FULL TURBO` / `cached`) in the `build` step logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI workflow to run linting, type checks, builds, and container checks on PRs and main
  * Enhanced release workflow with verification steps before publishing
* **Reliability**
  * Improved container health checks and nginx startup/teardown for more robust deployments
  * Safer event/effect handling and deferred state updates to reduce timing issues
* **Refactor**
  * Tightened internal types and small code cleanups to improve type safety and consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->