### PR TITLE
chore(docker): scope .dockerignore to all depths and correct pnpm ver…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,32 +1,46 @@
-# Dependencies
-node_modules
-apps/*/node_modules
-packages/*/node_modules
+# NOTE: .dockerignore is NOT .gitignore.
+# A bare pattern like `dist` matches ONLY the root-level path, not every depth.
+# Use `**/` prefixes to match at any depth. Last matching pattern wins.
+
+# ---------- Dependencies ----------
+**/node_modules
 .pnpm-store
 
-# Build Outputs
-dist
-build
-.turbo
+# ---------- Build outputs ----------
+**/dist
+**/build
+**/.turbo
+**/*.tsbuildinfo
+**/coverage
 
-# Environment Variables & Secrets
-.env
-.env.local
-.env.*
-!.env.example
+# ---------- Secrets (CRITICAL: all depths) ----------
+**/.env
+**/.env.*
+!**/.env.example
 
-# Database (CRITICAL: Do not copy local dev DB)
-storage/*.db
-*.sqlite
-*.sqlite-journal
-apps/backend/*.db
-apps/backend/local.db
-backend/*.db
-apps/backend/storage/*.db
+# ---------- Databases & user data (CRITICAL) ----------
+**/*.db
+**/*.db-wal
+**/*.db-shm
+**/*.db-journal
+**/*.sqlite
+**/*.sqlite3
+storage/
+apps/backend/storage/
 
-# Version Control & Logs
+# ---------- VCS, editors, tooling ----------
 .git
-.DS_Store
-npm-debug.log*
-yarn-debug.log*
-pnpm-debug.log*
+.gitignore
+.github
+.husky
+.vscode
+.idea
+
+# ---------- Logs & OS cruft ----------
+**/*.log
+**/.DS_Store
+
+# ---------- Docker's own files ----------
+Dockerfile*
+docker-compose*.yml
+.dockerignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ If you have questions about implementation details or need help:
 Before you begin, ensure you have the following installed:
 
 - [Node.js](https://nodejs.org/) >= 18
-- [pnpm](https://pnpm.io/) 9.0.0
+- [pnpm](https://pnpm.io/) 10.33.0
 
 ### Getting Started
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -210,21 +210,36 @@ Then edit `.env` with your values. The `.env.example` file contains all availabl
 
 ### What's Excluded from Docker Builds
 
-The `.dockerignore` file excludes the following from Docker builds:
+The `.dockerignore` file excludes the following from Docker builds, **at every
+directory depth**:
 
-- **Dependencies**: `node_modules`, `.pnpm-store`
-- **Build outputs**: `dist`, `build`, `.turbo`
-- **Environment files**: `.env`, `.env.local`, `.env.*` (but keeps `.env.example`)
-- **Database files**: `*.db`, `*.sqlite`, `*.sqlite-journal` (prevents copying local dev databases)
-- **Version control**: `.git`
-- **Logs**: `npm-debug.log*`, `yarn-debug.log*`, `pnpm-debug.log*`
-- **System files**: `.DS_Store`
+- **Dependencies**: `**/node_modules`, `.pnpm-store`
+- **Build outputs**: `**/dist`, `**/build`, `**/.turbo`, `**/*.tsbuildinfo`, `**/coverage`
+- **Environment files**: `**/.env`, `**/.env.*` (but keeps every `**/.env.example`)
+- **Databases**: `**/*.db`, `**/*.db-wal`, `**/*.db-shm`, `**/*.db-journal`, `**/*.sqlite`, `**/*.sqlite3`
+- **User uploads**: the whole `storage/` and `apps/backend/storage/` directories
+- **Version control & tooling**: `.git`, `.gitignore`, `.github`, `.husky`, `.vscode`, `.idea`
+- **Logs and OS cruft**: `**/*.log`, `**/.DS_Store`
+- **Docker's own files**: `Dockerfile*`, `docker-compose*.yml`, `.dockerignore`
+
+> **Important — `.dockerignore` is not `.gitignore`.** In a `.dockerignore`, a
+> bare pattern such as `dist` matches **only** the root-level path; it does not
+> match `apps/web/dist`. That is why every pattern above is written with a
+> `**/` prefix. When the last matching pattern is a negation (`!`), the file is
+> re-included — which is how `.env.example` survives the `**/.env.*` rule.
+
+> **Do not add these to `.dockerignore`:** `patches/` (pnpm applies the Lexical
+> patches listed in `pnpm-workspace.yaml` during install — excluding this
+> directory breaks the build), `.npmrc`, `pnpm-workspace.yaml`, `turbo.json`,
+> and `pnpm-lock.yaml`.
 
 This ensures:
 
 - Smaller build context and faster builds
-- No accidental inclusion of secrets or local databases
+- No accidental inclusion of secrets, local databases, or user uploads
 - Clean production images
+- Stable Docker layer caching (stale `dist/` output no longer invalidates the
+  cache on every local build)
 
 ### Method 2: Directly in `docker-compose.yml`
 
@@ -389,7 +404,7 @@ The `Dockerfile` uses a multi-stage build process optimized for a monorepo:
 ### Stage 2: Builder
 
 - **Base**: `node:20-alpine` with `sqlite` and `libc6-compat`
-- **Package Manager**: pnpm 9.0.0 (via Corepack)
+- **Package Manager**: pnpm (via Corepack, version resolved from the `packageManager` field in the root `package.json` — currently 10.33.0)
 - **Process**:
   1. Copies pruned files from pruner stage
   2. Installs dependencies with `pnpm install --frozen-lockfile`

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@ FROM node:20-alpine AS builder
 RUN apk add --no-cache libc6-compat sqlite
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@10.27.0 --activate
+# Corepack resolves the pnpm version from the `packageManager` field in
+# package.json (including its integrity hash), so do not pin a version here —
+# a version pinned in this file is silently ignored and only wastes a download.
+RUN corepack enable
 
 # Copy pruned files
 COPY --from=pruner /app/out/json/ .

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -7,7 +7,7 @@ This guide will help you set up and run WordyMe on your local machine.
 Before you begin, ensure you have the following installed:
 
 - **Node.js** >= 18 ([Download](https://nodejs.org/))
-- **pnpm** 9.0.0 ([Installation Guide](https://pnpm.io/installation))
+- **pnpm** 10.33.0 ([Installation Guide](https://pnpm.io/installation))
 
 ### Installing pnpm
 
@@ -15,7 +15,7 @@ If you don't have pnpm installed:
 
 ```bash
 # Using npm
-npm install -g pnpm@9.0.0
+npm install -g pnpm@10.33.0
 
 # Using Homebrew (macOS)
 brew install pnpm

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The application will be available at:
 ### Prerequisites
 
 - **Node.js** >= 18
-- **pnpm** 9.0.0 (specified in `packageManager` field)
+- **pnpm** 10.33.0 (specified in `packageManager` field)
 
 ### Available Scripts
 


### PR DESCRIPTION
…sion

.dockerignore was written with .gitignore semantics, where a bare pattern matches only the root-level path. As a result apps/backend/.env, apps/web/dist, apps/backend/dist and the SQLite WAL sidecars were all being uploaded into the build context.

- Rewrite .dockerignore with **/ prefixes so patterns apply at every depth
- Exclude .env at all depths (keeping every .env.example), the -wal/-shm sidecars, and the storage/ directories in full rather than only *.db inside them, so user uploads cannot be swept in
- Drop dead patterns: backend/*.db (no such directory) and the redundant apps/backend/local.db
- Remove the pnpm@10.27.0 pin from the Dockerfile. Corepack resolves the version from the packageManager field in package.json, so the pin was silently ignored and only cost a wasted download.
- Correct five stale "pnpm 9.0.0" references to 10.33.0 across README, CONTRIBUTING, LOCAL_SETUP and DOCKER.md
- Document the .dockerignore depth semantics and the must-not-ignore list (patches/, .npmrc, pnpm-workspace.yaml, turbo.json, pnpm-lock.yaml) in DOCKER.md

Build context drops from 15.66 MB to 5.36 MB. Verified by exporting the context and confirming only .env.example files remain, patches/ is intact, and corepack resolves 10.33.0 on node:20-alpine.

## Summary

<!-- Briefly describe what this PR does and why it's needed. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close issues when merged. -->

Fixes #

## Type of Change

<!-- Examples: Bug fix, New feature, Breaking change, Refactor, Documentation, Performance improvement -->

## Changes

<!-- List key changes in bullet points. Be specific. -->

-
-

## How to Test

<!-- Provide clear steps for reviewers to verify your changes work as expected. -->

1.
2.
3.

**Expected result:**

## Screenshots

<!-- Required for UI changes. Include before/after screenshots or videos. Remove this section if not a UI change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and contribution guidance to require pnpm 10.33.0.
  * Expanded Docker documentation with clearer build requirements and file-exclusion behavior.
* **Chores**
  * Improved Docker build exclusions for dependencies, build artifacts, secrets, databases, logs, and development files.
  * Simplified package-manager setup during Docker builds for more consistent version resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->