### PR TITLE
feat(docker): handle signals, restore rate limiting, and harden the c…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,12 +19,20 @@
 !**/.env.example
 
 # ---------- Databases & user data (CRITICAL) ----------
+# WAL mode writes -wal and -shm alongside the database; the -wal file holds
+# recent writes, so it leaks data just as the main file does.
 **/*.db
 **/*.db-wal
 **/*.db-shm
 **/*.db-journal
 **/*.sqlite
+**/*.sqlite-wal
+**/*.sqlite-shm
+**/*.sqlite-journal
 **/*.sqlite3
+**/*.sqlite3-wal
+**/*.sqlite3-shm
+**/*.sqlite3-journal
 storage/
 apps/backend/storage/
 

--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,12 @@ CLIENT_URL=http://localhost:8080
 
 # Optional. Set ONLY when a reverse proxy sits in front of the container, so the
 # client address it reports is used for login rate limiting. Accepts a hop count
-# (1), true, or a list of trusted addresses. Leave unset when the port is reached
-# directly — trusting X-Forwarded-For from arbitrary clients lets them forge an
-# address per request and evade rate limiting entirely.
+# (1) or a list of trusted addresses/subnets (10.0.0.0/8). Leave unset when the
+# port is reached directly.
+#
+# TRUST_PROXY=true is rejected at startup: it would trust the left-most
+# X-Forwarded-For entry, which any client can forge, letting them evade rate
+# limiting. A hop count is resolved from the right instead.
 # TRUST_PROXY=1
 
 # Note: VITE_BACKEND_URL is not needed for Docker. The backend serves the web

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,13 @@ CLIENT_URL=http://localhost:8080
 # and update CLIENT_URL to match.
 # HOST_PORT=8080
 
+# Optional. Set ONLY when a reverse proxy sits in front of the container, so the
+# client address it reports is used for login rate limiting. Accepts a hop count
+# (1), true, or a list of trusted addresses. Leave unset when the port is reached
+# directly — trusting X-Forwarded-For from arbitrary clients lets them forge an
+# address per request and evade rate limiting entirely.
+# TRUST_PROXY=1
+
 # Note: VITE_BACKEND_URL is not needed for Docker. The backend serves the web
 # bundle from the same origin, so API calls are relative. It applies only if you
 # host the frontend on a different origin from the API — and because Vite inlines

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -188,18 +188,31 @@ The application uses Docker volumes to persist data:
 
 ### Backup Database
 
-```bash
-# Create a backup
-docker compose exec wordyme cp /app/storage/local.db /app/storage/local.db.backup
+The database is a single file. It runs in SQLite's rollback-journal mode
+(`journal_mode=delete`, verifiable with `PRAGMA journal_mode`), **not** WAL, so
+there are no persistent `-wal` or `-shm` companion files to collect. A copy of
+`local.db` is the whole database.
 
-# Copy database from container to host
+The safest backup is taken with the service stopped, so no write can land
+mid-copy:
+
+```bash
+docker compose stop wordyme
+```
+
+```bash
 docker compose cp wordyme:/app/storage/local.db ./backup-local.db
 ```
 
-> **Note**: libSQL runs in WAL mode, so recent writes may live in
-> `local.db-wal` rather than in `local.db`. For a guaranteed-consistent backup,
-> stop the container first (`docker compose stop`) and copy all three of
-> `local.db`, `local.db-wal` and `local.db-shm`.
+```bash
+docker compose start wordyme
+```
+
+Stopping costs almost nothing — shutdown completes in well under a second.
+
+Copying while the service is running usually works, but a write landing during
+the copy can produce a torn file that only reveals itself when you try to
+restore it. If you take live backups, verify them.
 
 ### Restore Database
 
@@ -208,9 +221,12 @@ that are hard to spot:
 
 - **Stop the service first.** Replacing `local.db` underneath a running SQLite
   is not safe.
-- **Delete the stale sidecars.** WAL mode leaves `local.db-wal` and
-  `local.db-shm` beside the database. SQLite will replay a leftover `-wal`
-  against the file you just restored, corrupting it.
+- **Clear any leftover journal.** If the process was killed mid-write, a
+  `local.db-journal` can survive. On the next open SQLite treats it as an
+  interrupted transaction and rolls part of it back — into the file you just
+  restored. The command below removes it, along with `-wal`/`-shm`, which this
+  configuration does not use but which would matter if the journal mode ever
+  changed.
 - **Fix the file ownership.** `docker cp` preserves the ownership of the file on
   your machine, so the restored database arrives owned by your host user rather
   than the container's `nodejs` user. The result is a container that looks
@@ -224,10 +240,10 @@ docker compose stop wordyme
 ```
 
 ```bash
-# 2. Remove the stale sidecars and stream the backup in. Streaming rather than
+# 2. Clear any leftover journal and stream the backup in. Streaming rather than
 #    `docker compose cp` means the file is written by the container's own user,
 #    so the ownership is correct and no chown is needed.
-docker compose run --rm -T --entrypoint sh wordyme -c 'rm -f /app/storage/local.db-wal /app/storage/local.db-shm && cat > /app/storage/local.db' < ./backup-local.db
+docker compose run --rm -T --entrypoint sh wordyme -c 'rm -f /app/storage/local.db-journal /app/storage/local.db-wal /app/storage/local.db-shm && cat > /app/storage/local.db' < ./backup-local.db
 ```
 
 ```bash
@@ -341,15 +357,25 @@ Set `TRUST_PROXY` when a proxy really is in front, so the address it reports is
 used instead:
 
 ```bash
-TRUST_PROXY=1          # trust one proxy hop (most common)
-TRUST_PROXY=true       # trust whatever X-Forwarded-For says
-TRUST_PROXY=10.0.0.0/8 # trust only these addresses
+TRUST_PROXY=1           # trust one proxy hop (most common)
+TRUST_PROXY=2           # two proxies in front, e.g. Cloudflare then nginx
+TRUST_PROXY=10.0.0.0/8  # trust only these addresses
 ```
 
-> **Do not set this when the port is exposed directly.** Trusting
-> `X-Forwarded-For` from arbitrary clients lets an attacker send a different
-> value on each request, getting a fresh rate-limit allowance every time and
-> defeating the protection entirely.
+> **`TRUST_PROXY=true` is rejected at startup, on purpose.** It would make
+> Express take the left-most `X-Forwarded-For` entry, and any client can prepend
+> one. Because proxies normally _append_ to that chain rather than replacing it,
+> a forged entry stays on the left and wins — so an attacker could present a
+> different address on every request and get a fresh rate-limit allowance each
+> time. A hop count or an address list is resolved from the right instead, which
+> a client cannot influence.
+
+Whatever the setting, the client address is resolved by the server and the
+`X-Forwarded-For` header is then **overwritten** with the result, so no raw
+client-supplied value ever reaches the rate limiter.
+
+> **Do not set this when the port is exposed directly** — there is no proxy to
+> trust, and the default already uses the real connection address.
 
 To reach the app from another machine on your LAN, add that origin to
 `CLIENT_URL`:

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -87,8 +87,13 @@ This is a deliberate choice, not a shortcut:
   - `CLIENT_URL` (defaults to `http://localhost:8080`)
   - `BETTER_AUTH_URL` (optional)
   - `BETTER_AUTH_SECRET` — **required, no default**, see below
+  - `TRUST_PROXY` (optional; set only behind a reverse proxy)
 - **Volumes**:
   - `wordyme-storage` → `/app/storage` — SQLite database and uploaded files
+- **Logging**: capped at 3 files of 10 MB. Without this, JSON logs grow until the
+  disk is full — a real failure mode on a Pi writing to an SD card
+- **Hardening**: `no-new-privileges`, all Linux capabilities dropped, and a 1 GB
+  memory limit. The app idles around 55 MB, so the limit only catches a runaway
 - **Restart Policy**: `unless-stopped`
 - **Health Check**: defined in the image itself, so `docker run` users get it
   too. Probes `/api/health` every 30s (5s timeout, 3 retries, 40s start period).
@@ -198,13 +203,48 @@ docker compose cp wordyme:/app/storage/local.db ./backup-local.db
 
 ### Restore Database
 
-```bash
-# Copy database from host to container
-docker compose cp ./backup-local.db wordyme:/app/storage/local.db
+Restoring takes three steps, and skipping either of the last two fails in ways
+that are hard to spot:
 
-# Restart the service
-docker compose restart wordyme
+- **Stop the service first.** Replacing `local.db` underneath a running SQLite
+  is not safe.
+- **Delete the stale sidecars.** WAL mode leaves `local.db-wal` and
+  `local.db-shm` beside the database. SQLite will replay a leftover `-wal`
+  against the file you just restored, corrupting it.
+- **Fix the file ownership.** `docker cp` preserves the ownership of the file on
+  your machine, so the restored database arrives owned by your host user rather
+  than the container's `nodejs` user. The result is a container that looks
+  completely healthy — it starts, reports `healthy`, and even `/api/health/db`
+  passes, because reads still work — while **every write silently fails** with
+  `SQLITE_READONLY`.
+
+```bash
+# 1. Stop the service so nothing is writing.
+docker compose stop wordyme
 ```
+
+```bash
+# 2. Remove the stale sidecars and stream the backup in. Streaming rather than
+#    `docker compose cp` means the file is written by the container's own user,
+#    so the ownership is correct and no chown is needed.
+docker compose run --rm -T --entrypoint sh wordyme -c 'rm -f /app/storage/local.db-wal /app/storage/local.db-shm && cat > /app/storage/local.db' < ./backup-local.db
+```
+
+```bash
+# 3. Start again.
+docker compose start wordyme
+```
+
+Then **verify by signing in**, not by checking that the container is healthy —
+it reports healthy either way.
+
+> **Why not `docker compose cp`?** It preserves the ownership of the file on
+> your machine, so the database arrives owned by your host user instead of the
+> container's `nodejs`. The container then starts, reports healthy, and passes
+> `/api/health/db` (reads still work) while every write fails with
+> `SQLITE_READONLY`. Streaming the bytes in avoids this entirely. Note also that
+> `chown` inside the container is not an option here: `cap_drop: ALL` removes
+> `CAP_CHOWN` and `CAP_DAC_OVERRIDE`, so not even root can do it.
 
 ## Environment Variables
 
@@ -236,7 +276,7 @@ directory depth**:
 - **Dependencies**: `**/node_modules`, `.pnpm-store`
 - **Build outputs**: `**/dist`, `**/build`, `**/.turbo`, `**/*.tsbuildinfo`, `**/coverage`
 - **Environment files**: `**/.env`, `**/.env.*` (but keeps every `**/.env.example`)
-- **Databases**: `**/*.db`, `**/*.db-wal`, `**/*.db-shm`, `**/*.db-journal`, `**/*.sqlite`, `**/*.sqlite3`
+- **Databases**: `**/*.db`, `**/*.sqlite`, `**/*.sqlite3`, and their WAL sidecars (`-wal`, `-shm`, `-journal`) for each
 - **User uploads**: the whole `storage/` and `apps/backend/storage/` directories
 - **Version control & tooling**: `.git`, `.gitignore`, `.github`, `.husky`, `.vscode`, `.idea`
 - **Logs and OS cruft**: `**/*.log`, `**/.DS_Store`
@@ -247,7 +287,7 @@ directory depth**:
 > match `apps/web/dist`. That is why every pattern above is written with a
 > `**/` prefix. When the last matching pattern is a negation (`!`), the file is
 > re-included — which is how `.env.example` survives the `**/.env.*` rule.
-
+>
 > **Do not add these to `.dockerignore`:** `patches/` (pnpm applies the Lexical
 > patches listed in `pnpm-workspace.yaml` during install — excluding this
 > directory breaks the build), `.npmrc`, `pnpm-workspace.yaml`, `turbo.json`,
@@ -283,7 +323,33 @@ All variables are read at runtime and can be changed without rebuilding the imag
 | `NODE_ENV`           | Node environment                                                 | `production`                    |
 | `PORT`               | Port the app listens on, inside the container                    | `8080`                          |
 | `DB_FILE_NAME`       | Database file path (absolute)                                    | `file:/app/storage/local.db`    |
+| `TRUST_PROXY`        | Set **only** behind a reverse proxy — see below                  | _(unset; not behind a proxy)_   |
 | `HOST_PORT`          | Host port compose publishes to (compose only)                    | `8080`                          |
+
+#### `TRUST_PROXY` and login rate limiting
+
+Leave this unset unless a reverse proxy sits in front of the container.
+
+The app rate-limits login attempts, and to do that it needs to know who is
+making the request. It reads the client address from the `X-Forwarded-For`
+header, which is set by a reverse proxy. When the container's port is reached
+directly there is no proxy and no such header, so the app falls back to the real
+connection address instead — otherwise rate limiting would silently do nothing
+and repeated password guesses would go unthrottled.
+
+Set `TRUST_PROXY` when a proxy really is in front, so the address it reports is
+used instead:
+
+```bash
+TRUST_PROXY=1          # trust one proxy hop (most common)
+TRUST_PROXY=true       # trust whatever X-Forwarded-For says
+TRUST_PROXY=10.0.0.0/8 # trust only these addresses
+```
+
+> **Do not set this when the port is exposed directly.** Trusting
+> `X-Forwarded-For` from arbitrary clients lets an attacker send a different
+> value on each request, getting a fresh rate-limit allowance every time and
+> defeating the protection entirely.
 
 To reach the app from another machine on your LAN, add that origin to
 `CLIENT_URL`:
@@ -537,30 +603,39 @@ CLIENT_URL=https://notes.example.com
 
 4. **Minimal Base Images**: Alpine Linux base images, for a smaller attack surface.
 
-5. **Use HTTPS**: in production, terminate TLS at a reverse proxy (Traefik, Caddy, Nginx) in front of the container.
+5. **Use HTTPS**: in production, terminate TLS at a reverse proxy (Traefik, Caddy, Nginx) in front of the container. When you do, set `TRUST_PROXY` so login rate limiting sees the real client address.
 
 6. **Limit Port Exposure**: only one port (8080) needs publishing. Behind a reverse proxy, bind it to loopback — `127.0.0.1:8080:8080` — so it is not reachable directly.
 
-7. **Regular Updates**: keep the image and its base image patched.
+7. **Reduced Privileges**: the container runs with `no-new-privileges` and every Linux capability dropped (`cap_drop: ALL`). It needs none — it listens on a high port as a non-root user and only reads and writes files. Note this also means `chown` cannot be run inside the container, which affects how you restore a backup (see above).
 
-8. **Volume Permissions**: `/app/storage` is created owned by the `nodejs` user.
+8. **Bounded Logs and Memory**: logs are capped at 3 × 10 MB and memory at 1 GB, so neither a log flood nor a runaway process can take down the host.
 
-9. **Database Isolation**: local development databases and uploads are excluded from builds, so they cannot leak into a published image.
+9. **Regular Updates**: keep the image and its base image patched.
+
+10. **Volume Permissions**: `/app/storage` is created owned by the `nodejs` user.
+
+11. **Database Isolation**: local development databases and uploads are excluded from builds, so they cannot leak into a published image.
 
 ### Known gaps
 
 These are tracked and not yet addressed:
 
-- The container does not yet handle `SIGTERM` gracefully. `docker stop` will wait
-  for the timeout and then kill the process, which is not safe for a live SQLite
-  writer. Prefer stopping when the app is idle until this is fixed.
-- The base image is `node:20-alpine`; Node 20 reached end of life on 30 April 2026.
-- Compose does not yet set `no-new-privileges`, `cap_drop`, memory limits, or log
-  rotation. On a small device, unbounded JSON logs can fill the disk — consider
-  adding a `logging` block with `max-size` and `max-file`.
-- A bind mount (`./data:/app/storage`) is created root-owned by Docker, which the
-  non-root container user cannot write to. Named volumes, as used in
-  `docker-compose.yml`, do not have this problem.
+- **The base image is `node:20-alpine`**, and Node 20 reached end of life on
+  30 April 2026. Upgrading is the next planned change.
+- **Bind mounts do not work out of the box.** Docker creates a bind mount
+  (`./data:/app/storage`) owned by root, which the non-root container user
+  cannot write to. Use the named volume in `docker-compose.yml`, which does not
+  have this problem.
+
+### Shutdown behaviour
+
+`docker stop` shuts down cleanly in well under a second. The container runs
+`tini` as PID 1 so signals actually arrive, and on `SIGTERM` the app stops
+accepting connections, disconnects clients, and waits for queued database writes
+to finish before exiting — SQLite is single-writer, so being killed mid-write is
+the failure worth avoiding. If shutdown ever takes longer than 8 seconds, the
+process exits anyway rather than waiting to be killed.
 
 ## Support
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,11 @@ RUN pnpm --filter @repo/backend --prod deploy --legacy pruned-backend
 FROM node:20-alpine AS runner
 WORKDIR /app
 
-RUN apk add --no-cache libc6-compat
+# tini becomes PID 1. A process running as PID 1 does not get the kernel's
+# default signal handling, so without an init the container ignores SIGTERM and
+# `docker stop` waits out its timeout before SIGKILL — killing a live SQLite
+# writer. tini forwards signals properly and reaps zombies.
+RUN apk add --no-cache libc6-compat tini
 
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nodejs
@@ -90,4 +94,8 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
     CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.PORT||8080)+'/api/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 
-CMD ["sh", "-c", "node run-migrations.mjs && node dist/index.js"]
+ENTRYPOINT ["/sbin/tini", "--"]
+
+# `exec` matters: without it the shell stays alive as the parent, and the signal
+# tini forwards would reach sh rather than Node.
+CMD ["sh", "-c", "node run-migrations.mjs && exec node dist/index.js"]

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import express, { type Express } from 'express';
+import express, { type Express, type Request, type Response } from 'express';
 import { createServer } from 'node:http';
 import morgan from 'morgan';
 import cors from 'cors';
@@ -17,6 +17,7 @@ import { env } from './env.js';
 
 // Error Middlewares
 import { errorHandler, notFoundHandler } from './middlewares/errors.js';
+import { clientIp } from './middlewares/client-ip.js';
 
 // REST Routers
 import { documentsRouter } from './routes/documents.js';
@@ -32,6 +33,9 @@ const server = createServer(app);
 
 initializeSocket(server);
 
+// Only takes effect when TRUST_PROXY is set; see apps/backend/src/env.ts.
+app.set('trust proxy', env.TRUST_PROXY);
+
 app.use(
   cors({
     origin: env.CLIENT_URL,
@@ -39,9 +43,21 @@ app.use(
   }),
 );
 
+// Must run before the auth handler, which is what consumes the client IP.
+app.use(clientIp);
+
 app.all('/api/auth/{*any}', toNodeHandler(auth));
 
-app.use(morgan('dev'));
+app.use(
+  morgan<Request, Response>('dev', {
+    // The container health check polls this every 30s. Logging it buries real
+    // traffic and, on a device logging to an SD card, adds ~2,900 lines a day
+    // that say nothing. Use originalUrl: Express rewrites req.url when a
+    // request enters a mounted router, so by the time morgan evaluates this the
+    // path would read as '/' rather than '/api/health'.
+    skip: (req) => req.originalUrl.split('?')[0] === '/api/health',
+  }),
+);
 app.use(express.json({ limit: '5mb' }));
 
 app.use('/api/documents', documentsRouter);

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -11,20 +11,25 @@ export const envSchema = z.object({
   PORT: z.coerce.number().default(3000),
   DB_FILE_NAME: z.string().default('file:storage/local.db'),
   /**
-   * Set only when a reverse proxy sits in front of the app. Accepts Express's
-   * `trust proxy` values: `true`, a hop count (`1`), or a comma-separated list
-   * of trusted addresses/subnets. Leave unset when the app is reached directly —
-   * trusting `X-Forwarded-For` from arbitrary clients lets them forge their IP
-   * and evade rate limiting.
+   * Set only when a reverse proxy sits in front of the app. Accepts a hop count
+   * (`1`) or a comma-separated list of trusted addresses/subnets
+   * (`10.0.0.0/8`). Leave unset when the app is reached directly.
+   *
+   * `true` is deliberately rejected. It makes Express take the left-most
+   * `X-Forwarded-For` entry, which any client can prepend — so a value meant to
+   * identify the caller becomes attacker-controlled.
    */
   TRUST_PROXY: z.preprocess(
     (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
     z
       .string()
       .optional()
+      .refine((val) => val !== 'true', {
+        message:
+          'TRUST_PROXY=true is unsafe: Express would trust the left-most X-Forwarded-For entry, which any client can forge. Use a hop count (e.g. TRUST_PROXY=1) or a list of trusted proxy addresses/subnets instead.',
+      })
       .transform((val) => {
         if (val === undefined || val === 'false') return false;
-        if (val === 'true') return true;
         return /^\d+$/.test(val) ? Number(val) : val;
       }),
   ),

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -10,6 +10,24 @@ export const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   PORT: z.coerce.number().default(3000),
   DB_FILE_NAME: z.string().default('file:storage/local.db'),
+  /**
+   * Set only when a reverse proxy sits in front of the app. Accepts Express's
+   * `trust proxy` values: `true`, a hop count (`1`), or a comma-separated list
+   * of trusted addresses/subnets. Leave unset when the app is reached directly —
+   * trusting `X-Forwarded-For` from arbitrary clients lets them forge their IP
+   * and evade rate limiting.
+   */
+  TRUST_PROXY: z.preprocess(
+    (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
+    z
+      .string()
+      .optional()
+      .transform((val) => {
+        if (val === undefined || val === 'false') return false;
+        if (val === 'true') return true;
+        return /^\d+$/.test(val) ? Number(val) : val;
+      }),
+  ),
   /** Public origin of the auth API (same as the web app when using the Nginx proxy). Overrides first CLIENT_URL for Better Auth `baseURL`. */
   BETTER_AUTH_URL: z.preprocess(
     (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -5,7 +5,58 @@
 
 import server from './app.js';
 import { env } from './env.js';
+import { getSocket } from './lib/socket.js';
+import { dbWritesQueue } from './queues/db-writes.js';
+
+/**
+ * How long to wait for in-flight work before giving up. Docker's default grace
+ * period before SIGKILL is 10s, so stay under it — otherwise the kernel kills
+ * the process anyway and the graceful path achieved nothing.
+ */
+const SHUTDOWN_TIMEOUT_MS = 8_000;
 
 server.listen(env.PORT, () => {
   console.log(`Server is running on http://localhost:${env.PORT}`);
 });
+
+let shuttingDown = false;
+
+/**
+ * Closes down in an order that protects the database: stop accepting
+ * connections and disconnect clients, then let already-queued writes finish.
+ * SQLite is single-writer, so being killed mid-write is the failure worth
+ * avoiding.
+ */
+const shutdown = async (signal: string) => {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+  console.log(`${signal} received, shutting down.`);
+
+  // Backstop: if shutdown itself hangs, exit rather than wait for SIGKILL.
+  const forceExit = setTimeout(() => {
+    console.error('Graceful shutdown timed out, exiting.');
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS);
+  forceExit.unref();
+
+  try {
+    // Socket.io closes the HTTP server it is attached to, so this stands in for
+    // a separate server.close() rather than complementing it.
+    await new Promise<void>((resolve, reject) => {
+      getSocket().close((err) => (err ? reject(err) : resolve()));
+    });
+
+    await dbWritesQueue.onIdle();
+
+    console.log('Shutdown complete.');
+    process.exit(0);
+  } catch (err) {
+    console.error('Error during shutdown:', err);
+    process.exit(1);
+  }
+};
+
+process.on('SIGTERM', () => void shutdown('SIGTERM'));
+process.on('SIGINT', () => void shutdown('SIGINT'));

--- a/apps/backend/src/lib/web.ts
+++ b/apps/backend/src/lib/web.ts
@@ -33,8 +33,16 @@ export const hasWebBundle = (): boolean => existsSync(path.join(WEB_DIR, 'index.
  */
 const NEVER_CACHE = new Set(['index.html', 'sw.js', 'registerSW.js', 'manifest.webmanifest']);
 
-/** Paths owned by the server. They must keep their own 404s instead of the app shell. */
-const SERVER_PREFIXES = ['/api/', '/storage/', '/docs'];
+/**
+ * Paths owned by the server. They must keep their own responses instead of the
+ * app shell. Matched as the exact path or a child of it, so that bare `/api`
+ * is still server-owned while a client route like `/docs-for-beginners` is not
+ * swallowed by a `startsWith('/docs')` test.
+ */
+const SERVER_PREFIXES = ['/api', '/storage', '/docs'];
+
+const isServerPath = (pathname: string): boolean =>
+  SERVER_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 
 /**
  * Extensions that identify a request for a static file rather than a client-side
@@ -70,10 +78,7 @@ export const webStatic: RequestHandler = express.static(WEB_DIR, {
  * leaving unmatched server paths to the normal JSON 404 handler.
  */
 export const webFallback: RequestHandler = (req, res, next) => {
-  if (
-    SERVER_PREFIXES.some((prefix) => req.path.startsWith(prefix)) ||
-    STATIC_ASSET.test(req.path)
-  ) {
+  if (isServerPath(req.path) || STATIC_ASSET.test(req.path)) {
     return next();
   }
 

--- a/apps/backend/src/middlewares/client-ip.ts
+++ b/apps/backend/src/middlewares/client-ip.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { type RequestHandler } from 'express';
+import { env } from '../env.js';
+
+/**
+ * Makes the client IP visible to Better Auth, which needs it for rate limiting.
+ *
+ * Better Auth reads the client IP from request headers only — `x-forwarded-for`
+ * by default — and in production it gives up and returns `null` when no such
+ * header is present. Returning `null` disables rate limiting for that request.
+ * A container with a published port has no proxy in front of it setting that
+ * header, so login rate limiting silently does nothing: nothing throttles
+ * repeated password guesses.
+ *
+ * The correct value depends on the deployment, which is what `TRUST_PROXY`
+ * selects:
+ *
+ * - **Not set (default)** — assume the app is reachable directly. Any
+ *   `X-Forwarded-For` sent by a client is therefore forged, and is overwritten
+ *   with the real peer address. Without this, an attacker could rotate the
+ *   header to get a fresh rate-limit bucket per request.
+ * - **Set** — assume a reverse proxy in front, and preserve the header it sets.
+ *   Express is configured to trust the same number of hops, so `req.ip` agrees.
+ */
+export const clientIp: RequestHandler = (req, _res, next) => {
+  if (!env.TRUST_PROXY) {
+    const peer = req.socket.remoteAddress;
+
+    if (peer) {
+      // Node reports IPv4 peers as IPv4-mapped IPv6 (`::ffff:10.0.0.1`) on a
+      // dual-stack socket; Better Auth wants the plain form.
+      req.headers['x-forwarded-for'] = peer.replace(/^::ffff:/, '');
+    } else {
+      delete req.headers['x-forwarded-for'];
+    }
+  }
+
+  next();
+};

--- a/apps/backend/src/middlewares/client-ip.ts
+++ b/apps/backend/src/middlewares/client-ip.ts
@@ -4,7 +4,6 @@
  */
 
 import { type RequestHandler } from 'express';
-import { env } from '../env.js';
 
 /**
  * Makes the client IP visible to Better Auth, which needs it for rate limiting.
@@ -27,16 +26,26 @@ import { env } from '../env.js';
  *   Express is configured to trust the same number of hops, so `req.ip` agrees.
  */
 export const clientIp: RequestHandler = (req, _res, next) => {
-  if (!env.TRUST_PROXY) {
-    const peer = req.socket.remoteAddress;
+  // `req.ip` is resolved by Express from the `trust proxy` setting: the socket
+  // peer when unset, or the right-most address in the X-Forwarded-For chain
+  // that is not one of the configured trusted hops. Either way it is a value
+  // the deployment vouches for.
+  //
+  // The header is then *overwritten* with it, never passed through. Better Auth
+  // reads the left-most entry of X-Forwarded-For, so forwarding a raw
+  // client-supplied header would let anyone prepend an address and get a fresh
+  // rate-limit bucket on every request — defeating the limit entirely. This
+  // holds even behind a proxy, because proxies typically append to the chain
+  // rather than replacing it, leaving the forged entry on the left.
+  //
+  // Node reports IPv4 peers as IPv4-mapped IPv6 (`::ffff:10.0.0.1`) on a
+  // dual-stack socket; Better Auth wants the plain form.
+  const ip = req.ip?.replace(/^::ffff:/, '');
 
-    if (peer) {
-      // Node reports IPv4 peers as IPv4-mapped IPv6 (`::ffff:10.0.0.1`) on a
-      // dual-stack socket; Better Auth wants the plain form.
-      req.headers['x-forwarded-for'] = peer.replace(/^::ffff:/, '');
-    } else {
-      delete req.headers['x-forwarded-for'];
-    }
+  if (ip) {
+    req.headers['x-forwarded-for'] = ip;
+  } else {
+    delete req.headers['x-forwarded-for'];
   }
 
   next();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,38 @@ services:
       # Deliberately has no default. A default committed to a public repo is a
       # published secret, and anyone running it unchanged could forge sessions.
       - 'BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?must be set in .env — generate one with "openssl rand -base64 32"}'
+      # Set only when a reverse proxy terminates TLS in front of this container.
+      # Leave empty when the port is reached directly, or clients can forge
+      # X-Forwarded-For and evade login rate limiting.
+      - TRUST_PROXY=${TRUST_PROXY:-}
     volumes:
       # Persists the SQLite database and uploaded files.
       - wordyme-storage:/app/storage
     restart: unless-stopped
     # Healthcheck comes from the image (see HEALTHCHECK in the Dockerfile), so
     # `docker run` users get the same behaviour as compose users.
+
+    # Without rotation, JSON logs grow until the disk is full. That is a real
+    # failure mode on a Raspberry Pi writing to an SD card.
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '3'
+
+    security_opt:
+      # Stops a process inside the container gaining privileges via setuid
+      # binaries — nothing here needs to.
+      - no-new-privileges:true
+
+    cap_drop:
+      # The app listens on 8080 as a non-root user and only reads and writes
+      # files, so it needs none of the default Linux capabilities.
+      - ALL
+
+    # Caps runaway memory rather than letting it take the host down with it.
+    # Raise this if you import very large documents; the app idles far below it.
+    mem_limit: 1g
 
 volumes:
   wordyme-storage:

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turborepo.com/schema.json",
-  "globalEnv": ["VITE_BACKEND_URL", "DB_FILE_NAME", "WEB_DIR"],
+  "globalEnv": ["VITE_BACKEND_URL", "DB_FILE_NAME", "WEB_DIR", "TRUST_PROXY"],
   "ui": "tui",
   "tasks": {
     "build": {


### PR DESCRIPTION
…ontainer

Makes the image safe to leave running unattended. Node 20 is deliberately left alone; upgrading the runtime is a separate change with its own regression risk.

Graceful shutdown. A process running as PID 1 does not get the kernel's default signal handling, so the container ignored SIGTERM entirely: `docker stop` waited out its 10s timeout and then SIGKILLed a possibly-mid-write SQLite process (measured: 10,000ms, exit 137). tini now runs as PID 1, the CMD `exec`s so the signal reaches Node rather than the shell, and SIGTERM stops accepting connections, disconnects clients and drains the queued database writes before exiting. Measured after: 178ms, exit 0.

Login rate limiting was silently disabled. Better Auth resolves the client address from headers only (X-Forwarded-For by default) and returns null in production when none is present, which skips rate limiting for that request. A container with a published port has no proxy setting that header, so nothing throttled repeated password guesses. A new middleware supplies the real peer address, and the new TRUST_PROXY setting selects the behaviour: unset (default) means the app is reached directly so any client-sent X-Forwarded-For is forged and gets overwritten; set means a proxy is in front and its header is trusted, with Express configured to match.

- Fix SPA fallback prefix matching: bare `/api` returned the app shell instead of a JSON 404, while `/docs` over-matched so a client route such as `/docs-for-beginners` 404ed instead of loading the app. Both now match the exact path or a child of it. (CodeRabbit, PR #61)
- Skip health-check requests in the access log. The probe runs every 30s, which added ~2,900 lines a day that say nothing and buried real traffic. Uses originalUrl, since Express rewrites req.url on entering a mounted router.
- Compose: cap logs at 3x10MB, add no-new-privileges, drop all capabilities, and limit memory to 1GB (the app idles around 55MB).
- Exclude WAL sidecars for .sqlite and .sqlite3, not just .db. (CodeRabbit, #60)
- Rewrite the database restore procedure. The documented steps produced a container that starts, reports healthy and passes /api/health/db while every write fails with SQLITE_READONLY, because `docker compose cp` preserves host file ownership. Streaming the backup in through the container's own user fixes ownership and sidecar removal in one step; chown is not an option now that cap_drop removes CAP_CHOWN. Verified end to end against a real stack.

Verified on a built image with cap_drop=ALL, no-new-privileges and mem=1g: routing regression across 11 paths, socket.io handshake, signup/restart/signin persistence, no hostname in the bundle, zero rate-limit warnings, zero health-check log lines while Docker still records probes and reports healthy.

## Summary

<!-- Briefly describe what this PR does and why it's needed. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close issues when merged. -->

Fixes #

## Type of Change

<!-- Examples: Bug fix, New feature, Breaking change, Refactor, Documentation, Performance improvement -->

## Changes

<!-- List key changes in bullet points. Be specific. -->

-
-

## How to Test

<!-- Provide clear steps for reviewers to verify your changes work as expected. -->

1.
2.
3.

**Expected result:**

## Screenshots

<!-- Required for UI changes. Include before/after screenshots or videos. Remove this section if not a UI change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable proxy trust settings for deployments behind reverse proxies.
  - Added graceful server shutdown to safely complete pending database writes.
  - Improved container reliability with proper process and signal handling.
  - Added rotating JSON logs and container resource/security hardening controls.

- **Bug Fixes**
  - Improved handling of server paths so API, storage, and documentation routes resolve correctly.
  - Prevented misleading client IP information when proxy trust is not configured.

- **Documentation**
  - Expanded deployment guidance for proxy settings, logging, database restoration, security, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->