### PR TITLE
chore: move off end-of-life Node 20 to Node 22

### DIFF
--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ If you have questions about implementation details or need help:
 
 Before you begin, ensure you have the following installed:
 
-- [Node.js](https://nodejs.org/) >= 18
+- [Node.js](https://nodejs.org/) >= 22
 - [pnpm](https://pnpm.io/) 10.33.0
 
 ### Getting Started

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -508,13 +508,13 @@ The `Dockerfile` uses a multi-stage build process optimized for a monorepo:
 
 ### Stage 1: Pruner
 
-- **Base**: `node:20-alpine`
+- **Base**: `node:22-alpine`
 - **Purpose**: Uses Turbo to prune the monorepo, keeping only files needed for `web` and `@repo/backend` packages
 - **Output**: Pruned workspace with only necessary dependencies
 
 ### Stage 2: Builder
 
-- **Base**: `node:20-alpine` with `libc6-compat`
+- **Base**: `node:22-alpine` with `libc6-compat`
 - **Package Manager**: pnpm (via Corepack, version resolved from the `packageManager` field in the root `package.json` — currently 10.33.0)
 - **Process**:
   1. Copies pruned files from pruner stage
@@ -528,7 +528,7 @@ relative URLs and no hostname is inlined into the JavaScript.
 
 ### Stage 3: Runner (all-in-one)
 
-- **Base**: `node:20-alpine` with `libc6-compat`
+- **Base**: `node:22-alpine` with `libc6-compat`
 - **User**: Runs as non-root user (`nodejs`, UID 1001)
 - **Contents**:
   - Production backend dependencies and compiled `dist/`
@@ -647,8 +647,8 @@ CLIENT_URL=https://notes.example.com
 
 These are tracked and not yet addressed:
 
-- **The base image is `node:20-alpine`**, and Node 20 reached end of life on
-  30 April 2026. Upgrading is the next planned change.
+- **Node 22 leaves security support around April 2027.** The base image will need
+  moving to a newer LTS line before then.
 - **Bind mounts do not work out of the box.** Docker creates a bind mount
   (`./data:/app/storage`) owned by root, which the non-root container user
   cannot write to. Use the named volume in `docker-compose.yml`, which does not

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ==========================================
 # STAGE 1: Pruner
 # ==========================================
-FROM node:20-alpine AS pruner
+FROM node:22-alpine AS pruner
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 RUN npm install -g turbo
@@ -11,7 +11,7 @@ RUN turbo prune --scope=web --scope=@repo/backend --docker
 # ==========================================
 # STAGE 2: Base & Builder
 # ==========================================
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
@@ -47,7 +47,7 @@ RUN pnpm --filter @repo/backend --prod deploy --legacy pruned-backend
 # files and the web bundle. SQLite is single-writer, so splitting this into web
 # and backend containers would buy no scaling — only a hardcoded hostname and a
 # backend URL that has to be baked in at build time.
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 # tini becomes PID 1. A process running as PID 1 does not get the kernel's

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -6,7 +6,7 @@ This guide will help you set up and run WordyMe on your local machine.
 
 Before you begin, ensure you have the following installed:
 
-- **Node.js** >= 18 ([Download](https://nodejs.org/))
+- **Node.js** >= 22 ([Download](https://nodejs.org/))
 - **pnpm** 10.33.0 ([Installation Guide](https://pnpm.io/installation))
 
 ### Installing pnpm

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The application will be available at:
 
 ### Prerequisites
 
-- **Node.js** >= 18
+- **Node.js** >= 22
 - **pnpm** 10.33.0 (specified in `packageManager` field)
 
 ### Available Scripts

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
Node 20 reached end of life on 30 April 2026, so the published image was shipping an unsupported runtime that no longer receives security patches.

Updated all 12 references, including the two CI workflows that are easy to miss because they have nothing to do with Docker:

- Dockerfile x3 (pruner, builder, runner stages)
- DOCKER.md x3 stage descriptions
- .github/workflows/release.yml and license-header.yml (node-version)
- package.json engines.node: ">=18" -> ">=22"
- README.md, LOCAL_SETUP.md, CONTRIBUTING.md prerequisites

Node 22 rather than 24 was chosen deliberately: it matches the version used for local development, so contributors see no engines warning. Node 22 leaves security support around April 2027; DOCKER.md's "Known gaps" now records that instead of the Node 20 entry this change resolves.

The image grows 368MB -> 402MB. The app payload is byte-identical (112.7MB node_modules, 20.8MB web bundle), so the entire +34MB is the larger Node 22 binary in the base image. Net against the original 739MB, still a 46% reduction.

Verified with a --no-cache build, running as v22.23.2 with cap_drop=ALL and no-new-privileges: migrations run, the libSQL native bindings load (they use N-API, which is ABI-stable across Node majors), signup and signin succeed, database healthy, rate limiting throttles, routing correct across 10 paths, socket.io handshake works, tini is still PID 1 with node as its child, data survives a restart (269ms), graceful shutdown exits 0, health-check log suppression still holds, and the web app loads in a browser with zero console errors.

Note for later: @types/node is ^25.4.0 while the runtime is Node 22, so TypeScript will accept APIs that do not exist at runtime. Pre-existing, and left alone here.

## Summary

<!-- Briefly describe what this PR does and why it's needed. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close issues when merged. -->

Fixes #

## Type of Change

<!-- Examples: Bug fix, New feature, Breaking change, Refactor, Documentation, Performance improvement -->

## Changes

<!-- List key changes in bullet points. Be specific. -->

-
-

## How to Test

<!-- Provide clear steps for reviewers to verify your changes work as expected. -->

1.
2.
3.

**Expected result:**

## Screenshots

<!-- Required for UI changes. Include before/after screenshots or videos. Remove this section if not a UI change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Node.js version to 22 or newer.
  * Updated automated workflows and Docker images to use Node.js 22.

* **Documentation**
  * Updated setup, contribution, README, and Docker guidance to reflect the Node.js 22 requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->