### PR TITLE
feat(ci): publish multi-arch images to Docker Hub and GHCR on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,16 @@ on:
           - beta
           - rc
 
+env:
+  # Both registries are published in parallel. GHCR is the one documented as the
+  # default pull source: Docker Hub throttles unauthenticated pulls to 100 per
+  # 6 hours *per IP address*, which a school or office behind one NAT shares
+  # between everyone. Names are hardcoded rather than derived from
+  # github.repository_owner because GHCR requires them lowercase and the org is
+  # spelled "TeamCoderz".
+  DOCKERHUB_IMAGE: teamcoderz/wordyme
+  GHCR_IMAGE: ghcr.io/teamcoderz/wordyme
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -33,6 +43,11 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+
+    # Consumed by the publish job so it builds the tag this job just created,
+    # rather than the commit the workflow started from.
+    outputs:
+      version: ${{ steps.standard.outputs.version || steps.prerelease.outputs.version }}
 
     steps:
       - name: Checkout code
@@ -58,6 +73,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Run release (standard version)
+        id: standard
         if: inputs.preid == 'none' || inputs.preid == ''
         run: |
           npm version ${{ inputs.increment }} --no-git-tag-version
@@ -67,10 +83,12 @@ jobs:
           git commit -m "chore: release v$VERSION"
           git tag "v$VERSION"
           git push --follow-tags
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run release (pre-release version)
+        id: prerelease
         if: inputs.preid != 'none' && inputs.preid != ''
         run: |
           npm version ${{ inputs.increment }} --preid=${{ inputs.preid }} --no-git-tag-version
@@ -80,5 +98,163 @@ jobs:
           git commit -m "chore: release v$VERSION"
           git tag "v$VERSION"
           git push --follow-tags
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ==========================================================================
+  # Publish container images
+  # ==========================================================================
+  # This lives inside the release workflow on purpose. The release job pushes
+  # its tag using the default GITHUB_TOKEN, and GitHub deliberately does not
+  # start new workflow runs from events created with that token — so a separate
+  # `on: push: tags: ['v*']` workflow would never fire.
+  publish:
+    name: Publish container images
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push to GHCR using GITHUB_TOKEN
+      security-events: write # upload the Trivy report to the Security tab
+
+    steps:
+      - name: Checkout the released tag
+        uses: actions/checkout@v4
+        with:
+          # Not the workflow's starting SHA: the release job added a version
+          # bump commit, and the image must contain it.
+          ref: v${{ needs.release.outputs.version }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # --- Gate: scan before anything is published -------------------------
+      # Built for one platform and loaded locally so the scan runs against a
+      # real image. The multi-platform build below reuses this layer cache, so
+      # the amd64 half costs almost nothing the second time.
+      - name: Build amd64 image for scanning
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: wordyme:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Fail the release on fixable HIGH or CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: wordyme:scan
+          format: table
+          severity: CRITICAL,HIGH
+          # Only gate on issues that can actually be acted on. A CVE with no
+          # published fix would otherwise block every release indefinitely.
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Full vulnerability report
+        if: always()
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: wordyme:scan
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          exit-code: '0'
+
+      - name: Upload report to the Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: container-image
+
+      # --- Publish ---------------------------------------------------------
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          # A long-lived access token, because Docker Hub's keyless OIDC login
+          # requires a Team/Business subscription or DSOS membership.
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          # No stored secret needed: this token is minted per run and expires
+          # with it.
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags and labels
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.GHCR_IMAGE }}
+          # `latest` is handled by the explicit rule below rather than the
+          # default `latest=auto`, which would also emit it from the semver
+          # tagger and produce the same tag from two rules.
+          flavor: |
+            latest=false
+          # The version comes from the release job rather than the git ref,
+          # because this workflow is triggered manually, not by a tag push.
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.version }}
+            type=sha,format=long
+            # Never point `latest` at a pre-release. metadata-action also
+            # collapses {{major}}.{{minor}} to the full version for
+            # pre-releases, so `1.1` can never resolve to a beta either.
+            type=raw,value=latest,enable=${{ !contains(needs.release.outputs.version, '-') }}
+          labels: |
+            org.opencontainers.image.title=WordyMe
+            org.opencontainers.image.description=Centralized platform for students to manage educational information
+            org.opencontainers.image.vendor=TeamCoderz Ltd
+            org.opencontainers.image.url=https://teamcoderz.org
+            org.opencontainers.image.licenses=AGPL-3.0-or-later
+            org.opencontainers.image.version=${{ needs.release.outputs.version }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          # arm64 is a product promise, not an optimisation — the project
+          # advertises running on a Raspberry Pi.
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          # A signed record of what went into the image and how it was built.
+          sbom: true
+          provenance: mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Show what was published
+        run: |
+          echo "Published the following tags:"
+          echo "${{ steps.meta.outputs.tags }}"
+          docker buildx imagetools inspect "${{ env.GHCR_IMAGE }}:${{ needs.release.outputs.version }}"
+
+      # Runs after the push, so the repository exists on Docker Hub by now —
+      # the first release creates it.
+      - name: Sync the Docker Hub listing
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.DOCKERHUB_IMAGE }}
+          # A literal rather than the repository description, which is optional
+          # on GitHub and would blank the listing if it were ever unset.
+          # Docker Hub caps this at 100 characters.
+          short-description: 'Self-hosted note-taking and document management for students. AGPL-3.0.'
+          readme-filepath: ./DOCKER.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,10 @@ jobs:
           # Not the workflow's starting SHA: the release job added a version
           # bump commit, and the image must contain it.
           ref: v${{ needs.release.outputs.version }}
+          # This job only reads the repository, and it runs several third-party
+          # actions. Leaving the token in .git/config would expose it to all of
+          # them for no benefit.
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -233,17 +237,27 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          # A signed record of what went into the image and how it was built.
+          # Attestations recording what went into the image and how it was
+          # built, attached to the manifest. They are verifiable but NOT
+          # cryptographically signed — that would need a separate cosign or
+          # Sigstore step with an identity token.
           sbom: true
           provenance: mode=max
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Values are passed through the environment rather than interpolated
+      # straight into the script, so nothing from an expression can be parsed
+      # as shell.
       - name: Show what was published
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          IMAGE: ${{ env.GHCR_IMAGE }}
+          VERSION: ${{ needs.release.outputs.version }}
         run: |
           echo "Published the following tags:"
-          echo "${{ steps.meta.outputs.tags }}"
-          docker buildx imagetools inspect "${{ env.GHCR_IMAGE }}:${{ needs.release.outputs.version }}"
+          echo "$TAGS"
+          docker buildx imagetools inspect "${IMAGE}:${VERSION}"
 
       # Runs after the push, so the repository exists on Docker Hub by now —
       # the first release creates it.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -14,43 +14,80 @@ docker --version
 docker compose version
 ```
 
-## Quick Start
+## Quick Start (self-hosting)
 
-1. **Clone the repository** (if you haven't already):
+You do not need to clone the repository. Published images cover both
+`linux/amd64` and `linux/arm64`, so this works on a normal server and on a
+Raspberry Pi 4 or 5.
 
-   ```bash
-   git clone <repository-url>
-   cd WordyMe
-   ```
-
-2. **Set up environment variables** (required):
-   Copy the example environment file:
+1. **Fetch the compose file**:
 
    ```bash
-   cp .env.example .env
+   curl -O https://raw.githubusercontent.com/TeamCoderz/WordyMe/main/docker-compose.public.yml
    ```
 
-   Then set `BETTER_AUTH_SECRET`. It has no default and startup fails without it:
+2. **Set a signing secret** (required — startup fails without it):
 
    ```bash
-   echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" >> .env
+   echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" > .env
    ```
 
-   > **Note**:
-   >
-   > - The `.env` file is excluded from Docker builds (via `.dockerignore`) for security, but Docker Compose will still read it for variable substitution in `docker-compose.yml`
-   > - The `.env.example` file serves as a template with all available environment variables documented
-
-3. **Build and start the containers**:
+3. **Start it**:
 
    ```bash
-   docker compose up -d
+   docker compose -f docker-compose.public.yml up -d
    ```
 
-4. **Access the application**: http://localhost:8080
+4. **Open** http://localhost:8080 and create the first account.
 
    The web app and the API are served from the same origin and the same port.
    There is no separate frontend URL.
+
+### Where to pull from
+
+The same image is published to two registries on every release:
+
+| Registry   | Image                        | Notes                             |
+| ---------- | ---------------------------- | --------------------------------- |
+| GHCR       | `ghcr.io/teamcoderz/wordyme` | **Default.** No pull rate limits. |
+| Docker Hub | `teamcoderz/wordyme`         | Easier to find; rate limited.     |
+
+GHCR is the default in `docker-compose.public.yml` because Docker Hub limits
+unauthenticated pulls to 100 per 6 hours **per IP address** — a budget shared by
+everyone behind the same office or campus NAT. Both registries carry identical
+images; switch by changing one line.
+
+### Which tag to use
+
+| Tag            | Moves?               | Use when                                 |
+| -------------- | -------------------- | ---------------------------------------- |
+| `latest`       | Every stable release | You want updates when you re-pull        |
+| `1.2.3`        | Never                | You want to upgrade deliberately         |
+| `1.2`          | Within a minor line  | You want patches but not feature changes |
+| `sha-<commit>` | Never                | You need to pin an exact build           |
+
+Pre-releases (`1.3.0-beta.1`) are published but never tagged `latest`.
+
+## Running from source instead
+
+Contributors building locally use the other compose file, which builds the image
+rather than pulling it:
+
+```bash
+cp .env.example .env
+```
+
+```bash
+echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" >> .env
+```
+
+```bash
+docker compose up -d --build
+```
+
+> **Note**: `.env` is excluded from Docker builds via `.dockerignore`, so no
+> secret is baked into the image. Compose still reads it for variable
+> substitution.
 
 ## Architecture: one image, one process
 
@@ -662,6 +699,102 @@ accepting connections, disconnects clients, and waits for queued database writes
 to finish before exiting — SQLite is single-writer, so being killed mid-write is
 the failure worth avoiding. If shutdown ever takes longer than 8 seconds, the
 process exits anyway rather than waiting to be killed.
+
+## How images are published
+
+Images are built and pushed by the **Manual Release** workflow
+(`.github/workflows/release.yml`). Running that workflow bumps the version,
+writes the changelog, tags the commit, creates the GitHub release, and then
+builds and publishes the image — in that order, from the tag it just created.
+
+The image build lives inside the release workflow rather than in a separate
+`on: push: tags` workflow, and that is deliberate. The release job pushes its
+tag using the default `GITHUB_TOKEN`, and GitHub does not start new workflow
+runs from events created with that token — a tag-triggered workflow would never
+fire.
+
+What each release produces:
+
+- **Two architectures**, `linux/amd64` and `linux/arm64`, in one manifest, so
+  `docker pull` selects the right one automatically.
+- **Both registries**, GHCR and Docker Hub, from a single build.
+- **OCI labels**, including `org.opencontainers.image.source` pointing at this
+  repository. That also serves the AGPL's source-availability requirement: the
+  image itself carries a link to the code it was built from.
+- **An SBOM and provenance attestation**, a signed record of what went into the
+  image and how it was built.
+- **A vulnerability scan that gates the push.** The workflow builds and scans
+  before publishing anything, and fails if Trivy reports a HIGH or CRITICAL
+  issue _that has a fix available_. Unfixable CVEs are reported but do not block
+  a release, since there would be nothing to do about them. The full report,
+  including MEDIUM and LOW, is uploaded to the repository's Security tab.
+
+### One-time setup
+
+Two repository secrets are required, under **Settings → Secrets and variables →
+Actions**:
+
+| Secret               | Value                                                |
+| -------------------- | ---------------------------------------------------- |
+| `DOCKERHUB_USERNAME` | `teamcoderz`                                         |
+| `DOCKERHUB_TOKEN`    | A Docker Hub access token with **Read, Write** scope |
+
+Create the token at **Docker Hub → Account settings → Personal access tokens**.
+Do not use your account password: with 2FA enabled it will not work anyway, and
+a scoped token can be revoked on its own.
+
+GHCR needs no secret. It authenticates with the `GITHUB_TOKEN` that GitHub mints
+for each run and expires when the run ends.
+
+> Docker Hub also supports keyless OIDC login, which avoids storing a token at
+> all, but it requires a Docker Team or Business subscription or membership of
+> the Docker-Sponsored Open Source programme. On a free account, a token is the
+> only option — so treat it as a credential: rotate it periodically, and revoke
+> it immediately if the repository's secrets are ever exposed.
+
+### Publishing by hand
+
+If Actions is unavailable, the same result can be produced locally. You need
+Docker with `buildx`, and you must be logged in to whichever registry you are
+pushing to.
+
+```bash
+docker login                    # Docker Hub — use an access token, not a password
+```
+
+```bash
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u <your-github-username> --password-stdin
+```
+
+Build and push both architectures in one command. On a machine of a single
+architecture the other is emulated through QEMU, which is slower but produces a
+correct image:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 --sbom=true --provenance=mode=max --tag ghcr.io/teamcoderz/wordyme:1.2.3 --tag ghcr.io/teamcoderz/wordyme:latest --tag teamcoderz/wordyme:1.2.3 --tag teamcoderz/wordyme:latest --push .
+```
+
+Then confirm both architectures are present:
+
+```bash
+docker buildx imagetools inspect ghcr.io/teamcoderz/wordyme:1.2.3
+```
+
+You should see two manifests, one `linux/amd64` and one `linux/arm64`. If only
+one appears, the build fell back to a single platform and the tag should not be
+released.
+
+### Inspecting a published image
+
+Anyone can check what they are about to run:
+
+```bash
+docker buildx imagetools inspect ghcr.io/teamcoderz/wordyme:latest --format '{{ json .Provenance }}'
+```
+
+```bash
+docker buildx imagetools inspect ghcr.io/teamcoderz/wordyme:latest --format '{{ json .SBOM }}'
+```
 
 ## Support
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -29,8 +29,13 @@ Raspberry Pi 4 or 5.
 2. **Set a signing secret** (required — startup fails without it):
 
    ```bash
-   echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" > .env
+   [ -e .env ] || ( umask 077; echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" > .env )
    ```
+
+   The `umask` keeps `.env` readable only by you — it holds the key that signs
+   every session cookie, and a default umask would leave it world-readable. The
+   guard means re-running this will not overwrite a `.env` you have already
+   customised, or rotate the secret and log everyone out.
 
 3. **Start it**:
 
@@ -721,8 +726,10 @@ What each release produces:
 - **OCI labels**, including `org.opencontainers.image.source` pointing at this
   repository. That also serves the AGPL's source-availability requirement: the
   image itself carries a link to the code it was built from.
-- **An SBOM and provenance attestation**, a signed record of what went into the
-  image and how it was built.
+- **An SBOM and provenance attestation**, attached to the image manifest,
+  recording what went into it and how it was built. These are verifiable but
+  **not cryptographically signed** — signing would require a separate cosign or
+  Sigstore step, which this pipeline does not yet do.
 - **A vulnerability scan that gates the push.** The workflow builds and scans
   before publishing anything, and fails if Trivy reports a HIGH or CRITICAL
   issue _that has a fix available_. Unfixable CVEs are reported but do not block

--- a/docker-compose.public.yml
+++ b/docker-compose.public.yml
@@ -1,0 +1,79 @@
+# WordyMe — self-hosting stack.
+#
+# This file pulls a published image instead of building from source, so you do
+# not need to clone the repository:
+#
+#   curl -O https://raw.githubusercontent.com/TeamCoderz/WordyMe/main/docker-compose.public.yml
+#   echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" > .env
+#   docker compose -f docker-compose.public.yml up -d
+#
+# Then open http://localhost:8080
+#
+# (The docker-compose.yml next to this one builds from source instead, which is
+# what contributors want.)
+
+services:
+  wordyme:
+    # GHCR is the default because it does not rate-limit pulls of public images.
+    # Docker Hub allows 100 unauthenticated pulls per 6 hours *per IP address* —
+    # a limit shared by everyone behind the same office or campus NAT. The same
+    # image is published to both, so swap this line if you prefer Docker Hub:
+    #   image: teamcoderz/wordyme:latest
+    image: ghcr.io/teamcoderz/wordyme:latest
+
+    # Pin to a version instead of :latest if you would rather upgrade
+    # deliberately, e.g. ghcr.io/teamcoderz/wordyme:1.0.0
+
+    # No container_name: leaving it unset lets two stacks run side by side.
+    ports:
+      - '${HOST_PORT:-8080}:8080'
+
+    environment:
+      - NODE_ENV=production
+      - PORT=8080
+      - DB_FILE_NAME=file:/app/storage/local.db
+      # Every origin you reach the app on, comma separated. Must match the
+      # address in your browser, or logging in will fail.
+      - CLIENT_URL=${CLIENT_URL:-http://localhost:8080}
+      - BETTER_AUTH_URL=${BETTER_AUTH_URL:-}
+      # Deliberately has no default. A shipped default would be a published
+      # secret, and anyone running it unchanged could forge sessions.
+      - 'BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?must be set in .env — generate one with "openssl rand -base64 32"}'
+      # Set only when a reverse proxy terminates TLS in front of this container.
+      # Leave empty when the port is reached directly, or clients can forge
+      # X-Forwarded-For and evade login rate limiting.
+      - TRUST_PROXY=${TRUST_PROXY:-}
+
+    volumes:
+      # Your database and uploaded files. Back this up.
+      - wordyme-storage:/app/storage
+
+    restart: unless-stopped
+    # The health check ships inside the image, so `docker ps` reports health
+    # whether you use compose or plain `docker run`.
+
+    # Without rotation, JSON logs grow until the disk is full. That is a real
+    # failure mode on a Raspberry Pi writing to an SD card.
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '3'
+
+    security_opt:
+      # Stops a process inside the container gaining privileges via setuid
+      # binaries — nothing here needs to.
+      - no-new-privileges:true
+
+    cap_drop:
+      # The app listens on 8080 as a non-root user and only reads and writes
+      # files, so it needs none of the default Linux capabilities.
+      - ALL
+
+    # Caps runaway memory rather than letting it take the host down with it.
+    # The app idles around 100MB; raise this if you import very large documents.
+    mem_limit: 1g
+
+volumes:
+  wordyme-storage:
+    driver: local

--- a/docker-compose.public.yml
+++ b/docker-compose.public.yml
@@ -4,8 +4,12 @@
 # not need to clone the repository:
 #
 #   curl -O https://raw.githubusercontent.com/TeamCoderz/WordyMe/main/docker-compose.public.yml
-#   echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" > .env
+#   [ -e .env ] || ( umask 077; echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" > .env )
 #   docker compose -f docker-compose.public.yml up -d
+#
+# The umask keeps .env readable only by you — it holds the key that signs every
+# session cookie. The guard means re-running the command will not overwrite a
+# .env you have already customised, or rotate the secret and log everyone out.
 #
 # Then open http://localhost:8080
 #
@@ -33,8 +37,10 @@ services:
       - PORT=8080
       - DB_FILE_NAME=file:/app/storage/local.db
       # Every origin you reach the app on, comma separated. Must match the
-      # address in your browser, or logging in will fail.
-      - CLIENT_URL=${CLIENT_URL:-http://localhost:8080}
+      # address in your browser, or logging in will fail. The default follows
+      # HOST_PORT, so changing the published port alone cannot leave this
+      # pointing at the wrong address.
+      - CLIENT_URL=${CLIENT_URL:-http://localhost:${HOST_PORT:-8080}}
       - BETTER_AUTH_URL=${BETTER_AUTH_URL:-}
       # Deliberately has no default. A shipped default would be a published
       # secret, and anyone running it unchanged could forge sessions.


### PR DESCRIPTION
Running the Manual Release workflow now builds and publishes the container image as well as cutting the release. No separate step, and nothing to run by hand.

The build lives inside release.yml rather than in its own `on: push: tags` workflow, deliberately: the release job pushes its tag using the default GITHUB_TOKEN, and GitHub does not start new workflow runs from events created with that token, so a tag-triggered workflow would never fire. The publish job checks out `v$VERSION` rather than the workflow's starting SHA, because the release job adds a version-bump commit that must be in the image.

Each release produces:

- linux/amd64 and linux/arm64 in one manifest. arm64 is a product promise — the project advertises running on a Raspberry Pi — not an optimisation.
- Both registries from a single build. GHCR is documented as the default pull source because Docker Hub throttles unauthenticated pulls to 100 per 6 hours *per IP address*, a budget shared by everyone behind one school or office NAT.
- OCI labels including org.opencontainers.image.source, which also satisfies the AGPL's source-availability requirement: the image carries a link to the code it was built from.
- An SBOM and a max-mode provenance attestation.
- A vulnerability scan that gates the push. The image is built and scanned before anything is published, and the release fails on HIGH or CRITICAL findings that have a fix available. Unfixable CVEs are reported but do not block, since there would be nothing to do about them. The full report is uploaded to the Security tab.

Emulated builds are used rather than a native-runner matrix. A matrix would be faster, but publishing to two registries that way needs a push-by-digest and manifest-merge dance that cannot be tested outside a real Actions run. A fully emulated amd64 build of this image measured 4.6 minutes locally — dominated by package downloads, not CPU — so the simpler design costs a few minutes on a manual release and removes the part most likely to be subtly wrong.

Also adds docker-compose.public.yml, which pulls the published image instead of building, so self-hosters never need to clone the repository. DOCKER.md now opens with that path, documents the tag strategy, and includes a manual buildx fallback for when Actions is unavailable.

Verified with actionlint (which does catch bad runner labels and undefined `needs` references — confirmed against a deliberately broken workflow), prettier, and `docker compose config` on both compose files including the BETTER_AUTH_SECRET guard. Every action version was checked against its repository: build-push-action, metadata-action, login-action, setup-buildx, setup-qemu and codeql-action had all moved a major version beyond what I first wrote. metadata-action's source confirmed that `latest=auto` would emit the latest tag from the semver tagger as well as the explicit rule, so flavor is pinned to latest=false and the one explicit rule owns it.

Requires two repository secrets before the next release: DOCKERHUB_USERNAME and DOCKERHUB_TOKEN. GHCR needs none — it uses the per-run GITHUB_TOKEN.

## Summary

<!-- Briefly describe what this PR does and why it's needed. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close issues when merged. -->

Fixes #

## Type of Change

<!-- Examples: Bug fix, New feature, Breaking change, Refactor, Documentation, Performance improvement -->

## Changes

<!-- List key changes in bullet points. Be specific. -->

-
-

## How to Test

<!-- Provide clear steps for reviewers to verify your changes work as expected. -->

1.
2.
3.

**Expected result:**

## Screenshots

<!-- Required for UI changes. Include before/after screenshots or videos. Remove this section if not a UI change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ready-to-use Compose configuration for running published multi-architecture container images.
  * Added persistent storage, configurable ports, automatic restarts, log rotation, resource limits, and container security settings.
  * Release automation now publishes signed images to Docker Hub and GHCR with version-aware tags.

* **Documentation**
  * Expanded Docker guidance for self-hosting, source-based development, releases, security scanning, and image verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->