### PR TITLE
 fix: correct five bugs introduced by the all-in-one Docker image

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -545,10 +545,14 @@ Request handling inside the single process:
 | Path            | Handled by                                                             |
 | --------------- | ---------------------------------------------------------------------- |
 | `/api/*`        | Express API routers                                                    |
+| `/api/docs`     | Scalar API reference                                                   |
 | `/storage/*`    | Express file routes (uploads, avatars, attachments)                    |
 | `/socket.io/`   | Socket.io, attached to the same HTTP server                            |
-| `/docs`         | Scalar API reference                                                   |
 | everything else | Static web bundle, falling back to `index.html` for client-side routes |
+
+Server routes live under `/api` and `/storage` only. Every other path belongs to
+the web app — `/docs` and `/spaces`, for instance, are its own screens — so the
+API reference is served at `/api/docs` rather than at the top level.
 
 Caching is set per file type: fingerprinted assets under `/assets/` are
 immutable for a year, while `index.html` and the service worker are never

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -52,6 +52,67 @@ docker compose version
    The web app and the API are served from the same origin and the same port.
    There is no separate frontend URL.
 
+## Upgrading from a version before the all-in-one image
+
+Earlier releases ran two containers — Nginx on port 5173 serving the web app,
+and the API on port 3000. That is now a single container on port 8080. Fresh
+installs need none of this; skip to the next section.
+
+Your `.env` is not part of the image and survives the upgrade untouched, so it
+still names the old ports. Two values have to change before the app will work.
+
+1. **Point `CLIENT_URL` at the address you actually open in the browser.**
+
+   ```diff
+   - CLIENT_URL=http://localhost:5173
+   + CLIENT_URL=http://localhost:8080
+   ```
+
+   This is the one that bites. Better Auth rejects any request whose `Origin`
+   is not listed in `CLIENT_URL`, so leaving it on `5173` makes every sign-in
+   fail with `403 Invalid origin` — while the container reports healthy and
+   every page loads normally. It reads like a wrong password, not a
+   misconfiguration. The server now prints its trusted origins at startup and
+   warns when they cannot match the port it is listening on.
+
+2. **Remove `BETTER_AUTH_URL` if it points at the old API port.** It defaults
+   to the first `CLIENT_URL`, which is what you want:
+
+   ```diff
+   - BETTER_AUTH_URL=http://localhost:3000
+   ```
+
+   Keep it only when the canonical public URL is not first in `CLIENT_URL`.
+
+3. **Leave `BETTER_AUTH_SECRET` alone.** It signs session cookies; changing it
+   signs out every user.
+
+Then rebuild, and remove the containers from the old layout in the same step:
+
+```bash
+docker compose up -d --build --remove-orphans
+```
+
+`--build` matters: `docker compose up` reuses an existing image and will
+silently keep running the old code. `--remove-orphans` matters just as much —
+without it the previous `wordyme-backend` and `wordyme-web` containers keep
+running, and the old backend holds the _same_ SQLite file open as the new one.
+SQLite allows a single writer, so two containers sharing it risks lock errors
+and corruption.
+
+Your data is safe throughout: documents, uploads and accounts live in the
+`wordyme-storage` volume, which neither rebuilding nor removing containers
+touches. To be certain, take a backup first — see
+[Data Persistence](#data-persistence).
+
+If you published the app on a different host port, use that everywhere instead
+of `8080`:
+
+```bash
+HOST_PORT=9000
+CLIENT_URL=http://localhost:9000
+```
+
 ## Architecture: one image, one process
 
 WordyMe ships as a **single all-in-one image**. Express serves the API, the

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ pnpm drizzle-kit migrate
 
 ## API Documentation
 
-The backend API includes OpenAPI documentation. When running the backend, visit `/api-docs` for interactive API documentation.
+The backend API includes OpenAPI documentation. When running the backend, visit `/api/docs` for the interactive API reference, or `/api/docs/openapi.json` for the raw OpenAPI schema.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ WordyMe/
 WordyMe™ can be run using Docker and Docker Compose for easy deployment. See [DOCKER.md](DOCKER.md) for complete Docker documentation, including:
 
 - Quick start guide
+- Upgrading from an earlier version
 - Common commands
 - Data persistence and backups
 - Troubleshooting
@@ -155,13 +156,20 @@ WordyMe™ can be run using Docker and Docker Compose for easy deployment. See [
 **Quick Start:**
 
 ```bash
+cp .env.example .env
+echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" >> .env
 docker compose up -d
 ```
 
-The application will be available at:
+`BETTER_AUTH_SECRET` has no default and Compose refuses to start without it, so
+the first two steps are required rather than optional.
 
-- Web: http://localhost:5173
-- API: http://localhost:3000
+The application will be available at **http://localhost:8080** — one container
+serves the web app and the API from the same origin, so there is no separate
+frontend URL. The API reference is at http://localhost:8080/api/docs.
+
+Already running an older version? Ports and origins changed; see
+[Upgrading](DOCKER.md#upgrading-from-a-version-before-the-all-in-one-image).
 
 ## Development Workflow
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -44,15 +44,16 @@ app.use(
 
 app.use(clientIp);
 
-app.use('/api/auth', express.text({ type: '*/*', limit: '100kb' }));
-
-app.all('/api/auth/{*any}', toNodeHandler(auth));
-
 app.use(
   morgan<Request, Response>('dev', {
     skip: (req) => req.originalUrl.split('?')[0] === '/api/health',
   }),
 );
+
+app.use('/api/auth', express.text({ type: '*/*', limit: '100kb' }));
+
+app.all('/api/auth/{*any}', toNodeHandler(auth));
+
 app.use(express.json({ limit: '5mb' }));
 
 app.use('/api/documents', documentsRouter);

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -33,7 +33,6 @@ const server = createServer(app);
 
 initializeSocket(server);
 
-// Only takes effect when TRUST_PROXY is set; see apps/backend/src/env.ts.
 app.set('trust proxy', env.TRUST_PROXY);
 
 app.use(
@@ -43,18 +42,12 @@ app.use(
   }),
 );
 
-// Must run before the auth handler, which is what consumes the client IP.
 app.use(clientIp);
 
 app.all('/api/auth/{*any}', toNodeHandler(auth));
 
 app.use(
   morgan<Request, Response>('dev', {
-    // The container health check polls this every 30s. Logging it buries real
-    // traffic and, on a device logging to an SD card, adds ~2,900 lines a day
-    // that say nothing. Use originalUrl: Express rewrites req.url when a
-    // request enters a mounted router, so by the time morgan evaluates this the
-    // path would read as '/' rather than '/api/health'.
     skip: (req) => req.originalUrl.split('?')[0] === '/api/health',
   }),
 );
@@ -69,24 +62,21 @@ app.use('/api/auth-state', authStateRouter);
 
 app.use('/storage', storageRouter);
 
-app.get('/docs/openapi.json', (req, res) => {
+app.get('/api/docs/openapi.json', (req, res) => {
   res.json(openApiDocument);
 });
 
 app.get(
-  '/docs',
+  '/api/docs',
   apiReference({
     sources: [
-      { title: 'WordyMe API', url: '/docs/openapi.json' },
+      { title: 'WordyMe API', url: '/api/docs/openapi.json' },
       { title: 'Better-Auth API', url: '/api/auth/open-api/generate-schema' },
     ],
     pageTitle: 'Wordy API Documentation',
   }),
 );
 
-// Serve the built web bundle from the same origin as the API. Mounted after
-// every server route so it can never shadow one. When no bundle is present
-// (`pnpm dev`), Vite serves the web app separately and this is skipped.
 if (hasWebBundle()) {
   app.use(webStatic);
   app.get('/{*any}', webFallback);

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -44,6 +44,8 @@ app.use(
 
 app.use(clientIp);
 
+app.use('/api/auth', express.text({ type: '*/*', limit: '100kb' }));
+
 app.all('/api/auth/{*any}', toNodeHandler(auth));
 
 app.use(

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -5,7 +5,9 @@
 
 import server from './app.js';
 import { env } from './env.js';
+import { clientUrlWarning } from './lib/client-url.js';
 import { getSocket } from './lib/socket.js';
+import { hasWebBundle } from './lib/web.js';
 import { dbWritesQueue } from './queues/db-writes.js';
 
 /**
@@ -17,6 +19,16 @@ const SHUTDOWN_TIMEOUT_MS = 8_000;
 
 server.listen(env.PORT, () => {
   console.log(`Server is running on http://localhost:${env.PORT}`);
+  console.log(`Trusted origins (CLIENT_URL): ${env.CLIENT_URL.join(', ')}`);
+
+  const warning = clientUrlWarning({
+    clientUrls: env.CLIENT_URL,
+    port: env.PORT,
+    servesWebBundle: hasWebBundle(),
+    behindProxy: env.TRUST_PROXY !== false,
+  });
+
+  if (warning) console.warn(warning);
 });
 
 let shuttingDown = false;

--- a/apps/backend/src/lib/client-url.ts
+++ b/apps/backend/src/lib/client-url.ts
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const originPort = (origin: string): number | null => {
+  try {
+    const { port, protocol } = new URL(origin);
+
+    if (port) return Number(port);
+    if (protocol === 'https:') return 443;
+    if (protocol === 'http:') return 80;
+
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+export const clientUrlWarning = ({
+  clientUrls,
+  port,
+  servesWebBundle,
+  behindProxy,
+}: {
+  clientUrls: string[];
+  port: number;
+  servesWebBundle: boolean;
+  behindProxy: boolean;
+}): string | null => {
+  if (!servesWebBundle || behindProxy) return null;
+  if (clientUrls.some((origin) => originPort(origin) === port)) return null;
+
+  return [
+    '',
+    '  ⚠  CLIENT_URL does not name the port this server listens on.',
+    '',
+    `     listening on   http://localhost:${port}`,
+    `     CLIENT_URL     ${clientUrls.join(', ')}`,
+    '',
+    '     If users reach this server at the address above, sign-in will fail with',
+    '     "403 Invalid origin": Better Auth trusts only the origins in CLIENT_URL.',
+    '     Pages and health checks keep working regardless, so the symptom reads as',
+    '     a rejected password rather than a configuration problem.',
+    '',
+    '     Fix: set CLIENT_URL to the URL you open in the browser, then restart.',
+    '',
+    '     Expected, and safe to ignore, when the container is published on a',
+    '     different host port — CLIENT_URL should name the address users type,',
+    '     which this process cannot see. Behind a reverse proxy, set TRUST_PROXY;',
+    '     that silences this check.',
+    '',
+  ].join('\n');
+};

--- a/apps/backend/src/lib/web.ts
+++ b/apps/backend/src/lib/web.ts
@@ -36,10 +36,16 @@ const NEVER_CACHE = new Set(['index.html', 'sw.js', 'registerSW.js', 'manifest.w
 /**
  * Paths owned by the server. They must keep their own responses instead of the
  * app shell. Matched as the exact path or a child of it, so that bare `/api`
- * is still server-owned while a client route like `/docs-for-beginners` is not
- * swallowed by a `startsWith('/docs')` test.
+ * is still server-owned while a client route like `/api-guide` is not swallowed
+ * by a `startsWith('/api')` test.
+ *
+ * Every server route must live under one of these prefixes. The web app owns
+ * the rest of the URL space — including `/docs`, which is why the API reference
+ * is mounted at `/api/docs` rather than at the top level. Adding a top-level
+ * prefix here silently takes that path away from the SPA: its deep links stop
+ * returning the app shell and answer with a JSON 404 instead.
  */
-const SERVER_PREFIXES = ['/api', '/storage', '/docs'];
+const SERVER_PREFIXES = ['/api', '/storage'];
 
 const isServerPath = (pathname: string): boolean =>
   SERVER_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));


### PR DESCRIPTION


## 🔴 Critical

### 1. The Documents screens are gone — `/docs` serves the API reference

Opening **http://localhost:8080/docs** shows the Scalar API reference instead of
the app. The other three Documents screens are worse — they return a raw JSON 404:

| URL                   | Serves                    |
| --------------------- | ------------------------- |
| `/docs`               | Scalar API reference      |
| `/docs/manage`        | `{"name":"HttpNotFound"}` |
| `/docs/favorites`     | `{"name":"HttpNotFound"}` |
| `/docs/recent-viewed` | `{"name":"HttpNotFound"}` |

The SPA owns all four paths, and they are linked from the main sidebar and the
home page. Once Express began serving the bundle from the same origin, the
server's own top-level `/docs` route sat in front of them, and `/docs` was also
listed as a server-owned prefix so the SPA fallback refused to serve the shell.

In-app navigation still worked, which is what hid this: the break only appears on
a full page load — a reload, a bookmark, a shared link, or a middle-click into a
new tab. The sidebar links carry `data-new-tab="true"`, so opening Documents in a
new tab hits it directly.

Fixed by moving the API reference to `/api/docs` and returning `/docs` to the app.

### 2. Any anonymous POST could kill the server

Better Auth's Node adapter calls better-call's `getRequest()` without a
`bodySizeLimit`, which disables the size check and buffers the entire body in
memory before any validation. `express.json` is mounted _after_ that handler, so
it never saw these requests — sign-in had no cap at all.

Verified: a 200 MB POST to `/api/auth/sign-in/email` OOM-killed a 300 MB
container (`OOMKilled: true`, exit 137). With `restart: unless-stopped` an
attacker can loop it, and the SIGKILL also bypasses the graceful-shutdown
protection this release added.

Fixed with `express.text({ type: '*/*', limit: '100kb' })` in front of the auth
handler. `text` with a wildcard type rather than `json` on purpose: better-call
passes a pre-parsed string `req.body` through untouched, so every content type is
capped. `json` would cap only `application/json` and leave the rest on the
unlimited path — one header away from a bypass.

## 🟠 High — every existing install breaks on upgrade

`CLIENT_URL` lives in the operator's `.env`, which survives upgrades, so it still
named the old port `5173` while the app moved to `8080`. Better Auth rejects any
`Origin` absent from `CLIENT_URL`, so every sign-in failed with
`403 Invalid origin` — while the container reported _healthy_ and all pages
rendered. The symptom reads as a wrong password, not a config error.

Fixed by logging trusted origins at startup, warning on a mismatch, and adding an
upgrade section to `DOCKER.md`. The check only runs when this process serves the
web bundle, so `pnpm dev` and reverse-proxy deployments are exempt.

## 🟡 Also fixed

- **No `/api/auth` request was ever logged.** `toNodeHandler` is terminal and
  never calls `next()`, so failed sign-ins, forged origins and rate-limit 429s left
  zero log lines. Morgan now mounts above the auth handler.
- **The README quick start failed.** It documented the deleted two-container
  layout and a bare `docker compose up -d`, which now exits 1 because
  `BETTER_AUTH_SECRET` is mandatory. Both URLs it listed were dead.

## Verification

Every fix was tested against a running server, before and after.

| Check                                                             | Before            | After                   |
| ----------------------------------------------------------------- | ----------------- | ----------------------- |
| `/docs`, `/docs/manage`, `/docs/favorites`, `/docs/recent-viewed` | Scalar / JSON 404 | app shell               |
| `/api/docs`, `/api/docs/openapi.json`                             | 404               | API reference, schema   |
| 200 MB POST to `/api/auth/*` (4 content types + chunked)          | OOM-killed        | 413, container at 65 MB |
| Full auth flow: signup → session → signout → sign-in              | —                 | all pass                |
| `/api/auth` requests logged                                       | 0 of 6            | 6 of 6                  |
| `CLIENT_URL` mismatch at startup                                  | silent            | warns                   |
| README quick start in a clean checkout                            | exits 1           | exits 0                 |

`tsc`, `eslint` and `prettier` pass. No behaviour change for `pnpm dev`: the
frontend stays on `:5173`, the API on `:3000`.

## Upgrading

`.env` needs two edits — set `CLIENT_URL=http://localhost:8080` and remove
`BETTER_AUTH_URL` if it points at `:3000` — then:

```bash
docker compose up -d --build --remove-orphans
```

`--remove-orphans` matters:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added upgrade guidance for migrating to the all-in-one Docker deployment.
  * Added startup warnings for potentially incorrect client URL or proxy configuration.
  * Added clearer documentation for environment setup, data persistence, custom ports, and API endpoints.

* **Improvements**
  * Moved API documentation to `/api/docs`, with the OpenAPI schema at `/api/docs/openapi.json`.
  * Improved request handling and logging for authentication requests.
  * Clarified routing between web application and server-owned paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->