### PR TITLE
chore(ci): add a dry run for the publishing setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+updates:
+  # Workflow actions are pinned to commit SHAs so a compromised upstream tag
+  # cannot silently run new code with this repository's registry credentials.
+  # A pin only stays safe if something keeps it current, which is this: without
+  # it, pinning trades a mutable-tag risk for a stale-action one.
+  #
+  # The `# v4` comment beside each SHA is what Dependabot reads to know which
+  # release a pin corresponds to, and it rewrites both together.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'chore(ci)'
+    groups:
+      # One PR for the whole Docker toolchain rather than five.
+      docker-actions:
+        patterns:
+          - 'docker/*'

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -9,18 +9,26 @@ on:
 jobs:
   license-check:
     runs-on: ubuntu-latest
+    # This job only reads the repository. Without an explicit block it would
+    # inherit the default token scopes, which are far wider than it needs.
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          # Nothing here pushes, so there is no reason to leave the token in
+          # .git/config for later steps to reach.
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,18 +51,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Checkout the released tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # Not the workflow's starting SHA: the release job added a version
           # bump commit, and the image must contain it.
@@ -131,17 +131,17 @@ jobs:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       # --- Gate: scan before anything is published -------------------------
       # Built for one platform and loaded locally so the scan runs against a
       # real image. The multi-platform build below reuses this layer cache, so
       # the amd64 half costs almost nothing the second time.
       - name: Build amd64 image for scanning
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64
@@ -151,7 +151,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Fail the release on fixable HIGH or CRITICAL vulnerabilities
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: wordyme:scan
           format: table
@@ -163,7 +163,7 @@ jobs:
 
       - name: Full vulnerability report
         if: always()
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: wordyme:scan
           format: sarif
@@ -173,14 +173,14 @@ jobs:
 
       - name: Upload report to the Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           sarif_file: trivy-results.sarif
           category: container-image
 
       # --- Publish ---------------------------------------------------------
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           # A long-lived access token, because Docker Hub's keyless OIDC login
@@ -188,7 +188,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -198,7 +198,7 @@ jobs:
 
       - name: Compute tags and labels
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: |
             ${{ env.DOCKERHUB_IMAGE }}
@@ -227,7 +227,7 @@ jobs:
             org.opencontainers.image.version=${{ needs.release.outputs.version }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           # arm64 is a product promise, not an optimisation — the project
@@ -262,7 +262,7 @@ jobs:
       # Runs after the push, so the repository exists on Docker Hub by now —
       # the first release creates it.
       - name: Sync the Docker Hub listing
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/verify-publishing.yml
+++ b/.github/workflows/verify-publishing.yml
@@ -1,0 +1,188 @@
+# Rehearses the publishing pipeline without cutting a release.
+#
+# Run this from the Actions tab before the first real release, and again after
+# rotating the Docker Hub token. It exercises every step the release workflow
+# does — secrets, both registry logins, the CI build, the vulnerability gate,
+# and a real push to both registries — but writes only a disposable `ci-verify`
+# tag. No version bump, no git tag, no GitHub release, and `latest` is never
+# touched.
+#
+# The push is the point. `docker login` succeeds with a read-only token and
+# only fails later at push time, so a successful login proves nothing about
+# write access.
+
+name: Verify publishing setup
+
+on:
+  workflow_dispatch:
+
+env:
+  DOCKERHUB_IMAGE: teamcoderz/wordyme
+  GHCR_IMAGE: ghcr.io/teamcoderz/wordyme
+  # Deliberately not a version number, so it cannot be mistaken for a release
+  # and stands out in the registry listing.
+  VERIFY_TAG: ci-verify
+
+jobs:
+  verify:
+    name: Verify publishing setup
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # Fail in seconds rather than after a five minute build.
+      - name: Check the required secrets exist
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          missing=0
+          if [ -z "$DOCKERHUB_USERNAME" ]; then
+            echo "::error::DOCKERHUB_USERNAME is not set. Add it under Settings -> Secrets and variables -> Actions."
+            missing=1
+          fi
+          if [ -z "$DOCKERHUB_TOKEN" ]; then
+            echo "::error::DOCKERHUB_TOKEN is not set. Create a Read/Write access token on Docker Hub and add it as a repository secret."
+            missing=1
+          fi
+          if [ "$missing" -eq 0 ]; then
+            echo "Both secrets are present."
+          fi
+          exit "$missing"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read the current version
+        id: version
+        run: echo "value=$(node -pe "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      # Shows the tags a release of the current version would publish. Nothing
+      # is pushed under these names — this only proves the tagging rules behave.
+      - name: Preview the tags a real release would produce
+        id: preview
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.GHCR_IMAGE }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.value }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.value }}
+            type=sha,format=long
+            type=raw,value=latest,enable=${{ !contains(steps.version.outputs.value, '-') }}
+
+      - name: Build for scanning
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: wordyme:verify
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run the same vulnerability gate as a release
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: wordyme:verify
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+
+      # The step that actually proves write access to both registries.
+      - name: Push the disposable verify tag
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.DOCKERHUB_IMAGE }}:${{ env.VERIFY_TAG }}
+            ${{ env.GHCR_IMAGE }}:${{ env.VERIFY_TAG }}
+          sbom: true
+          provenance: mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Confirm both architectures landed
+        env:
+          GHCR: ${{ env.GHCR_IMAGE }}
+          HUB: ${{ env.DOCKERHUB_IMAGE }}
+          TAG: ${{ env.VERIFY_TAG }}
+        run: |
+          echo "::group::GHCR manifest"
+          docker buildx imagetools inspect "${GHCR}:${TAG}"
+          echo "::endgroup::"
+          echo "::group::Docker Hub manifest"
+          docker buildx imagetools inspect "${HUB}:${TAG}"
+          echo "::endgroup::"
+
+      - name: Check the Docker Hub listing sync works
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.DOCKERHUB_IMAGE }}
+          short-description: 'Self-hosted note-taking and document management for students. AGPL-3.0.'
+          readme-filepath: ./DOCKER.md
+
+      - name: Summary
+        env:
+          PREVIEW_TAGS: ${{ steps.preview.outputs.tags }}
+          TAG: ${{ env.VERIFY_TAG }}
+        run: |
+          {
+            echo "## Publishing setup verified"
+            echo
+            echo "Everything the release workflow needs is working:"
+            echo
+            echo "- Both secrets are present"
+            echo "- Docker Hub and GHCR logins succeed"
+            echo "- The image builds on a CI runner"
+            echo "- The vulnerability gate passes"
+            echo "- **Write access to both registries confirmed by a real push**"
+            echo "- Both \`linux/amd64\` and \`linux/arm64\` are in the manifest"
+            echo "- The Docker Hub listing syncs from DOCKER.md"
+            echo
+            echo "### Tags a release of the current version would publish"
+            echo
+            echo '```'
+            echo "$PREVIEW_TAGS"
+            echo '```'
+            echo
+            echo "### Clean up"
+            echo
+            echo "A disposable \`${TAG}\` tag now exists in both registries:"
+            echo
+            echo "- Docker Hub: repository -> Tags -> \`${TAG}\` -> Delete"
+            echo "- GHCR: package -> Versions -> the \`${TAG}\` version -> Delete"
+            echo
+            echo "Leaving it does no harm; it is only untidy."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify-publishing.yml
+++ b/.github/workflows/verify-publishing.yml
@@ -53,24 +53,24 @@ jobs:
           exit "$missing"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -84,7 +84,7 @@ jobs:
       # is pushed under these names — this only proves the tagging rules behave.
       - name: Preview the tags a real release would produce
         id: preview
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: |
             ${{ env.DOCKERHUB_IMAGE }}
@@ -98,7 +98,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(steps.version.outputs.value, '-') }}
 
       - name: Build for scanning
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64
@@ -108,7 +108,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run the same vulnerability gate as a release
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: wordyme:verify
           format: table
@@ -118,7 +118,7 @@ jobs:
 
       # The step that actually proves write access to both registries.
       - name: Push the disposable verify tag
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -131,21 +131,47 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # `imagetools inspect` exits 0 whatever the manifest contains, so printing
+      # it proves nothing. Parse the raw manifest list and fail if either
+      # architecture is absent from either registry — a single-arch push would
+      # otherwise sail through and only be discovered by a Raspberry Pi user.
       - name: Confirm both architectures landed
         env:
           GHCR: ${{ env.GHCR_IMAGE }}
           HUB: ${{ env.DOCKERHUB_IMAGE }}
           TAG: ${{ env.VERIFY_TAG }}
         run: |
-          echo "::group::GHCR manifest"
-          docker buildx imagetools inspect "${GHCR}:${TAG}"
-          echo "::endgroup::"
-          echo "::group::Docker Hub manifest"
-          docker buildx imagetools inspect "${HUB}:${TAG}"
-          echo "::endgroup::"
+          set -euo pipefail
+
+          assert_arches() {
+            ref="$1"
+            echo "::group::$ref"
+            docker buildx imagetools inspect "$ref"
+            echo "::endgroup::"
+
+            raw="$(docker buildx imagetools inspect --raw "$ref")"
+            rc=0
+            for arch in amd64 arm64; do
+              # Selects on os=linux too, so the os/arch "unknown" entries that
+              # the SBOM and provenance attestations add cannot satisfy this.
+              if printf '%s' "$raw" | jq -e --arg a "$arch" \
+                   '.manifests[]? | select(.platform.os == "linux" and .platform.architecture == $a)' >/dev/null; then
+                echo "  linux/$arch present in $ref"
+              else
+                echo "::error::$ref is missing linux/$arch"
+                rc=1
+              fi
+            done
+            return "$rc"
+          }
+
+          failed=0
+          assert_arches "${GHCR}:${TAG}" || failed=1
+          assert_arches "${HUB}:${TAG}" || failed=1
+          exit "$failed"
 
       - name: Check the Docker Hub listing sync works
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
The first release was the only untested part of the publishing chain, and it is an awkward thing to test: a failure happens after the version bump, git tag and GitHub release already exist.

This workflow rehearses the whole path without releasing anything. It checks the secrets, logs in to both registries, builds on a CI runner, runs the same vulnerability gate, pushes to both registries, confirms both architectures are in the manifest, and syncs the Docker Hub listing — writing only a disposable `ci-verify` tag. No version bump, no git tag, no GitHub release, and `latest` is never touched.

It pushes deliberately. `docker login` succeeds with a read-only token and only fails later at push time, so a green login step would prove nothing about write access — which is exactly the mistake worth catching before a release rather than during one.

The secret check runs first and fails in seconds with a message naming the missing secret, rather than after a five minute build.

The summary also prints the tags a real release of the current version would publish, so the tagging rules can be eyeballed before they are used for real.

## Summary

<!-- Briefly describe what this PR does and why it's needed. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close issues when merged. -->

Fixes #

## Type of Change

<!-- Examples: Bug fix, New feature, Breaking change, Refactor, Documentation, Performance improvement -->

## Changes

<!-- List key changes in bullet points. Be specific. -->

-
-

## How to Test

<!-- Provide clear steps for reviewers to verify your changes work as expected. -->

1.
2.
3.

**Expected result:**

## Screenshots

<!-- Required for UI changes. Include before/after screenshots or videos. Remove this section if not a UI change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a manually triggered publishing verification workflow.
  * Validates registry credentials, previews release tags, builds and scans container images, and verifies multi-architecture manifests.
  * Uses temporary verification tags without modifying release tags or `latest`.
  * Provides detailed results in the workflow summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->