### PR TITLE
fix(ci): give the Docker Hub listing its own page and never fail a re…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,11 @@ jobs:
       # Built for one platform and loaded locally so the scan runs against a
       # real image. The multi-platform build below reuses this layer cache, so
       # the amd64 half costs almost nothing the second time.
+      #
+      # amd64 stands in for both architectures: findings come from package
+      # versions — node_modules installed from the same lockfile, and Alpine
+      # packages at the same versions per arch — so an arm64 scan would repeat
+      # the same results at the cost of a QEMU build on the pre-publish path.
       - name: Build amd64 image for scanning
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,8 +284,16 @@ jobs:
           docker buildx imagetools inspect "${IMAGE}:${VERSION}"
 
       # Runs after the push, so the repository exists on Docker Hub by now —
-      # the first release creates it.
+      # the first release creates it. Requires DOCKERHUB_TOKEN to have
+      # Read/Write/Delete scope: the description API rejects Read/Write tokens
+      # with 403, even though the same token pushes images fine.
+      #
+      # continue-on-error: by this point the images are already published, and
+      # a stale listing is not worth a red release run. The verify-publishing
+      # workflow runs this same step *fatally*, so a broken sync is still
+      # caught — during rehearsal, not release.
       - name: Sync the Docker Hub listing
+        continue-on-error: true
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -295,4 +303,6 @@ jobs:
           # on GitHub and would blank the listing if it were ever unset.
           # Docker Hub caps this at 100 characters.
           short-description: 'Self-hosted note-taking and document management for students. AGPL-3.0.'
-          readme-filepath: ./DOCKER.md
+          # A dedicated short page, not DOCKER.md: Docker Hub truncates
+          # listings at 25,000 bytes and DOCKER.md is well past that.
+          readme-filepath: ./DOCKERHUB.md

--- a/.github/workflows/verify-publishing.yml
+++ b/.github/workflows/verify-publishing.yml
@@ -177,7 +177,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: ${{ env.DOCKERHUB_IMAGE }}
           short-description: 'Self-hosted note-taking and document management for students. AGPL-3.0.'
-          readme-filepath: ./DOCKER.md
+          # A dedicated short page, not DOCKER.md: Docker Hub truncates
+          # listings at 25,000 bytes and DOCKER.md is well past that. This step
+          # stays fatal here on purpose — the release workflow marks it
+          # continue-on-error, so the rehearsal is where a broken sync must
+          # surface.
+          readme-filepath: ./DOCKERHUB.md
 
       - name: Summary
         env:

--- a/.github/workflows/verify-publishing.yml
+++ b/.github/workflows/verify-publishing.yml
@@ -44,7 +44,7 @@ jobs:
             missing=1
           fi
           if [ -z "$DOCKERHUB_TOKEN" ]; then
-            echo "::error::DOCKERHUB_TOKEN is not set. Create a Read/Write access token on Docker Hub and add it as a repository secret."
+            echo "::error::DOCKERHUB_TOKEN is not set. Create a Read/Write/Delete access token on Docker Hub and add it as a repository secret. Delete scope is needed by the listing-sync step: the description API returns 403 for Read/Write tokens, even though pushing works."
             missing=1
           fi
           if [ "$missing" -eq 0 ]; then
@@ -200,7 +200,7 @@ jobs:
             echo "- The vulnerability gate passes"
             echo "- **Write access to both registries confirmed by a real push**"
             echo "- Both \`linux/amd64\` and \`linux/arm64\` are in the manifest"
-            echo "- The Docker Hub listing syncs from DOCKER.md"
+            echo "- The Docker Hub listing syncs from DOCKERHUB.md"
             echo
             echo "### Tags a release of the current version would publish"
             echo

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -6,7 +6,7 @@ WordyMe is a centralized platform for students to manage educational information
 
 - **One container, one port.** The web app and API are served from the same origin — no separate frontend, no reverse-proxy gymnastics required.
 - **`linux/amd64` and `linux/arm64`** in every tag. Runs on a normal server, an Apple Silicon Mac, or a Raspberry Pi 4/5.
-- **Hardened by default.** Runs as a non-root user, ships with a built-in health check, handles `SIGTERM` cleanly (shutdown in under a second), and every release is vulnerability-scanned before it is published — a release is blocked if a fixable HIGH or CRITICAL issue is found.
+- **Hardened by default.** Runs as a non-root user, ships with a built-in health check, handles `SIGTERM` cleanly (shutdown in under a second), and every release is vulnerability-scanned before it is published — a fixable HIGH or CRITICAL finding blocks the release. The scan runs against the `amd64` image; its findings are based on package versions, which are the same in both architectures.
 - **SBOM and provenance attestations** attached to every image manifest.
 - Your data lives in one volume: a single SQLite database plus uploaded files.
 

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,0 +1,73 @@
+# WordyMe
+
+**A lightweight note-taking app you can self-host anywhere. Even on your Raspberry Pi.**
+
+WordyMe is a centralized platform for students to manage educational information: rich documents with diagram (Mermaid), math (KaTeX) and music-notation support, organized into spaces, with revision history, favorites and real-time updates.
+
+- **One container, one port.** The web app and API are served from the same origin — no separate frontend, no reverse-proxy gymnastics required.
+- **`linux/amd64` and `linux/arm64`** in every tag. Runs on a normal server, an Apple Silicon Mac, or a Raspberry Pi 4/5.
+- **Hardened by default.** Runs as a non-root user, ships with a built-in health check, handles `SIGTERM` cleanly (shutdown in under a second), and every release is vulnerability-scanned before it is published — a release is blocked if a fixable HIGH or CRITICAL issue is found.
+- **SBOM and provenance attestations** attached to every image manifest.
+- Your data lives in one volume: a single SQLite database plus uploaded files.
+
+## Quick start
+
+```console
+curl -O https://raw.githubusercontent.com/TeamCoderz/WordyMe/main/docker-compose.public.yml
+[ -e .env ] || ( umask 077; echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" > .env )
+docker compose -f docker-compose.public.yml up -d
+```
+
+Then open **http://localhost:8080** and create the first account.
+
+Or with plain `docker run`:
+
+```console
+docker run -d \
+  -p 8080:8080 \
+  -e BETTER_AUTH_SECRET="$(openssl rand -base64 32)" \
+  -e CLIENT_URL=http://localhost:8080 \
+  -v wordyme-storage:/app/storage \
+  teamcoderz/wordyme:latest
+```
+
+`BETTER_AUTH_SECRET` is required — it signs session cookies and deliberately has no default. `CLIENT_URL` must match the address you open in the browser, or sign-in is rejected.
+
+## Tags
+
+| Tag            | Moves?               | Use when                                 |
+| -------------- | -------------------- | ---------------------------------------- |
+| `latest`       | Every stable release | You want updates when you re-pull        |
+| `1.2.3`        | Never                | You want to upgrade deliberately         |
+| `1.2`          | Within a minor line  | You want patches but not feature changes |
+| `sha-<commit>` | Never                | You need to pin an exact build           |
+
+Pre-releases (for example `1.3.0-beta.1`) are published but never tagged `latest`.
+
+## Also on GHCR
+
+The same image is published to GitHub Container Registry, which does not rate-limit pulls of public images:
+
+```console
+docker pull ghcr.io/teamcoderz/wordyme:latest
+```
+
+Docker Hub allows 100 unauthenticated pulls per 6 hours per IP address — a budget shared by everyone behind the same office or campus NAT. If that could bite you, prefer GHCR.
+
+## Configuration, upgrades and backups
+
+The full guide — every environment variable, running behind a reverse proxy, upgrading from the older two-container layout, and safe backup/restore of the database — lives in the repository:
+
+**https://github.com/TeamCoderz/WordyMe/blob/main/DOCKER.md**
+
+## Source and license
+
+WordyMe is free software, licensed under **AGPL-3.0**. The complete corresponding source for every image is at:
+
+**https://github.com/TeamCoderz/WordyMe**
+
+Each image also carries an `org.opencontainers.image.source` label pointing at the repository. Bug reports and contributions are welcome via GitHub issues.
+
+---
+
+Maintained by **TeamCoderz Ltd**. WordyMe™ is a trademark of TeamCoderz Ltd.


### PR DESCRIPTION

The dry run caught both problems in its first execution — which is what it was for.

The sync step returned 403 Forbidden: the description API requires a token with Read/Write/Delete scope and rejects the Read/Write token that pushes images fine. The token has been upgraded to RWD, and the requirement is now documented next to the step so the next scope question answers itself.

The run also warned that the listing source was truncated: DOCKER.md is 33,119 bytes against Docker Hub's 25,000-byte cap, so the public listing would have been an operations manual chopped off mid-sentence. The listing now has a dedicated DOCKERHUB.md (3,485 bytes): what the image is, quick start, the tag table, the GHCR alternative, and links into the full guide — written to stay stable between releases.

The sync step in release.yml is now continue-on-error: by the time it runs the images are already published, and a stale listing is not worth a red release run. It stays fatal in verify-publishing.yml on purpose — the rehearsal is where a broken sync must surface, and it just proved it does.

## Summary

<!-- Briefly describe what this PR does and why it's needed. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close issues when merged. -->

Fixes #

## Type of Change

<!-- Examples: Bug fix, New feature, Breaking change, Refactor, Documentation, Performance improvement -->

## Changes

<!-- List key changes in bullet points. Be specific. -->

-
-

## How to Test

<!-- Provide clear steps for reviewers to verify your changes work as expected. -->

1.
2.
3.

**Expected result:**

## Screenshots

<!-- Required for UI changes. Include before/after screenshots or videos. Remove this section if not a UI change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Docker Hub documentation, including supported architectures, security details, setup instructions, configuration, image tags, GHCR usage, rate limits, licensing, and maintenance information.
  * Updated publishing documentation references to use the dedicated Docker Hub page.
* **Bug Fixes**
  * Improved release handling so Docker Hub listing sync failures do not interrupt releases, while publishing verification continues to detect and report synchronization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->