### PR TITLE
chore(ci): rehearse the pull a self-hoster would actually make

### DIFF
--- a/.github/workflows/verify-publishing.yml
+++ b/.github/workflows/verify-publishing.yml
@@ -189,22 +189,38 @@ jobs:
           # A private package can surface at either of two stages, both seen
           # against the live registry: GHCR may refuse the anonymous token
           # outright (401 authentication required), or issue one and reject
-          # the manifest fetch (403). `|| true` keeps a non-JSON error body
-          # from killing the step under pipefail before it can explain itself.
-          TOKEN="$(curl -s "https://ghcr.io/token?scope=repository:${IMG}:pull&service=ghcr.io" | jq -r '.token // empty' || true)"
+          # the manifest fetch (403).
+          #
+          # The network failure case is kept separate from the refusal case on
+          # purpose — a timeout that produced an empty token would otherwise be
+          # misdiagnosed as "the package is private" and send an operator to
+          # the wrong fix.
+          if ! RESP="$(curl -s --connect-timeout 5 --max-time 10 \
+                "https://ghcr.io/token?scope=repository:${IMG}:pull&service=ghcr.io")"; then
+            echo "::error::Could not reach the ghcr.io token endpoint. Network problem or registry outage — not a visibility issue. Retry once GHCR is reachable."
+            exit 1
+          fi
+          TOKEN="$(printf '%s' "$RESP" | jq -r '.token // empty' || true)"
           if [ -z "$TOKEN" ]; then
             echo "::error::GHCR refused to issue an anonymous pull token for ${IMG} — the package is almost certainly private, which is GHCR's default on first push. $FIX"
             exit 1
           fi
 
-          CODE="$(curl -s -o /dev/null -w '%{http_code}' \
+          if ! CODE="$(curl -s -o /dev/null -w '%{http_code}' \
+            --connect-timeout 5 --max-time 10 \
             -H "Authorization: Bearer $TOKEN" \
             -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json" \
-            "https://ghcr.io/v2/${IMG}/manifests/${TAG}")"
+            "https://ghcr.io/v2/${IMG}/manifests/${TAG}")"; then
+            echo "::error::Could not reach ghcr.io for the manifest fetch. Network problem or registry outage — not a visibility issue. Retry once GHCR is reachable."
+            exit 1
+          fi
           if [ "$CODE" = "200" ]; then
             echo "Anonymous pull works (HTTP 200) — the GHCR package is public."
+          elif [ "$CODE" = "401" ] || [ "$CODE" = "403" ]; then
+            echo "::error::Anonymous GHCR pull returned HTTP $CODE (access denied). $FIX"
+            exit 1
           else
-            echo "::error::Anonymous GHCR pull returned HTTP $CODE. $FIX"
+            echo "::error::Anonymous GHCR pull returned HTTP $CODE (unexpected — not a visibility problem). Check that ${IMG}:${TAG} exists and that ghcr.io is healthy."
             exit 1
           fi
 

--- a/.github/workflows/verify-publishing.yml
+++ b/.github/workflows/verify-publishing.yml
@@ -170,6 +170,44 @@ jobs:
           assert_arches "${HUB}:${TAG}" || failed=1
           exit "$failed"
 
+      # GHCR creates a package PRIVATE on its first push, even when the
+      # repository is public. Anonymous pulls then fail with 401/403 until a
+      # human flips the package to public in its settings — and every
+      # authenticated step in this job is blind to that, because the workflow
+      # pulls as the repository, not as a stranger. So check it the way a
+      # self-hoster's machine would: with no credentials at all.
+      - name: Confirm the GHCR package is publicly pullable
+        env:
+          GHCR: ${{ env.GHCR_IMAGE }}
+          TAG: ${{ env.VERIFY_TAG }}
+        run: |
+          set -euo pipefail
+          IMG="${GHCR#ghcr.io/}"
+
+          FIX="Fix: repository page -> Packages -> wordyme -> Package settings -> Danger Zone -> Change visibility -> Public. Note: deleting the whole package resets this and the next push recreates it private; delete individual versions only."
+
+          # A private package can surface at either of two stages, both seen
+          # against the live registry: GHCR may refuse the anonymous token
+          # outright (401 authentication required), or issue one and reject
+          # the manifest fetch (403). `|| true` keeps a non-JSON error body
+          # from killing the step under pipefail before it can explain itself.
+          TOKEN="$(curl -s "https://ghcr.io/token?scope=repository:${IMG}:pull&service=ghcr.io" | jq -r '.token // empty' || true)"
+          if [ -z "$TOKEN" ]; then
+            echo "::error::GHCR refused to issue an anonymous pull token for ${IMG} — the package is almost certainly private, which is GHCR's default on first push. $FIX"
+            exit 1
+          fi
+
+          CODE="$(curl -s -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json" \
+            "https://ghcr.io/v2/${IMG}/manifests/${TAG}")"
+          if [ "$CODE" = "200" ]; then
+            echo "Anonymous pull works (HTTP 200) — the GHCR package is public."
+          else
+            echo "::error::Anonymous GHCR pull returned HTTP $CODE. $FIX"
+            exit 1
+          fi
+
       - name: Check the Docker Hub listing sync works
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
         with:
@@ -200,6 +238,7 @@ jobs:
             echo "- The vulnerability gate passes"
             echo "- **Write access to both registries confirmed by a real push**"
             echo "- Both \`linux/amd64\` and \`linux/arm64\` are in the manifest"
+            echo "- The GHCR package is publicly pullable — anonymous pull returns 200"
             echo "- The Docker Hub listing syncs from DOCKERHUB.md"
             echo
             echo "### Tags a release of the current version would publish"


### PR DESCRIPTION
The dry run went green while nobody could pull the image. GHCR creates every package private on its first push, even when the repository is public, so anonymous pulls of ghcr.io/teamcoderz/wordyme failed with 401 until a teammate tried it by hand. Every existing step was blind to this: the workflow pulls as the repository, never as a stranger.

The verify workflow now fetches the manifest with no credentials at all, the way a self-hoster's machine does. Tested against the live registry, a private package surfaces at either of two stages — GHCR may refuse the anonymous token outright (401 authentication required), or issue one and reject the manifest fetch (403) — and the step handles both, with an error message that includes the fix and the footgun: deleting the whole package resets visibility, so only individual versions should ever be deleted during cleanup.

Both paths verified against live GHCR before commit: a known-public package passes with HTTP 200, and teamcoderz/wordyme (still private at time of writing) fails at the token stage with the diagnostic message.

## Summary

<!-- Briefly describe what this PR does and why it's needed. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close issues when merged. -->

Fixes #

## Type of Change

<!-- Examples: Bug fix, New feature, Breaking change, Refactor, Documentation, Performance improvement -->

## Changes

<!-- List key changes in bullet points. Be specific. -->

-
-

## How to Test

<!-- Provide clear steps for reviewers to verify your changes work as expected. -->

1.
2.
3.

**Expected result:**

## Screenshots

<!-- Required for UI changes. Include before/after screenshots or videos. Remove this section if not a UI change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved publishing verification for publicly available container packages.
  * Added checks to confirm packages can be pulled anonymously after publication.
  * Added clearer reporting when packages are private or unavailable, making publishing issues easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->