### PR TITLE
docs(local-setup): make the guide produce a working app

### DIFF
--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -13,14 +13,21 @@ see [DOCKER.md](DOCKER.md). That path is a single command and needs no toolchain
 
 ### Installing pnpm
 
-The repository pins its package manager in `package.json`, so the least
-error-prone option is Corepack, which ships with Node and reads that pin:
+The repository pins its package manager in `package.json`, and Corepack reads
+that pin, so it is the least error-prone option:
 
 ```bash
 corepack enable
 ```
 
-Otherwise install it yourself:
+Corepack shipped with Node through v24. It is no longer part of the official
+Node 25+ distributions, so on those you install it first:
+
+```bash
+npm install -g corepack
+```
+
+Otherwise install pnpm yourself:
 
 ```bash
 # Using npm
@@ -76,20 +83,32 @@ echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" >> apps/backend/.env
 
 **Do not skip this.** Better Auth does not fail when `BETTER_AUTH_SECRET` is
 missing and logs no warning — it quietly falls back to a hard-coded default that
-is the same in every install. Anything signed with it, including your session
-cookies, can be forged by anyone. Locally that is a small thing; the moment you
-expose the port to your network, or reuse the file on a server, it is not.
+is the same in every install. It refuses to start only under
+`NODE_ENV=production`, which nothing in local development sets. Anything signed
+with that default, including your session cookies, can be forged by anyone.
+Locally that is a small thing; the moment you expose the port to your network, or
+reuse the file on a server, it is not.
 
 Changing this value later invalidates existing sessions and logs everyone out.
 
 The remaining settings have working defaults:
 
-| Variable       | Default                 | Notes                                         |
-| -------------- | ----------------------- | --------------------------------------------- |
-| `PORT`         | `3000`                  | Backend port                                  |
-| `DB_FILE_NAME` | `file:storage/local.db` | Created on first migration                    |
-| `CLIENT_URL`   | `http://localhost:5173` | Trusted origins — must match your browser URL |
-| `TRUST_PROXY`  | unset                   | Leave unset locally                           |
+| Variable          | Default                 | Notes                                         |
+| ----------------- | ----------------------- | --------------------------------------------- |
+| `PORT`            | `3000`                  | Backend port                                  |
+| `DB_FILE_NAME`    | `file:storage/local.db` | Created on first migration                    |
+| `CLIENT_URL`      | `http://localhost:5173` | Trusted origins — must match your browser URL |
+| `BETTER_AUTH_URL` | first `CLIENT_URL`      | Public origin of the auth API                 |
+| `TRUST_PROXY`     | unset                   | Leave unset locally                           |
+
+Upgrading an existing clone? `DB_FILE_NAME` used to default to `file:local.db`.
+An `.env` you already have keeps working untouched, but if you replace it from
+the template, bring the database with it — otherwise you are pointed at a new,
+empty one, which looks exactly like skipping [Step 4](#step-4-database-setup):
+
+```bash
+mv apps/backend/local.db apps/backend/storage/local.db
+```
 
 ### Frontend
 
@@ -138,7 +157,7 @@ Commit the generated file along with your schema change.
 
 ### Option 1: Start Everything (Recommended)
 
-From the root directory:
+From the root directory — `cd ../..` if Step 4 left you in `apps/backend`:
 
 ```bash
 pnpm dev
@@ -210,6 +229,11 @@ sub-routes.
 2. Sign up with an email and password — no verification email is sent locally
 3. You are logged in automatically
 
+Sign-up is open only while the database has no users. Once the first account
+exists the API rejects further sign-ups, the login page stops offering the link,
+and `/signup` redirects to `/login` — so a second local account means resetting
+the database first, see [Database Issues](#database-issues).
+
 ### Initial Setup
 
 1. Create your first **Space** (a container for organizing documents)
@@ -227,9 +251,10 @@ Migrations have not been applied. See [Step 4](#step-4-database-setup).
 **Backend (3000):** change `PORT` in `apps/backend/.env`. If you do, the Vite
 proxy targets in `apps/web/vite.config.ts` need the same port.
 
-**Frontend (5173):** the port is set in `apps/web/vite.config.ts` with
-`strictPort: true`, so Vite fails rather than silently picking another port. If
-you change it, add the new origin to `CLIENT_URL` in `apps/backend/.env` or
+**Frontend (5173):** the port is set twice in `apps/web/vite.config.ts` — under
+`server` for `pnpm dev` and under `preview` for `pnpm start` — both with
+`strictPort: true`, so Vite fails rather than silently picking another port.
+Change both, and add the new origin to `CLIENT_URL` in `apps/backend/.env` or
 sign-in will be rejected.
 
 ### Sign-in fails with an origin or CORS error
@@ -241,18 +266,26 @@ app over your LAN means adding that origin too:
 CLIENT_URL=http://localhost:5173,http://192.168.1.20:5173
 ```
 
+Reaching the app by hostname rather than by IP needs one more entry: that
+hostname has to be in `server.allowedHosts` in `apps/web/vite.config.ts`, which
+lists only `wordyme.test`. An unlisted hostname gets Vite's `Blocked request`
+before the request reaches the backend at all, so `CLIENT_URL` is not the fix.
+`localhost` and bare IP addresses are always allowed.
+
 ### Database Issues
 
 Start over with an empty database:
 
 ```bash
 cd apps/backend
-rm storage/local.db
+rm -f storage/local.db storage/local.db-wal storage/local.db-shm storage/local.db-journal
 pnpm drizzle-kit migrate
 ```
 
-This deletes all local data. Uploaded files live alongside it in `storage/` and
-are not removed by this.
+This deletes all local data. The `-wal`, `-shm` and `-journal` companions are
+SQLite's own; one left behind after the server was killed mid-write can fail the
+next open, so they go with it. Uploaded files live alongside the database in
+`storage/` and are not removed by this.
 
 ### Dependency Issues
 
@@ -279,8 +312,12 @@ surfaces in the apps that import it.
 
 ```bash
 rm -rf apps/*/dist packages/*/dist
-pnpm build
+pnpm build --force
 ```
+
+`--force` is the point: `build` is a cached Turbo task, so deleting `dist/` on
+its own achieves nothing — the next build replays the same output from `.turbo/`
+instead of running `tsc` and `vite build` again.
 
 ## Development Tips
 
@@ -288,13 +325,6 @@ pnpm build
 
 - **Frontend:** React components hot-reload
 - **Backend:** `tsx watch` restarts on file changes
-
-### Tests
-
-```bash
-cd apps/web
-pnpm test
-```
 
 ### Linting
 
@@ -332,7 +362,7 @@ WordyMe/
 │   ├── editor/             # Lexical-based rich text editor
 │   ├── embed-pdf/          # PDF viewer
 │   ├── ui/                 # Shared UI components
-│   ├── sdk/                # Generated API client
+│   ├── sdk/                # API client
 │   ├── lib/                # Shared utilities
 │   ├── shared/             # Code shared between apps
 │   ├── types/              # Shared type definitions

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -1,17 +1,26 @@
 # Local Setup Guide
 
-This guide will help you set up and run WordyMe on your local machine.
+This guide sets up WordyMe for development, running the backend and frontend
+directly on your machine with hot reloading.
+
+If you only want to _run_ WordyMe rather than work on it, use Docker instead —
+see [DOCKER.md](DOCKER.md). That path is a single command and needs no toolchain.
 
 ## Prerequisites
-
-Before you begin, ensure you have the following installed:
 
 - **Node.js** >= 22 ([Download](https://nodejs.org/))
 - **pnpm** 10.33.0 ([Installation Guide](https://pnpm.io/installation))
 
 ### Installing pnpm
 
-If you don't have pnpm installed:
+The repository pins its package manager in `package.json`, so the least
+error-prone option is Corepack, which ships with Node and reads that pin:
+
+```bash
+corepack enable
+```
+
+Otherwise install it yourself:
 
 ```bash
 # Using npm
@@ -24,69 +33,110 @@ brew install pnpm
 curl -fsSL https://get.pnpm.io/install.sh | sh -
 ```
 
-Verify installation:
+Verify:
 
 ```bash
 pnpm --version
 # Should output: 10.33.0
 ```
 
+pnpm also has to be on your `PATH` for the git pre-commit hooks to run — they
+call `pnpm` to add licence headers and format staged files.
+
 ## Step 1: Clone the Repository
 
 ```bash
-git clone <repository-url>
+git clone https://github.com/TeamCoderz/WordyMe.git
 cd WordyMe
 ```
 
 ## Step 2: Install Dependencies
 
-Install all dependencies for the monorepo:
-
 ```bash
 pnpm install
 ```
 
-This will install dependencies for all apps and packages in the monorepo.
+This installs dependencies for every app and package in the monorepo, and
+installs the git hooks.
 
 ## Step 3: Environment Configuration
 
-### Backend Environment Variables
-
-Create a `.env` file in `apps/backend/`:
+### Backend
 
 ```bash
-cd apps/backend
-cp .env.example .env
+cp apps/backend/.env.example apps/backend/.env
 ```
 
-**Note:** The database file will be created automatically on first run if it doesn't exist.
-
-### Frontend Environment Variables
-
-Create a `.env` file in `apps/web/`:
+Then generate the session-signing secret, which the template deliberately ships
+commented out:
 
 ```bash
-cd apps/web
-cp .env.example .env
+echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" >> apps/backend/.env
 ```
+
+**Do not skip this.** Better Auth does not fail when `BETTER_AUTH_SECRET` is
+missing and logs no warning — it quietly falls back to a hard-coded default that
+is the same in every install. Anything signed with it, including your session
+cookies, can be forged by anyone. Locally that is a small thing; the moment you
+expose the port to your network, or reuse the file on a server, it is not.
+
+Changing this value later invalidates existing sessions and logs everyone out.
+
+The remaining settings have working defaults:
+
+| Variable       | Default                 | Notes                                         |
+| -------------- | ----------------------- | --------------------------------------------- |
+| `PORT`         | `3000`                  | Backend port                                  |
+| `DB_FILE_NAME` | `file:storage/local.db` | Created on first migration                    |
+| `CLIENT_URL`   | `http://localhost:5173` | Trusted origins — must match your browser URL |
+| `TRUST_PROXY`  | unset                   | Leave unset locally                           |
+
+### Frontend
+
+**No `.env` is needed.** `apps/web/.env.example` exists only to document the
+optional `VITE_BACKEND_URL`, and every value in it already has a working default.
+
+Copying it is not a neutral act: `VITE_BACKEND_URL` is inlined by Vite at build
+time, so setting it to `http://localhost:3000` bakes that address into any
+production bundle you build afterwards. Leave it unset and requests stay
+relative — which is what the Vite dev proxy needs in development, and what the
+backend needs in production when it serves the bundle itself.
+
+### A note on `.env` files and git
+
+`.env` files are gitignored and must never be committed — `apps/backend/.env`
+holds your session secret. Only the `.env.example` templates are tracked. If you
+add a new setting, add it to the template with a comment, not to your `.env`
+alone.
 
 ## Step 4: Database Setup
 
-The backend uses SQLite (libSQL) which creates the database file automatically. However, if you need to run migrations:
+**This step is required on a fresh clone.** The database file is created
+automatically, but it is created _empty_ — nothing in the backend applies
+migrations at startup (only the Docker image does that, as part of its launch
+command). Skip this and the server starts fine, then every request that touches
+the database fails with `no such table: users`.
 
 ```bash
 cd apps/backend
-
-# Generate migrations (if schema changed)
-pnpm drizzle-kit generate
-
-# Apply migrations
 pnpm drizzle-kit migrate
 ```
 
+Run it again after pulling changes that add migrations.
+
+Only if you have **changed the schema** in `src/models/` do you also need to
+generate a migration first:
+
+```bash
+pnpm drizzle-kit generate   # writes a new file into drizzle/
+pnpm drizzle-kit migrate
+```
+
+Commit the generated file along with your schema change.
+
 ## Step 5: Start Development Servers
 
-### Option 1: Start All Services (Recommended)
+### Option 1: Start Everything (Recommended)
 
 From the root directory:
 
@@ -94,211 +144,181 @@ From the root directory:
 pnpm dev
 ```
 
-This will start both the backend and frontend in parallel.
+Starts the backend and frontend together.
 
 ### Option 2: Start Services Separately
 
-**Terminal 1 - Backend:**
+**Terminal 1 — Backend:**
 
 ```bash
 cd apps/backend
 pnpm dev
 ```
 
-The backend will start on `http://localhost:3000`
+Backend on `http://localhost:3000`.
 
-**Terminal 2 - Frontend:**
+**Terminal 2 — Frontend:**
 
 ```bash
 cd apps/web
 pnpm dev
 ```
 
-The frontend will start on `http://localhost:5173`
+Frontend on `http://localhost:5173`.
 
-## Step 6: Start Production Servers
+The dev server proxies `/api` and `/storage` through to port 3000, so the app
+sees a single origin and there is no CORS involved.
 
-Before starting production servers, you need to build the project:
+## Step 6: Running a Production Build Locally
 
-### Build the Project
-
-From the root directory:
+Build first:
 
 ```bash
 pnpm build
 ```
 
-This will build both the backend and frontend for production.
-
-### Option 1: Start All Services (Recommended)
-
-From the root directory:
+Then:
 
 ```bash
 pnpm start
 ```
 
-This will start both the backend and frontend in production mode.
+The backend serves the compiled API from `dist/`, and the frontend is served by
+`vite preview` on port 5173. Preview inherits the dev server's proxy
+configuration, so `/api` still reaches the backend.
 
-### Option 2: Start Services Separately
-
-**Terminal 1 - Backend:**
-
-```bash
-cd apps/backend
-pnpm start
-```
-
-The backend will start on `http://localhost:3000` (or the port specified in your `.env`)
-
-**Terminal 2 - Frontend:**
-
-```bash
-cd apps/web
-pnpm start
-```
-
-The frontend will start on `http://localhost:5173` (preview server for the production build)
-
-**Note:** The frontend `start` command runs `vite preview`, which serves the production build. For a true production server, you would typically use a server like Nginx or serve the `dist` folder with a static file server.
+This is a way to check that a production build behaves — it is not how you
+deploy. In a real deployment the backend serves the web bundle itself from one
+origin; see [DOCKER.md](DOCKER.md).
 
 ## Step 7: Access the Application
 
-Once both servers are running:
+- **Frontend:** [http://localhost:5173](http://localhost:5173)
+- **Backend API:** [http://localhost:3000](http://localhost:3000)
+- **API reference:** [http://localhost:3000/api/docs](http://localhost:3000/api/docs)
+- **OpenAPI document:** [http://localhost:3000/api/docs/openapi.json](http://localhost:3000/api/docs/openapi.json)
 
-- **Frontend:** Open [http://localhost:5173](http://localhost:5173) in your browser
-- **Backend API:** Available at [http://localhost:3000](http://localhost:3000)
-- **API Documentation:** [http://localhost:3000/api-docs](http://localhost:3000/api-docs) (if available)
+Every server route lives under `/api` or `/storage`. That is why the API
+reference sits at `/api/docs` and not `/docs` — the web app owns `/docs` and its
+sub-routes.
 
 ## First-Time Setup
 
 ### Create an Account
 
-1. Navigate to the signup page
-2. Create your account with email and password
-3. You'll be automatically logged in
+1. Open [http://localhost:5173](http://localhost:5173)
+2. Sign up with an email and password — no verification email is sent locally
+3. You are logged in automatically
 
 ### Initial Setup
 
-After logging in:
-
 1. Create your first **Space** (a container for organizing documents)
 2. Create your first **Document** within the space
-3. Start taking notes!
+3. Start taking notes
 
 ## Troubleshooting
 
+### `no such table: users` (or any other table)
+
+Migrations have not been applied. See [Step 4](#step-4-database-setup).
+
 ### Port Already in Use
 
-If you get a "port already in use" error:
+**Backend (3000):** change `PORT` in `apps/backend/.env`. If you do, the Vite
+proxy targets in `apps/web/vite.config.ts` need the same port.
 
-**Backend (port 3000):**
+**Frontend (5173):** the port is set in `apps/web/vite.config.ts` with
+`strictPort: true`, so Vite fails rather than silently picking another port. If
+you change it, add the new origin to `CLIENT_URL` in `apps/backend/.env` or
+sign-in will be rejected.
+
+### Sign-in fails with an origin or CORS error
+
+The address in your browser is not in `CLIENT_URL`. It is a list, so reaching the
+app over your LAN means adding that origin too:
 
 ```bash
-# Change PORT in apps/backend/.env
-PORT=3001
-```
-
-**Frontend (port 5173):**
-
-```bash
-# The port is configured in apps/web/vite.config.ts
-# You can modify it or kill the process using the port
+CLIENT_URL=http://localhost:5173,http://192.168.1.20:5173
 ```
 
 ### Database Issues
 
-If you encounter database errors:
+Start over with an empty database:
 
-1. **Delete and recreate the database:**
+```bash
+cd apps/backend
+rm storage/local.db
+pnpm drizzle-kit migrate
+```
 
-   ```bash
-   cd apps/backend
-   rm storage/local.db
-   # Restart the backend - it will create a new database
-   ```
-
-2. **Run migrations:**
-   ```bash
-   cd apps/backend
-   pnpm drizzle-kit migrate
-   ```
+This deletes all local data. Uploaded files live alongside it in `storage/` and
+are not removed by this.
 
 ### Dependency Issues
 
-If you encounter dependency-related errors:
-
 ```bash
-# Clean install
 rm -rf node_modules apps/*/node_modules packages/*/node_modules
-rm pnpm-lock.yaml
 pnpm install
 ```
 
+Do **not** delete `pnpm-lock.yaml` to fix an install. The lockfile carries
+pinned security overrides and dependency patches, and regenerating it silently
+resolves everything to whatever is newest — which changes what you are running
+and is rarely what you were trying to debug.
+
 ### Type Errors
 
-If you see TypeScript errors:
-
 ```bash
-# Type-check all packages
 pnpm check-types
-
-# If errors persist, rebuild packages
-pnpm build
 ```
+
+Workspace packages are consumed from source, so a type error in one package
+surfaces in the apps that import it.
 
 ### Build Errors
 
-If builds fail:
-
 ```bash
-# Clean build artifacts
 rm -rf apps/*/dist packages/*/dist
-
-# Rebuild
 pnpm build
 ```
 
 ## Development Tips
 
-### Hot Module Replacement (HMR)
+### Hot Module Replacement
 
-Both frontend and backend support hot reloading:
+- **Frontend:** React components hot-reload
+- **Backend:** `tsx watch` restarts on file changes
 
-- **Frontend:** Changes to React components will hot-reload automatically
-- **Backend:** Uses `tsx watch` for automatic restarts on file changes
-
-### Type Checking
-
-Run type checking in watch mode:
+### Tests
 
 ```bash
-# In a separate terminal
-pnpm check-types --watch
+cd apps/web
+pnpm test
 ```
 
 ### Linting
 
-Lint your code:
-
 ```bash
-# Lint all packages
-pnpm lint
-
-# Lint specific package
-pnpm lint --filter=web
+pnpm lint                 # all packages
+pnpm lint --filter=web    # one package
 ```
 
 ### Code Formatting
 
-Format your code:
+```bash
+pnpm format
+```
+
+This also runs automatically on staged files when you commit.
+
+### Licence Headers
+
+Source files carry an SPDX header, added automatically by the pre-commit hook.
+To check or apply it by hand:
 
 ```bash
-# Format all files
-pnpm format
-
-# Format specific files
-pnpm format --write "apps/web/src/**/*.{ts,tsx}"
+pnpm license:check
+pnpm license:fix
 ```
 
 ## Project Structure Overview
@@ -306,32 +326,34 @@ pnpm format --write "apps/web/src/**/*.{ts,tsx}"
 ```
 WordyMe/
 ├── apps/
-│   ├── backend/        # Backend API (Express + libSQL)
-│   └── web/            # Frontend App (React + Vite)
+│   ├── backend/            # API (Express 5 + libSQL/SQLite + Socket.io)
+│   └── web/                # Web app (React 19 + Vite + TanStack Router)
 ├── packages/
-│   ├── editor/         # Rich text editor
-│   ├── ui/             # UI components
-│   ├── sdk/            # API client
-│   └── types/          # Type definitions
-└── package.json        # Root package.json
+│   ├── editor/             # Lexical-based rich text editor
+│   ├── embed-pdf/          # PDF viewer
+│   ├── ui/                 # Shared UI components
+│   ├── sdk/                # Generated API client
+│   ├── lib/                # Shared utilities
+│   ├── shared/             # Code shared between apps
+│   ├── types/              # Shared type definitions
+│   ├── eslint-config/      # Shared ESLint configuration
+│   └── typescript-config/  # Shared TypeScript configuration
+└── package.json            # Workspace root
 ```
 
 ## Next Steps
 
 - Read the [README.md](README.md) for project documentation
-- Explore the codebase structure
-- Check out the API documentation at `/api-docs` when the backend is running
-- Review the component library in `packages/ui`
+- Run WordyMe in a container with [DOCKER.md](DOCKER.md)
+- Browse the API reference at `/api/docs` while the backend is running
 
 ## Getting Help
 
-If you encounter issues:
-
 1. Check the troubleshooting section above
-2. Review error messages in the terminal
-3. Check browser console for frontend errors
-4. Verify all environment variables are set correctly
-5. Ensure all dependencies are installed (`pnpm install`)
+2. Read the terminal output — the backend logs the trusted origins it started with
+3. Check the browser console for frontend errors
+4. Confirm migrations have been applied
+5. Confirm dependencies are installed (`pnpm install`)
 
 ## Additional Resources
 
@@ -339,3 +361,4 @@ If you encounter issues:
 - [Vite Documentation](https://vitejs.dev)
 - [TanStack Router](https://tanstack.com/router)
 - [Drizzle ORM](https://orm.drizzle.team)
+- [Better Auth](https://better-auth.com)

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -28,6 +28,11 @@ DB_FILE_NAME=file:storage/local.db
 # need this if you change the frontend port or reach the app over your LAN.
 # CLIENT_URL=http://localhost:5173
 
+# Optional. Public origin of the auth API, used as Better Auth's baseURL.
+# Defaults to the first CLIENT_URL entry, which is what you want locally. Set it
+# only when the canonical URL is not the one listed first.
+# BETTER_AUTH_URL=http://localhost:5173
+
 # Optional. Set ONLY when a reverse proxy sits in front of the backend. Accepts
 # a hop count (1) or trusted addresses/subnets (10.0.0.0/8). Leave unset for
 # local development — you are reaching the port directly.

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,2 +1,38 @@
+# Environment variables for running the backend locally.
+# Copy to .env and fill in the secret:  cp .env.example .env
+#
+# This file is a template. The .env you create from it is gitignored and must
+# stay that way — it holds the key that signs every session cookie.
+
+# REQUIRED, and deliberately left commented out rather than blank: a secret
+# committed to a public repository is a published secret, and an empty value
+# behaves exactly like no value at all.
+#
+# Better Auth does NOT fail when this is unset — it silently falls back to a
+# hard-coded default that is identical in every install, so anyone could forge a
+# session. Append your own, so the file ends up with exactly one entry:
+#
+#   echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" >> .env
+#
+# BETTER_AUTH_SECRET=
+
 PORT=3000
-DB_FILE_NAME=file:local.db
+
+# Where the SQLite database lives, relative to apps/backend. Sits alongside
+# uploaded files in storage/, which is gitignored, and mirrors the layout the
+# Docker image uses at /app/storage.
+DB_FILE_NAME=file:storage/local.db
+
+# Optional. Comma-separated: every origin you open the app on (Better Auth
+# trusted origins + CORS). Defaults to the Vite dev server below, so you only
+# need this if you change the frontend port or reach the app over your LAN.
+# CLIENT_URL=http://localhost:5173
+
+# Optional. Set ONLY when a reverse proxy sits in front of the backend. Accepts
+# a hop count (1) or trusted addresses/subnets (10.0.0.0/8). Leave unset for
+# local development — you are reaching the port directly.
+#
+# TRUST_PROXY=true is rejected at startup: it would trust the left-most
+# X-Forwarded-For entry, which any client can forge, letting them evade login
+# rate limiting. A hop count is resolved from the right instead.
+# TRUST_PROXY=1

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,23 @@
-BUILD_OUT_DIR="./dist"
-SERVER_ORIGIN="http://localhost:5173"
-ANALAYZE_BUNDLE=false
-VITE_BACKEND_URL="http://localhost:3000"
+# Environment variables for the web app.
+#
+# You do NOT need to copy this file to run the app locally. Every value below
+# has a working default in vite.config.ts, and `pnpm dev` ignores
+# VITE_BACKEND_URL entirely — the dev server proxies /api and /storage to the
+# backend on port 3000, so requests are same-origin either way.
+
+# Origin of the backend API. Leave unset unless the API really is served from a
+# different origin than the web app.
+#
+# Vite inlines this at BUILD time, so a value here is baked into the bundle and
+# cannot be changed afterwards without rebuilding. Setting it to
+# http://localhost:3000 and then deploying ships a bundle that asks every user's
+# browser for localhost.
+#
+# Unset means relative URLs, which is what both supported setups need: in dev
+# the Vite proxy forwards them, and in production the backend serves this bundle
+# from its own origin.
+# VITE_BACKEND_URL=
+
+# BUILD_OUT_DIR, SERVER_ORIGIN and ANALAYZE_BUNDLE are defined by
+# vite.config.ts but are not read anywhere in the application, so setting them
+# has no effect today.


### PR DESCRIPTION
## Summary

`LOCAL_SETUP.md` did not produce a working app. Following it verbatim on a clean clone, sign-up fails:

```
POST /api/auth/sign-up/email 500
SqliteError: no such table: users
```

**Step 4 presented migrations as conditional** — *"However, if you need to run migrations"*. They are mandatory on a fresh clone. Nothing in the backend applies migrations at startup; only the Docker image does, via its launch command (`src/scripts/run-migrations.mjs`). The old note said the database file is created automatically, which is true — but it is created *empty*, so the server starts cleanly and then every request that touches the database fails.

This fixes the guide and two `.env.example` templates. No runtime code changes.

## Related Issues

None.

## Type of Change

Documentation, plus two `.env.example` templates. No application code changed.

One behavioural note for existing clones: the `DB_FILE_NAME` default moves (see Changes).

## Changes

**Corrections to the guide**

| Was | Is |
| --- | --- |
| Migrations optional | Required step, before first run |
| `drizzle-kit generate` then `migrate` | `migrate` only; `generate` moved under "if you changed the schema" |
| API reference at `/api-docs` | `/api/docs` — the old path 404s; it moved when the SPA took ownership of `/docs` |
| Troubleshooting: `rm storage/local.db` | Matches where the database actually lands |
| Troubleshooting: `rm pnpm-lock.yaml` | Removed — discards the security overrides, dependency patches and release-age quarantine |
| `packages/` list: 4 entries | All 9 workspace packages |

**`BETTER_AUTH_SECRET` was undocumented for local development**

Better Auth does **not** fail when it is unset, and logs no warning. It falls back to a hard-coded default identical in every install, so anything signed with it — including session cookies — is forgeable. Confirmed by a full sign-up succeeding with nothing in the log.

Step 3 now generates one, matching the wording already in `DOCKER.md`:

```bash
echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" >> apps/backend/.env
```

The template ships the key **commented out** rather than blank. With a blank entry above an appended one, dotenv resolves the last occurrence — so someone editing the visible top line would be silently overridden.

**`apps/web/.env` is no longer part of setup**

Step 3 previously told you to copy `apps/web/.env.example`. Diffing two production builds:

- **with** the file — `http://localhost:3000` is inlined into the bundle
- **without** it — nothing inlined; relative, same-origin

Vite forces `VITE_BACKEND_URL` empty in dev, so copying it does nothing for `pnpm dev`. In a production build it bakes `localhost:3000` into avatar and cover image URLs — the same trap `DOCKER.md` warns about. Its other three keys (`BUILD_OUT_DIR`, `SERVER_ORIGIN`, `ANALAYZE_BUNDLE`) are defined by `vite.config.ts` but read nowhere in the application.

**`DB_FILE_NAME` default moved**

`file:local.db` → `file:storage/local.db`, which matches the default already in `env.ts`, sits with uploaded files in the already-gitignored `storage/`, and mirrors the container layout at `/app/storage`. Previously, deleting your `.env` silently switched you to a *different* database.

Only affects new clones. Existing ones that want to keep their data:

```bash
mv apps/backend/local.db apps/backend/storage/local.db
```

**Additions**

pnpm-on-`PATH` requirement for the commit hooks, Corepack as the preferred install, `pnpm test`, the licence-header commands, and `CLIENT_URL`/CORS troubleshooting.

## How to Test

Use a scratch directory — an existing working copy already has `.env` files and a database, so it will not reproduce the new-contributor experience.

1. `git clone -b docs/local-setup-refresh https://github.com/TeamCoderz/WordyMe.git wordyme-test && cd wordyme-test`
2. Follow `LOCAL_SETUP.md` from Step 2, exactly as written.
3. **Skip Step 4** on the first pass and run `pnpm dev`, then try to sign up — this reproduces the bug the PR fixes.
4. Run Step 4 (`cd apps/backend && pnpm drizzle-kit migrate`), restart, and sign up again.
5. Check `apps/backend/.env` has exactly one live `BETTER_AUTH_SECRET` line.
6. Stop the dev server, then `pnpm build && pnpm start`.
7. `grep -rl "localhost:3000" apps/web/dist/assets/*.js`

**Expected result:**

- Step 3 → 500, `no such table: users`
- Step 4 → sign-up and sign-in both 200
- <http://localhost:3000/api/docs> → 200; <http://localhost:3000/api-docs> → 404
- Database at `apps/backend/storage/local.db`, not `apps/backend/local.db`
- Step 7 → no match; the bundle uses relative URLs

Verified end to end on a clean clone: all documented URLs 200, sign-up and sign-in 200, app renders with an empty browser console, production build clean with nothing inlined. Prettier-clean, so the pre-commit hook will not reformat it.

## Reviewer notes

Three judgement calls worth a second opinion:

1. **Should the backend apply migrations at startup in development?** Right now only the container does. Documenting the manual step fixes the guide, but auto-migrating in dev would remove the failure mode entirely. Deliberately not done here — it changes runtime behaviour, not docs.
2. **Should `env.ts` guard `BETTER_AUTH_SECRET`?** Docs cannot stop someone skipping the step, and the failure is silent. A startup warning alongside the existing `clientUrlWarning` is the low-risk version; refusing to boot, as Compose already does, is the strict one.
3. **The `DB_FILE_NAME` default change** — worth confirming nobody is relying on `apps/backend/local.db`.

Separately, out of scope here: `BUILD_OUT_DIR`, `SERVER_ORIGIN` and `ANALAYZE_BUNDLE` are dead config in `vite.config.ts`. `ANALAYZE_BUNDLE` is also misspelled, and the `analyze` script sets a differently-named `ANALYZE`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the local setup guide with complete installation, configuration, database migration, startup, troubleshooting, and development instructions.
  * Added guidance for secure session secrets, environment files, trusted origins, proxy ports, and production previews.
  * Expanded backend environment documentation for database, frontend origin, and reverse-proxy settings.
  * Clarified frontend environment defaults, development proxy behavior, and build-time configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->