### PR TITLE
Fix/trusted origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,14 +7,23 @@
 # Generate one with:  openssl rand -base64 32
 BETTER_AUTH_SECRET=
 
-# Comma-separated: every origin you use (Better Auth trusted origins + CORS).
-# Example for LAN access:
-# CLIENT_URL=http://localhost:8080,http://192.168.1.20:8080
+# Optional. Accept whichever address a request arrives at, so the app works at
+# http://localhost:8080, a LAN IP, a hostname, a Tailscale address or a public
+# domain without naming each one. On by default.
+#
+# This is not "trust anyone". The browser's Origin must match the Host it sent,
+# so a page on evil.com still cannot act on your session. Set false to accept
+# only the origins in CLIENT_URL, which is how older versions behaved.
+# TRUST_HOST=true
+
+# Optional. Extra origins to trust, comma separated. With TRUST_HOST on you only
+# need this when the frontend is served from a different origin than the API.
+# It also sets the CORS allowlist.
 CLIENT_URL=http://localhost:8080
 
-# Optional. Public origin where the app is served (session cookies use http vs https from this). Defaults to first CLIENT_URL.
-# Set when the canonical URL is not first in CLIENT_URL, e.g. BETTER_AUTH_URL=https://notes.example.com
-# BETTER_AUTH_URL=
+# The address users type. REQUIRED when serving over HTTPS: this is what marks
+# session cookies Secure, and without it they are sent over plain HTTP too.
+# BETTER_AUTH_URL=https://notes.example.com
 
 # Optional. Host port Compose publishes to. Change this if 8080 is already taken,
 # and update CLIENT_URL to match.

--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,10 @@ BETTER_AUTH_SECRET=
 # It also sets the CORS allowlist.
 CLIENT_URL=http://localhost:8080
 
-# The address users type. REQUIRED when serving over HTTPS: this is what marks
-# session cookies Secure, and without it they are sent over plain HTTP too.
+# The canonical public address — the one users type. Set it when serving over
+# HTTPS: an https:// value here marks session cookies Secure, so the browser
+# never sends them unencrypted. (When unset, an https:// origin in CLIENT_URL
+# also enables the flag, but the canonical address belongs here.)
 # BETTER_AUTH_URL=https://notes.example.com
 
 # Optional. Host port Compose publishes to. Change this if 8080 is already taken,

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -486,20 +486,31 @@ BETTER_AUTH_URL=https://notes.example.com
 TRUST_PROXY=1
 ```
 
-`BETTER_AUTH_URL` is what marks session cookies `Secure`, so the browser will
-only ever send them over an encrypted connection. **Without it your sessions are
-sent in the clear**, because the container is spoken to over plain HTTP by the
-proxy and has no way to tell that users are on HTTPS. The app warns at startup
-when `TRUST_PROXY` is set and no HTTPS address is configured.
+`BETTER_AUTH_URL` is what marks session cookies `Secure`, so the browser
+refuses to ever send them over an unencrypted connection. **Without an HTTPS
+address configured, cookies lack that flag** — they still work over HTTPS, but
+a downgrade or a stray `http://` link would send them in the clear. The
+container cannot detect TLS itself, because the proxy speaks plain HTTP to it.
+(An HTTPS origin in `CLIENT_URL` also enables the flag when `BETTER_AUTH_URL`
+is unset, but the canonical address belongs in `BETTER_AUTH_URL`.) The app
+warns at startup when `TRUST_PROXY` is set and no HTTPS address is configured
+in either variable.
 
 `TRUST_PROXY` is what makes login rate limiting see the real client address
 rather than the proxy's — see the section below.
 
-Your proxy must pass the original `Host` header through. Caddy and Traefik do
-this by default; for nginx add:
+Setting `TRUST_PROXY` declares that your proxy owns every `X-Forwarded-*`
+header, so the proxy must **set or overwrite** them all — never pass a
+client-supplied value through. A header the proxy neglects becomes
+attacker-controlled: a forwarded `X-Forwarded-Host` would override the host
+used for origin checks, and a forwarded `X-Forwarded-For` would let clients
+pick their own rate-limit identity. Caddy and Traefik overwrite all of these
+and pass the original `Host` through by default; for nginx, set every one
+explicitly:
 
 ```nginx
 proxy_set_header Host $host;
+proxy_set_header X-Forwarded-Host $host;
 proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 ```
@@ -520,9 +531,10 @@ Three things to set in the platform's UI for a production install:
 
 1. `BETTER_AUTH_SECRET` — required; the container refuses to start without it.
 2. `BETTER_AUTH_URL=https://your-domain` and `TRUST_PROXY=1` — the two settings
-   from the section above. Without them the app still works, but session
-   cookies are not marked `Secure` and login rate limiting sees every user as
-   the proxy's address.
+   from the section above. Each fixes its own thing, and the app works without
+   either: `BETTER_AUTH_URL` is what marks session cookies `Secure`, and
+   `TRUST_PROXY` is what stops login rate limiting seeing every user as the
+   proxy's address.
 3. A **persistent volume mounted at `/app/storage`** — otherwise the database
    and every uploaded file are lost on each redeploy.
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -456,15 +456,16 @@ password is simply refused.
 `TRUST_HOST=true`, the default, solves this by accepting whichever host the
 request arrived on. Pick your row:
 
-| How you reach it                                         | What to set                                |
-| -------------------------------------------------------- | ------------------------------------------ |
-| `http://localhost:8080` on the Docker host               | Nothing                                    |
-| `http://192.168.1.50:8080` — a Pi or NAS on your LAN     | Nothing                                    |
-| `http://wordy.local:8080` — a hostname                   | Nothing                                    |
-| `http://100.64.1.2:8080` — Tailscale or a VPN            | Nothing                                    |
-| `http://notes.example.com:8080` — a VPS, plain HTTP      | Nothing                                    |
-| `https://notes.example.com` — behind a reverse proxy     | `BETTER_AUTH_URL` and `TRUST_PROXY`, below |
-| A frontend hosted on a **different** origin from the API | Add that origin to `CLIENT_URL`            |
+| How you reach it                                         | What to set                                  |
+| -------------------------------------------------------- | -------------------------------------------- |
+| `http://localhost:8080` on the Docker host               | Nothing                                      |
+| `http://192.168.1.50:8080` — a Pi or NAS on your LAN     | Nothing                                      |
+| `http://wordy.local:8080` — a hostname                   | Nothing                                      |
+| `http://100.64.1.2:8080` — Tailscale or a VPN            | Nothing                                      |
+| `http://notes.example.com:8080` — a VPS, plain HTTP      | Nothing                                      |
+| `https://notes.example.com` — behind a reverse proxy     | `BETTER_AUTH_URL` and `TRUST_PROXY`, below   |
+| Deployed via **Coolify or Dokploy** with a domain        | Works as-is; two settings recommended, below |
+| A frontend hosted on a **different** origin from the API | Add that origin to `CLIENT_URL`              |
 
 **Is trusting the host safe?** Yes. It does not mean "trust everyone" — it means
 "trust the address this request was actually sent to". A browser always sets
@@ -507,6 +508,27 @@ Avoid listing both `http://` and `https://` origins in `CLIENT_URL`. Cookies
 carry a single `Secure` setting, so one of the two schemes will always be wrong.
 Set `BETTER_AUTH_URL` to the canonical address instead; the app warns if it sees
 a mixture.
+
+#### Coolify, Dokploy and similar platforms
+
+These platforms are the reverse-proxy case above with the proxy managed for you:
+their built-in Traefik terminates TLS for your domain and forwards plain HTTP to
+the container. Traefik passes the original `Host` header through by default, so
+with `TRUST_HOST` on, **sign-up and sign-in work with no configuration at all**.
+
+Three things to set in the platform's UI for a production install:
+
+1. `BETTER_AUTH_SECRET` — required; the container refuses to start without it.
+2. `BETTER_AUTH_URL=https://your-domain` and `TRUST_PROXY=1` — the two settings
+   from the section above. Without them the app still works, but session
+   cookies are not marked `Secure` and login rate limiting sees every user as
+   the proxy's address.
+3. A **persistent volume mounted at `/app/storage`** — otherwise the database
+   and every uploaded file are lost on each redeploy.
+
+Point the platform at container port `8080`. If you skip step 2, the app logs a
+one-time hint when it notices forwarded HTTPS traffic, naming exactly these
+settings.
 
 #### `TRUST_PROXY` and login rate limiting
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -434,16 +434,79 @@ environment:
 
 All variables are read at runtime and can be changed without rebuilding the image:
 
-| Variable             | Description                                                      | Default                         |
-| -------------------- | ---------------------------------------------------------------- | ------------------------------- |
-| `BETTER_AUTH_SECRET` | Secret key for authentication. **Required — no default.**        | _(none; startup fails without)_ |
-| `CLIENT_URL`         | Comma-separated origins for CORS and Better Auth trusted origins | `http://localhost:8080`         |
-| `BETTER_AUTH_URL`    | Public origin, when it differs from the first `CLIENT_URL`       | _(unset)_                       |
-| `NODE_ENV`           | Node environment                                                 | `production`                    |
-| `PORT`               | Port the app listens on, inside the container                    | `8080`                          |
-| `DB_FILE_NAME`       | Database file path (absolute)                                    | `file:/app/storage/local.db`    |
-| `TRUST_PROXY`        | Set **only** behind a reverse proxy — see below                  | _(unset; not behind a proxy)_   |
-| `HOST_PORT`          | Host port compose publishes to (compose only)                    | `8080`                          |
+| Variable             | Description                                               | Default                         |
+| -------------------- | --------------------------------------------------------- | ------------------------------- |
+| `BETTER_AUTH_SECRET` | Secret key for authentication. **Required — no default.** | _(none; startup fails without)_ |
+| `TRUST_HOST`         | Accept the address each request arrives on — see below    | `true`                          |
+| `CLIENT_URL`         | Extra origins to trust, comma separated. Also sets CORS   | `http://localhost:8080`         |
+| `BETTER_AUTH_URL`    | Public address users type. **Set this when using HTTPS**  | _(unset)_                       |
+| `NODE_ENV`           | Node environment                                          | `production`                    |
+| `PORT`               | Port the app listens on, inside the container             | `8080`                          |
+| `DB_FILE_NAME`       | Database file path (absolute)                             | `file:/app/storage/local.db`    |
+| `TRUST_PROXY`        | Set **only** behind a reverse proxy — see below           | _(unset; not behind a proxy)_   |
+| `HOST_PORT`          | Host port compose publishes to (compose only)             | `8080`                          |
+
+#### Deployment scenarios
+
+The container cannot know the address you type into your browser. Better Auth
+refuses any request whose `Origin` it does not trust, which shows up as
+**`403 Invalid origin`** when you try to create an account — the page loads, the
+password is simply refused.
+
+`TRUST_HOST=true`, the default, solves this by accepting whichever host the
+request arrived on. Pick your row:
+
+| How you reach it                                         | What to set                                |
+| -------------------------------------------------------- | ------------------------------------------ |
+| `http://localhost:8080` on the Docker host               | Nothing                                    |
+| `http://192.168.1.50:8080` — a Pi or NAS on your LAN     | Nothing                                    |
+| `http://wordy.local:8080` — a hostname                   | Nothing                                    |
+| `http://100.64.1.2:8080` — Tailscale or a VPN            | Nothing                                    |
+| `http://notes.example.com:8080` — a VPS, plain HTTP      | Nothing                                    |
+| `https://notes.example.com` — behind a reverse proxy     | `BETTER_AUTH_URL` and `TRUST_PROXY`, below |
+| A frontend hosted on a **different** origin from the API | Add that origin to `CLIENT_URL`            |
+
+**Is trusting the host safe?** Yes. It does not mean "trust everyone" — it means
+"trust the address this request was actually sent to". A browser always sets
+`Host` to the server it is talking to, so a malicious page on `evil.com` reaches
+you as `Origin: https://evil.com` with `Host: notes.example.com`. Those differ,
+so it is still refused. Cross-site request forgery protection is unchanged.
+
+Set `TRUST_HOST=false` if you would rather pin the app to an explicit list. Then
+only the origins in `CLIENT_URL` are accepted, which is how the app behaved
+before this option existed.
+
+#### Serving over HTTPS
+
+Two extra settings, and they matter:
+
+```bash
+BETTER_AUTH_URL=https://notes.example.com
+TRUST_PROXY=1
+```
+
+`BETTER_AUTH_URL` is what marks session cookies `Secure`, so the browser will
+only ever send them over an encrypted connection. **Without it your sessions are
+sent in the clear**, because the container is spoken to over plain HTTP by the
+proxy and has no way to tell that users are on HTTPS. The app warns at startup
+when `TRUST_PROXY` is set and no HTTPS address is configured.
+
+`TRUST_PROXY` is what makes login rate limiting see the real client address
+rather than the proxy's — see the section below.
+
+Your proxy must pass the original `Host` header through. Caddy and Traefik do
+this by default; for nginx add:
+
+```nginx
+proxy_set_header Host $host;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+```
+
+Avoid listing both `http://` and `https://` origins in `CLIENT_URL`. Cookies
+carry a single `Secure` setting, so one of the two schemes will always be wrong.
+Set `BETTER_AUTH_URL` to the canonical address instead; the app warns if it sees
+a mixture.
 
 #### `TRUST_PROXY` and login rate limiting
 

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -23,9 +23,19 @@ PORT=3000
 # Docker image uses at /app/storage.
 DB_FILE_NAME=file:storage/local.db
 
-# Optional. Comma-separated: every origin you open the app on (Better Auth
-# trusted origins + CORS). Defaults to the Vite dev server below, so you only
-# need this if you change the frontend port or reach the app over your LAN.
+# Optional. Accept whichever address a request arrives at, so the app works
+# over your LAN or a Tailscale address without naming each origin. On by
+# default.
+#
+# This is not "trust anyone": the browser's Origin must match the Host it sent,
+# so a page on evil.com still cannot act on your session. Set false to accept
+# only the origins in CLIENT_URL.
+# TRUST_HOST=true
+
+# Optional. Extra origins to trust, comma separated (also the CORS allowlist).
+# Defaults to the Vite dev server below. With TRUST_HOST on you only need this
+# when the frontend is served from a different origin than the API — in dev,
+# the Vite proxy makes everything same-origin, so the default is fine.
 # CLIENT_URL=http://localhost:5173
 
 # Optional. Public origin of the auth API, used as Better Auth's baseURL.

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -18,6 +18,7 @@ import { env } from './env.js';
 // Error Middlewares
 import { errorHandler, notFoundHandler } from './middlewares/errors.js';
 import { clientIp } from './middlewares/client-ip.js';
+import { originHint } from './middlewares/origin-hint.js';
 
 // REST Routers
 import { documentsRouter } from './routes/documents.js';
@@ -49,6 +50,8 @@ app.use(
     skip: (req) => req.originalUrl.split('?')[0] === '/api/health',
   }),
 );
+
+app.use('/api/auth', originHint);
 
 app.use('/api/auth', express.text({ type: '*/*', limit: '100kb' }));
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -19,6 +19,7 @@ import { env } from './env.js';
 import { errorHandler, notFoundHandler } from './middlewares/errors.js';
 import { clientIp } from './middlewares/client-ip.js';
 import { originHint } from './middlewares/origin-hint.js';
+import { proxyHint } from './middlewares/proxy-hint.js';
 
 // REST Routers
 import { documentsRouter } from './routes/documents.js';
@@ -50,6 +51,8 @@ app.use(
     skip: (req) => req.originalUrl.split('?')[0] === '/api/health',
   }),
 );
+
+app.use(proxyHint);
 
 app.use('/api/auth', originHint);
 

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -33,6 +33,29 @@ export const envSchema = z.object({
         return /^\d+$/.test(val) ? Number(val) : val;
       }),
   ),
+  /**
+   * Accept a request whose `Origin` matches the host it arrived on, so the app
+   * works at whatever address users reach it by — a LAN IP, a hostname, a
+   * Tailscale address, a public domain — without naming each one up front.
+   *
+   * On by default because a container cannot know the address users type, and
+   * the alternative is a 403 at sign-up that reads as a broken app. CSRF
+   * protection is unaffected: a browser always sets `Host` to the server it is
+   * talking to, so a cross-site request still fails the origin match.
+   *
+   * Set `false` to trust only the origins named in `CLIENT_URL`.
+   */
+  TRUST_HOST: z.preprocess(
+    (val) => {
+      if (typeof val !== 'string') return val;
+      const normalised = val.trim().toLowerCase();
+      if (normalised === '') return undefined;
+      if (['true', '1', 'yes', 'on'].includes(normalised)) return true;
+      if (['false', '0', 'no', 'off'].includes(normalised)) return false;
+      return val;
+    },
+    z.boolean({ message: 'TRUST_HOST must be true or false.' }).default(true),
+  ),
   /** Public origin of the auth API (same as the web app when using the Nginx proxy). Overrides first CLIENT_URL for Better Auth `baseURL`. */
   BETTER_AUTH_URL: z.preprocess(
     (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -54,7 +54,7 @@ export const envSchema = z.object({
       if (['false', '0', 'no', 'off'].includes(normalised)) return false;
       return val;
     },
-    z.boolean({ message: 'TRUST_HOST must be true or false.' }).default(true),
+    z.boolean({ error: 'TRUST_HOST must be true or false.' }).default(true),
   ),
   /** Public origin of the auth API (same as the web app when using the Nginx proxy). Overrides first CLIENT_URL for Better Auth `baseURL`. */
   BETTER_AUTH_URL: z.preprocess(

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -5,6 +5,7 @@
 
 import server from './app.js';
 import { env } from './env.js';
+import { originConfig } from './lib/auth.js';
 import { clientUrlWarning } from './lib/client-url.js';
 import { getSocket } from './lib/socket.js';
 import { hasWebBundle } from './lib/web.js';
@@ -20,12 +21,21 @@ const SHUTDOWN_TIMEOUT_MS = 8_000;
 server.listen(env.PORT, () => {
   console.log(`Server is running on http://localhost:${env.PORT}`);
   console.log(`Trusted origins (CLIENT_URL): ${env.CLIENT_URL.join(', ')}`);
+  console.log(
+    env.TRUST_HOST
+      ? 'TRUST_HOST=true: also trusting whichever host a request arrives on.'
+      : 'TRUST_HOST=false: only the origins above are accepted.',
+  );
+  console.log(`Session cookies Secure: ${originConfig.useSecureCookies}`);
+
+  for (const warning of originConfig.warnings) console.warn(warning);
 
   const warning = clientUrlWarning({
     clientUrls: env.CLIENT_URL,
     port: env.PORT,
     servesWebBundle: hasWebBundle(),
     behindProxy: env.TRUST_PROXY !== false,
+    trustHost: env.TRUST_HOST,
   });
 
   if (warning) console.warn(warning);

--- a/apps/backend/src/lib/auth.ts
+++ b/apps/backend/src/lib/auth.ts
@@ -8,6 +8,7 @@ import { APIError } from 'better-auth/api';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { bearer, customSession, openAPI, username } from 'better-auth/plugins';
 import { db } from './db.js';
+import { resolveOriginConfig } from './origin.js';
 import { env } from '../env.js';
 import { users } from '../models/auth.js';
 import { getEditorSettings, setEditorSettings } from '../services/editor-settings.js';
@@ -24,13 +25,28 @@ export const isSignupEnabled = async (): Promise<boolean> => {
   return existingUsers.length === 0;
 };
 
+/**
+ * Which origins to trust and whether cookies are `Secure`. Exported so startup
+ * can report the decision and surface any warnings it produced.
+ */
+export const originConfig = resolveOriginConfig({
+  clientUrls: env.CLIENT_URL,
+  betterAuthUrl: env.BETTER_AUTH_URL,
+  trustHost: env.TRUST_HOST,
+  behindProxy: env.TRUST_PROXY !== false,
+});
+
 export const options = {
   database: adapter,
   emailAndPassword: {
     enabled: true,
   },
-  baseURL: env.BETTER_AUTH_URL ?? env.CLIENT_URL[0],
-  trustedOrigins: env.CLIENT_URL,
+  baseURL: originConfig.baseURL,
+  trustedOrigins: originConfig.trustedOrigins,
+  advanced: {
+    useSecureCookies: originConfig.useSecureCookies,
+    trustedProxyHeaders: originConfig.trustedProxyHeaders,
+  },
   user: {
     additionalFields: {
       cover: {

--- a/apps/backend/src/lib/client-url.ts
+++ b/apps/backend/src/lib/client-url.ts
@@ -22,12 +22,17 @@ export const clientUrlWarning = ({
   port,
   servesWebBundle,
   behindProxy,
+  trustHost,
 }: {
   clientUrls: string[];
   port: number;
   servesWebBundle: boolean;
   behindProxy: boolean;
+  trustHost: boolean;
 }): string | null => {
+  // With TRUST_HOST on, the host a request arrives at is trusted regardless of
+  // what CLIENT_URL names, so a port mismatch is no longer a failure.
+  if (trustHost) return null;
   if (!servesWebBundle || behindProxy) return null;
   if (clientUrls.some((origin) => originPort(origin) === port)) return null;
 

--- a/apps/backend/src/lib/origin.ts
+++ b/apps/backend/src/lib/origin.ts
@@ -1,0 +1,198 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Works out which origins Better Auth should trust, and whether session cookies
+ * should carry the `Secure` flag.
+ *
+ * The problem this solves: a container cannot know the address users type. It
+ * sees `0.0.0.0:8080`, while the browser might be at `http://192.168.1.50:8080`,
+ * `https://notes.example.com`, or a Tailscale address. Better Auth rejects any
+ * request whose `Origin` is not trusted, so a mismatch surfaces as a 403 at
+ * sign-up — which reads as a broken app rather than a configuration problem.
+ */
+
+import { existsSync } from 'node:fs';
+
+/**
+ * Resolves the origins to trust for one request.
+ *
+ * Deliberately NOT Better Auth's dynamic `baseURL` with `allowedHosts: ['*']`.
+ * That expands to the literal entries `https://*` and `http://*` in the trusted
+ * list, which match every origin — including an attacker's — and so disables
+ * CSRF protection entirely rather than binding trust to the request's own host.
+ */
+export type TrustedOriginResolver = (request?: Request) => string[];
+
+export type OriginConfig = {
+  baseURL: string;
+  trustedOrigins: string[] | TrustedOriginResolver;
+  /**
+   * Set explicitly rather than left to Better Auth, which infers it from the
+   * scheme of `baseURL`. That inference reads whichever origin happens to be
+   * first in `CLIENT_URL`, so a list like
+   * `http://localhost:8080,https://notes.example.com` would strip `Secure` from
+   * cookies served over HTTPS. Deciding it here from the operator's declared
+   * public address keeps the two from disagreeing.
+   */
+  useSecureCookies: boolean;
+  /**
+   * Whether `X-Forwarded-Host` / `X-Forwarded-Proto` may be believed. Better
+   * Auth defaults this to `true`, which trusts headers any client can send when
+   * no proxy is present. Tied to `TRUST_PROXY` so the two cannot disagree.
+   */
+  trustedProxyHeaders: boolean;
+  warnings: string[];
+};
+
+const isHttps = (origin: string): boolean => origin.startsWith('https://');
+
+const hostOf = (origin: string): string | null => {
+  try {
+    return new URL(origin).hostname;
+  } catch {
+    return null;
+  }
+};
+
+const LOOPBACK = new Set(['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0']);
+
+const isLoopback = (origin: string): boolean => {
+  const host = hostOf(origin);
+  return host !== null && LOOPBACK.has(host);
+};
+
+/**
+ * True when the process is running inside a container.
+ *
+ * Detected by the marker files the runtimes create rather than an environment
+ * variable: Docker sets no variable of its own, and anything we set ourselves
+ * would be absent when the image is run by something other than our compose
+ * files.
+ */
+export const inContainer = (): boolean =>
+  existsSync('/.dockerenv') || existsSync('/run/.containerenv');
+
+export const resolveOriginConfig = ({
+  clientUrls,
+  betterAuthUrl,
+  trustHost,
+  behindProxy,
+  containerised = inContainer(),
+}: {
+  clientUrls: string[];
+  betterAuthUrl?: string;
+  trustHost: boolean;
+  behindProxy: boolean;
+  containerised?: boolean;
+}): OriginConfig => {
+  const warnings: string[] = [];
+
+  // Whether TLS is in play is something only the operator knows. Behind a proxy
+  // the container is spoken to over plain HTTP even when users are on HTTPS, so
+  // it cannot be detected from the socket. `BETTER_AUTH_URL` wins when set,
+  // because it names the canonical public address.
+  const declaredHttps = betterAuthUrl ? isHttps(betterAuthUrl) : clientUrls.some(isHttps);
+
+  const baseURL = betterAuthUrl ?? clientUrls[0];
+
+  /**
+   * Accepts an `Origin` whose host equals the host the request arrived on.
+   *
+   * This is what keeps CSRF protection intact. A browser always sets `Host` to
+   * the server it is actually talking to, so a cross-site request from evil.com
+   * arrives as `Origin: https://evil.com` with `Host: notes.example.com` — the
+   * hosts differ, and it is refused. An attacker cannot make a victim's browser
+   * send a forged `Host` without already controlling DNS for that name.
+   *
+   * Both schemes are allowed for the matched host. Behind a TLS-terminating
+   * proxy the container is spoken to over plain HTTP while the browser reports
+   * an `https://` origin, and requiring the schemes to agree would reject every
+   * such deployment that had not also set `TRUST_PROXY`. Accepting both adds no
+   * real exposure: reaching the same host over the other scheme already means
+   * controlling that host.
+   */
+  const trustRequestHost: TrustedOriginResolver = (request) => {
+    // Better Auth may resolve trusted origins outside a request. With no host to
+    // bind to, fall back to the explicit list rather than trusting anything.
+    if (!request) return clientUrls;
+
+    const forwarded = behindProxy ? request.headers.get('x-forwarded-host') : null;
+    const host = forwarded?.split(',')[0]?.trim() || request.headers.get('host');
+
+    if (!host) return clientUrls;
+
+    return [...clientUrls, `https://${host}`, `http://${host}`];
+  };
+
+  if (behindProxy && !declaredHttps) {
+    warnings.push(
+      [
+        '',
+        '  ⚠  TRUST_PROXY is set but no HTTPS address is configured.',
+        '',
+        '     Session cookies will be sent without the Secure flag, so a browser',
+        '     will also send them over plain HTTP. A reverse proxy almost always',
+        '     means users reach this app over HTTPS.',
+        '',
+        '     Fix: set BETTER_AUTH_URL to the address users type, then restart.',
+        '       BETTER_AUTH_URL=https://notes.example.com',
+        '',
+        '     Safe to ignore only if the proxy really does serve plain HTTP.',
+        '',
+      ].join('\n'),
+    );
+  }
+
+  const mixed = clientUrls.some(isHttps) && clientUrls.some((u) => !isHttps(u));
+
+  if (mixed && !betterAuthUrl) {
+    warnings.push(
+      [
+        '',
+        '  ⚠  CLIENT_URL mixes http:// and https:// origins.',
+        '',
+        `     CLIENT_URL   ${clientUrls.join(', ')}`,
+        '',
+        '     Cookies carry one Secure setting for all of them, so one scheme will',
+        '     always be wrong: Secure cookies are dropped on http, and omitting',
+        '     Secure exposes the session over http.',
+        '',
+        '     Fix: set BETTER_AUTH_URL to the canonical address users type.',
+        '',
+      ].join('\n'),
+    );
+  }
+
+  if (!trustHost && containerised && clientUrls.every(isLoopback)) {
+    warnings.push(
+      [
+        '',
+        '  ⚠  TRUST_HOST is off and CLIENT_URL only names loopback addresses.',
+        '',
+        `     CLIENT_URL   ${clientUrls.join(', ')}`,
+        '',
+        '     Inside a container, "localhost" is the container itself — not how',
+        '     anyone reaches this app. Every browser on another machine will be',
+        '     refused at sign-in with "403 Invalid origin", while pages and health',
+        '     checks keep working, so it reads as a rejected password.',
+        '',
+        '     Fix: set CLIENT_URL to the address users type, or leave TRUST_HOST',
+        '     on and let the app accept whichever host the request arrived on.',
+        '',
+      ].join('\n'),
+    );
+  }
+
+  return {
+    baseURL,
+    // Additive: the request's own host is trusted on top of these, so an
+    // explicit CLIENT_URL keeps working exactly as before.
+    trustedOrigins: trustHost ? trustRequestHost : clientUrls,
+    useSecureCookies: declaredHttps,
+    trustedProxyHeaders: behindProxy,
+    warnings,
+  };
+};

--- a/apps/backend/src/middlewares/origin-hint.ts
+++ b/apps/backend/src/middlewares/origin-hint.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { RequestHandler } from 'express';
+import { env } from '../env.js';
+
+/**
+ * Explains origin rejections in the server log.
+ *
+ * Better Auth answers an untrusted `Origin` with a bare `403 Invalid origin`.
+ * The browser shows it as a failed sign-in, and the operator has no way to see
+ * which origin was sent or which ones were trusted — the two facts needed to fix
+ * it. Rather than guess, print both.
+ *
+ * Only fires on 403 responses that carried an `Origin`, so ordinary
+ * authorisation failures stay quiet.
+ */
+export const originHint: RequestHandler = (req, res, next) => {
+  const origin = req.headers.origin;
+
+  if (origin) {
+    res.on('finish', () => {
+      if (res.statusCode !== 403) return;
+
+      console.warn(
+        [
+          '',
+          `  ⚠  403 on ${req.method} ${req.originalUrl} from Origin: ${origin}`,
+          '',
+          `     Host header   ${req.headers.host ?? '(none)'}`,
+          `     CLIENT_URL    ${env.CLIENT_URL.join(', ')}`,
+          `     TRUST_HOST    ${env.TRUST_HOST}`,
+          '',
+          env.TRUST_HOST
+            ? [
+                '     TRUST_HOST is on, so this Origin should have been accepted if it',
+                '     matched the Host above. When they differ — a separately hosted',
+                '     frontend, or a proxy rewriting Host — add the Origin to CLIENT_URL.',
+              ].join('\n')
+            : [
+                '     TRUST_HOST is off, so only the origins in CLIENT_URL are accepted.',
+                '     Add the Origin above to CLIENT_URL, or set TRUST_HOST=true to accept',
+                '     whichever host the request arrived on.',
+              ].join('\n'),
+          '',
+          '     If this was a permissions failure rather than an origin one, ignore this.',
+          '',
+        ].join('\n'),
+      );
+    });
+  }
+
+  next();
+};

--- a/apps/backend/src/middlewares/origin-hint.ts
+++ b/apps/backend/src/middlewares/origin-hint.ts
@@ -7,6 +7,20 @@ import type { RequestHandler } from 'express';
 import { env } from '../env.js';
 
 /**
+ * Makes a request-derived value safe to put in a log line. These values are
+ * attacker-controlled: embedded newlines would let a client forge entire log
+ * entries, and ANSI escape bytes can restyle or hide text in the terminal of
+ * whoever runs `docker logs`. Control characters become spaces rather than
+ * being dropped so the length of what was sent stays visible, and anything
+ * absurdly long is cut — no legitimate Origin or path is 300 characters.
+ */
+const sanitizeForLog = (value: string): string => {
+  // eslint-disable-next-line no-control-regex
+  const cleaned = value.replace(/[\u0000-\u001f\u007f\u2028\u2029]/g, ' ');
+  return cleaned.length > 300 ? `${cleaned.slice(0, 300)}…` : cleaned;
+};
+
+/**
  * Explains origin rejections in the server log.
  *
  * Better Auth answers an untrusted `Origin` with a bare `403 Invalid origin`.
@@ -27,9 +41,9 @@ export const originHint: RequestHandler = (req, res, next) => {
       console.warn(
         [
           '',
-          `  ⚠  403 on ${req.method} ${req.originalUrl} from Origin: ${origin}`,
+          `  ⚠  403 on ${req.method} ${sanitizeForLog(req.originalUrl)} from Origin: ${sanitizeForLog(origin)}`,
           '',
-          `     Host header   ${req.headers.host ?? '(none)'}`,
+          `     Host header   ${sanitizeForLog(req.headers.host ?? '(none)')}`,
           `     CLIENT_URL    ${env.CLIENT_URL.join(', ')}`,
           `     TRUST_HOST    ${env.TRUST_HOST}`,
           '',

--- a/apps/backend/src/middlewares/proxy-hint.ts
+++ b/apps/backend/src/middlewares/proxy-hint.ts
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { RequestHandler } from 'express';
+import { env } from '../env.js';
+import { originConfig } from '../lib/auth.js';
+
+/**
+ * One-time hint when a TLS-terminating proxy appears to be in front of the app
+ * but the app has not been told about it.
+ *
+ * This is the default state of a Coolify or Dokploy install: the platform's
+ * Traefik terminates HTTPS and forwards plain HTTP, and unless the operator
+ * sets TRUST_PROXY and BETTER_AUTH_URL, everything works — but session cookies
+ * are not marked Secure, and login rate limiting keys on the proxy's address
+ * instead of the client's. Nothing fails, so nothing prompts the operator to
+ * finish the job. The startup warnings cannot catch it either: at boot there is
+ * no request to look at.
+ *
+ * The `X-Forwarded-Proto: https` header is used purely as a hint to log a
+ * message. It is NOT trusted for any security decision — that stays gated on
+ * TRUST_PROXY — so a client sending the header directly can trigger this log
+ * line once, and nothing else.
+ */
+let hinted = false;
+
+export const proxyHint: RequestHandler = (req, _res, next) => {
+  if (!hinted && env.TRUST_PROXY === false) {
+    const raw = req.headers['x-forwarded-proto'];
+    const proto = (Array.isArray(raw) ? raw[0] : raw)?.split(',')[0]?.trim();
+
+    if (proto === 'https') {
+      hinted = true;
+
+      console.warn(
+        [
+          '',
+          '  ⚠  Requests carry X-Forwarded-Proto: https, but TRUST_PROXY is not set.',
+          '',
+          '     A reverse proxy (Traefik, Caddy, nginx — e.g. a Coolify or Dokploy',
+          '     install) appears to terminate TLS in front of this app. The app works,',
+          '     but two settings are missing:',
+          '',
+          '       TRUST_PROXY=1',
+          '         Login rate limiting currently sees every user as the proxy',
+          '         address, so all users share one bucket.',
+          ...(originConfig.useSecureCookies
+            ? []
+            : [
+                '',
+                '       BETTER_AUTH_URL=https://your-domain',
+                '         Session cookies are currently not marked Secure, so a',
+                '         downgrade to plain HTTP would expose them.',
+              ]),
+          '',
+          '     See "Serving over HTTPS" in DOCKER.md. This hint is logged once.',
+          '',
+        ].join('\n'),
+      );
+    }
+  }
+
+  next();
+};

--- a/docker-compose.public.yml
+++ b/docker-compose.public.yml
@@ -36,11 +36,17 @@ services:
       - NODE_ENV=production
       - PORT=8080
       - DB_FILE_NAME=file:/app/storage/local.db
-      # Every origin you reach the app on, comma separated. Must match the
-      # address in your browser, or logging in will fail. The default follows
-      # HOST_PORT, so changing the published port alone cannot leave this
-      # pointing at the wrong address.
+      # Accept whichever address a request arrives at, so this works on a LAN IP,
+      # a hostname, a Tailscale address or a domain without naming each one.
+      # Not "trust anyone": the browser's Origin must match the Host it sent, so
+      # cross-site requests are still refused. Set false to accept only
+      # CLIENT_URL.
+      - TRUST_HOST=${TRUST_HOST:-true}
+      # Extra origins to trust, on top of the one above. Only needed when the
+      # frontend is served from a different origin than the API.
       - CLIENT_URL=${CLIENT_URL:-http://localhost:${HOST_PORT:-8080}}
+      # Set to the address users type when serving over HTTPS. This is what
+      # marks session cookies Secure — without it they travel in the clear.
       - BETTER_AUTH_URL=${BETTER_AUTH_URL:-}
       # Deliberately has no default. A shipped default would be a published
       # secret, and anyone running it unchanged could forge sessions.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - TRUST_HOST=${TRUST_HOST:-true}
       # Extra origins to trust, on top of the one above. Only needed when the
       # frontend is served from a different origin than the API.
-      - CLIENT_URL=${CLIENT_URL:-http://localhost:8080}
+      - CLIENT_URL=${CLIENT_URL:-http://localhost:${HOST_PORT:-8080}}
       # Set to the address users type when serving over HTTPS. This is what
       # marks session cookies Secure — without it they travel in the clear.
       - BETTER_AUTH_URL=${BETTER_AUTH_URL:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,16 @@ services:
       - NODE_ENV=production
       - PORT=8080
       - DB_FILE_NAME=file:/app/storage/local.db
+      # Accept whichever address a request arrives at, so the app works on a LAN
+      # IP, a hostname or a domain without naming each one. Not "trust anyone":
+      # the Origin must match the Host the browser sent, so cross-site requests
+      # are still refused. Set false to accept only CLIENT_URL.
+      - TRUST_HOST=${TRUST_HOST:-true}
+      # Extra origins to trust, on top of the one above. Only needed when the
+      # frontend is served from a different origin than the API.
       - CLIENT_URL=${CLIENT_URL:-http://localhost:8080}
+      # Set to the address users type when serving over HTTPS. This is what
+      # marks session cookies Secure — without it they travel in the clear.
       - BETTER_AUTH_URL=${BETTER_AUTH_URL:-}
       # Deliberately has no default. A default committed to a public repo is a
       # published secret, and anyone running it unchanged could forge sessions.

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turborepo.com/schema.json",
-  "globalEnv": ["VITE_BACKEND_URL", "DB_FILE_NAME", "WEB_DIR", "TRUST_PROXY"],
+  "globalEnv": ["VITE_BACKEND_URL", "DB_FILE_NAME", "WEB_DIR", "TRUST_PROXY", "TRUST_HOST"],
   "ui": "tui",
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

Self-hosting the published image failed at account creation for almost everyone.

Better Auth rejects any request whose `Origin` is not trusted, and `CLIENT_URL` defaults to `http://localhost:8080` — correct only when browsing from the Docker host itself. Reaching a Pi, a NAS, a VM or a VPS by IP or domain gave:

```
POST /api/auth/sign-up/email 403 (Forbidden)
{message: 'Invalid origin', code: 'INVALID_ORIGIN'}
```

Pages and health checks kept working, so it presented as a rejected password rather than a configuration problem. Five of the six realistic deployments were broken out of the box:

| Scenario | Before | After |
| --- | --- | --- |
| `localhost:8080` on the Docker host | ✅ | ✅ |
| LAN IP — Pi, NAS | ❌ 403 | ✅ |
| LAN hostname | ❌ 403 | ✅ |
| VPS by domain, plain HTTP | ❌ 403 | ✅ |
| Behind a reverse proxy with TLS | ❌ 403 | ✅ |
| Tailscale / VPN address | ❌ 403 | ✅ |

## Related Issues

None.

## Type of Change

Bug fix, security-relevant. Changes a default: `TRUST_HOST` is on unless set otherwise.

## Changes

### `TRUST_HOST` (new, default `true`)

An `Origin` is accepted when its host matches the host the request arrived on. `CLIENT_URL` still applies and is **additive**, so any existing configuration keeps working, and `TRUST_HOST=false` restores the previous strict behaviour exactly.

**CSRF protection is unchanged.** A browser always sets `Host` to the server it is talking to, so a page on `evil.com` arrives as `Origin: https://evil.com` with `Host: notes.example.com` — the hosts differ and it is refused. An attacker cannot make a victim's browser send a forged `Host` without already controlling DNS for that name.

> **Note for review.** This was first implemented with Better Auth's dynamic `baseURL` and `allowedHosts: ['*']`. That is wrong and dangerous: it expands to the literal entries `https://*` and `http://*` in the trusted list, which match **every** origin and disable CSRF protection outright. The test matrix caught it accepting `Origin: https://evil.com`. The shipped implementation uses a `trustedOrigins` callback that binds trust to the request's own host, and `origin.ts` carries a comment explaining why the other approach must not be used.

### Session cookies could lose `Secure` over HTTPS

`baseURL` was `BETTER_AUTH_URL ?? CLIENT_URL[0]`, and Better Auth infers the `Secure` flag from that URL's scheme. So a perfectly reasonable `CLIENT_URL=http://localhost:8080,https://notes.example.com` served **session cookies without `Secure` to HTTPS users**, silently.

Now derived from the declared public address, and startup warns when `TRUST_PROXY` is set without an HTTPS address configured.

### `X-Forwarded-Host` was trusted unconditionally

Better Auth defaults `trustedProxyHeaders` to `true`, so the header was believed even with no proxy in front. Now tied to `TRUST_PROXY`.

### The startup check that should have caught this

[`client-url.ts`](apps/backend/src/lib/client-url.ts) compares only the **port**. With `CLIENT_URL=http://localhost:8080` and the server on 8080 it concluded all was well and stayed silent — the mismatch was in the hostname. It now defers to `TRUST_HOST`.

### Rejected origins are now explained

Better Auth returns a bare 403; the operator could not see which origin was sent or which were trusted. New middleware logs both, plus the `Host` and `TRUST_HOST` state.

### One-time hint for unconfigured TLS proxies (second commit)

The Coolify / Dokploy default — the platform's Traefik terminates HTTPS, forwards plain HTTP — is the one misconfiguration no startup warning can catch: sign-up works thanks to `TRUST_HOST`, nothing fails, so nothing tells the operator that cookies are not `Secure` and rate limiting keys on the proxy's address. At boot there is no request to inspect.

New middleware: when a request carries `X-Forwarded-Proto: https` while `TRUST_PROXY` is unset, log a **one-time** hint naming `BETTER_AUTH_URL` and `TRUST_PROXY` (cookie half dropped if `BETTER_AUTH_URL` is already set). The header is used only to decide whether to print the hint — never for a security decision, which stays gated on `TRUST_PROXY` — so a client sending it directly triggers one log line and nothing else.

### Docs

`DOCKER.md` gains a **Deployment scenarios** table (including a Coolify/Dokploy row), a **Serving over HTTPS** section, and a **Coolify, Dokploy and similar platforms** section (zero-config sign-in, the two production settings, and the `/app/storage` persistent volume without which redeploys lose all data). Both `.env.example` files (root and `apps/backend/`, the latter rewritten by #78) and both compose files document `TRUST_HOST` and the HTTPS requirement.

## How to Test

```bash
docker build -t wordyme:test . && docker run -d --name wm -p 8099:8080 \
  -e BETTER_AUTH_SECRET="$(openssl rand -base64 32)" wordyme:test
```

Note that **no `CLIENT_URL` is set** — this is a default self-host.

1. Sign up through a non-localhost address:
   ```bash
   curl -s -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1:8099/api/auth/sign-up/email \
     -H 'Host: 192.168.1.50:8099' -H 'Origin: http://192.168.1.50:8099' \
     -H 'Content-Type: application/json' \
     -d '{"email":"a@b.co","password":"TestPassw0rd!","name":"a"}'
   ```
2. Confirm a cross-site origin is still refused:
   ```bash
   curl -s -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1:8099/api/auth/sign-in/email \
     -H 'Host: 192.168.1.50:8099' -H 'Origin: https://evil.com' \
     -H 'Content-Type: application/json' -d '{"email":"a@b.co","password":"TestPassw0rd!"}'
   ```
3. Confirm the flag is what changed it — rerun step 1 against a container started with `-e TRUST_HOST=false`.
4. Check `docker logs wm` for the startup lines and, in step 3, the rejection diagnostic.

**Expected result:** 1 → `200`; 2 → `403`; 3 → `403` plus a logged explanation naming the Origin, the Host and `CLIENT_URL`.

Verified with an 11-case matrix against a running server — origin accepted for LAN IP / domain / Tailscale, refused for `evil.com` and for a lookalike subdomain, previous behaviour intact under `TRUST_HOST=false`, `CLIENT_URL` additive, `X-Forwarded-Host` refused without `TRUST_PROXY` and honoured with it, cookies `Secure` only when an HTTPS address is declared. The full matrix was re-run after rebasing onto `main` (post-#78), and the image was rebuilt and re-verified end to end: sign-up/sign-in 200 from a LAN-style host, CSRF and forged-header cases 403, web app and health 200, plain-HTTP cookies `HttpOnly`/`SameSite=Lax` without `Secure`, HTTPS-declared cookies carrying the `__Secure-` prefix, and the `TRUST_PROXY`-without-HTTPS warning firing exactly when it should. (One sign-in during the run answered 429 — that is the login rate limiter reacting to five rapid attempts from one address, and the same request returned 200 after the window.)

The proxy hint has its own 4-case matrix: fires once across repeated requests, silent when `TRUST_PROXY` is set, silent without the header, and drops the cookie line when an HTTPS address is declared.

Backend lints and typechecks clean. The pre-existing `web` typecheck error at `src/queries/revisions.ts:152` and the `@repo/shared` / `@repo/lib` lint warnings are unrelated and present on `main`.

## Reviewer notes

1. **`TRUST_HOST` defaulting to on** is the decision worth a second opinion — it changes behaviour for existing deployments on upgrade. The argument for it is that the current default produces a broken first run for nearly every self-hoster. Anyone wanting the old behaviour sets `TRUST_HOST=false`.
2. **Accepting both schemes for a matched host.** Behind a TLS proxy the container is spoken to over plain HTTP while the browser reports `https://`, so requiring the schemes to agree would break every proxy deployment that had not also set `TRUST_PROXY`. Reaching the same host over the other scheme already implies controlling that host, so this looks like no real exposure — worth a check.
3. **The Host-poisoning caveat.** Host-derived trust is safe here partly because the app sends no email and configures no social providers, so no absolute URL is built from `Host`. That stops being true the day password reset or OAuth is added. Noted in `origin.ts`.
4. **CORS** (`app.ts`) is still pinned to `CLIENT_URL`. That is harmless today because the container serves the frontend same-origin, but it is inconsistent with `TRUST_HOST` and would bite anyone hosting the frontend separately. Left alone deliberately — say if you want it aligned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable host trust behavior for authentication and cross-origin requests.
  * Added support for HTTPS-aware origin detection, secure cookies, and trusted proxy headers.
  * Added startup and request diagnostics for common proxy, origin, and cookie configuration issues.

* **Documentation**
  * Expanded environment and deployment guidance for HTTPS, reverse proxies, trusted origins, and host configuration.
  * Added `TRUST_HOST` configuration examples and clarified `CLIENT_URL` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->