### PR TITLE
fix(security): update socket.io-parser past CVE-2026-69185

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "picomatch": "^4.0.4",
       "qs": "^6.15.2",
       "serialize-javascript": "^7.0.5",
-      "socket.io-parser": "^4.2.6",
+      "socket.io-parser": "^4.2.7",
       "tar": "^7.5.19",
       "basic-ftp": "^5.2.1",
       "undici": "^6.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ overrides:
   picomatch: ^4.0.4
   qs: ^6.15.2
   serialize-javascript: ^7.0.5
-  socket.io-parser: ^4.2.6
+  socket.io-parser: ^4.2.7
   tar: ^7.5.19
   basic-ftp: ^5.2.1
   undici: ^6.24.0
@@ -8110,8 +8110,8 @@ packages:
     resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
     engines: {node: '>=10.0.0'}
 
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
     engines: {node: '>=10.0.0'}
 
   socket.io@4.8.3:
@@ -16754,13 +16754,13 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
       engine.io-client: 6.6.4
-      socket.io-parser: 4.2.6
+      socket.io-parser: 4.2.7
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6:
+  socket.io-parser@4.2.7:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
@@ -16775,7 +16775,7 @@ snapshots:
       debug: 4.4.3
       engine.io: 6.6.9
       socket.io-adapter: 2.5.6
-      socket.io-parser: 4.2.6
+      socket.io-parser: 4.2.7
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
CVE-2026-69185 (CVSS 7.5) affects socket.io-parser >=4.0.0 <4.2.7. The image shipped 4.2.6, reached through socket.io, so it is production code on the WebSocket path rather than build tooling.

The fix has been available for 19 days: 4.2.7 was published on 15 July, well outside the 4-day `minimumReleaseAge` quarantine, and the existing `^4.2.6` override already permitted it. Nothing upgraded because the lockfile pins the version it first resolved — a caret in an override is a floor, not a subscription.

Raises the override floor to ^4.2.7 so a future resolution cannot land back on a vulnerable version, and refreshes the lockfile. The lockfile diff is six lines and touches nothing else.

Verified: authenticated Socket.io client connects over WebSocket and round-trips a packet on 4.2.7; built image contains 4.2.7 where the published 1.2.0 contains 4.2.6; container serves the web app, health, sign-up and the Socket.io handshake normally.

## Summary

<!-- Briefly describe what this PR does and why it's needed. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close issues when merged. -->

Fixes #

## Type of Change

<!-- Examples: Bug fix, New feature, Breaking change, Refactor, Documentation, Performance improvement -->

## Changes

<!-- List key changes in bullet points. Be specific. -->

-
-

## How to Test

<!-- Provide clear steps for reviewers to verify your changes work as expected. -->

1.
2.
3.

**Expected result:**

## Screenshots

<!-- Required for UI changes. Include before/after screenshots or videos. Remove this section if not a UI change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Socket.IO parser package override to version 4.2.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->