### PR TITLE
docs: correct the origin guidance left stale by TRUST_HOST

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -26,12 +26,22 @@ Or with plain `docker run`:
 docker run -d \
   -p 8080:8080 \
   -e BETTER_AUTH_SECRET="$(openssl rand -base64 32)" \
-  -e CLIENT_URL=http://localhost:8080 \
   -v wordyme-storage:/app/storage \
   teamcoderz/wordyme:latest
 ```
 
-`BETTER_AUTH_SECRET` is required — it signs session cookies and deliberately has no default. `CLIENT_URL` must match the address you open in the browser, or sign-in is rejected.
+`BETTER_AUTH_SECRET` is the only required setting — it signs session cookies and deliberately has no default.
+
+**Reaching it from another machine** — a Pi or NAS on your LAN, a VPS by domain, a Tailscale address — needs no extra configuration. The app accepts whichever address the request arrives on, so `http://192.168.1.50:8080` works as-is. This is not "trust anyone": the browser's `Origin` still has to match the `Host` it sent, so a page on another site cannot act on your session.
+
+**Serving over HTTPS** behind a reverse proxy needs two settings, and the first matters:
+
+```console
+  -e BETTER_AUTH_URL=https://notes.example.com \
+  -e TRUST_PROXY=1 \
+```
+
+`BETTER_AUTH_URL` is what marks session cookies `Secure`; the container is spoken to over plain HTTP by the proxy and cannot detect TLS by itself. `TRUST_PROXY` makes login rate limiting see the real client rather than the proxy. The app logs a one-time hint if it notices forwarded HTTPS traffic without these set.
 
 ## Tags
 

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -93,13 +93,19 @@ Changing this value later invalidates existing sessions and logs everyone out.
 
 The remaining settings have working defaults:
 
-| Variable          | Default                 | Notes                                         |
-| ----------------- | ----------------------- | --------------------------------------------- |
-| `PORT`            | `3000`                  | Backend port                                  |
-| `DB_FILE_NAME`    | `file:storage/local.db` | Created on first migration                    |
-| `CLIENT_URL`      | `http://localhost:5173` | Trusted origins — must match your browser URL |
-| `BETTER_AUTH_URL` | first `CLIENT_URL`      | Public origin of the auth API                 |
-| `TRUST_PROXY`     | unset                   | Leave unset locally                           |
+| Variable          | Default                 | Notes                                          |
+| ----------------- | ----------------------- | ---------------------------------------------- |
+| `PORT`            | `3000`                  | Backend port                                   |
+| `DB_FILE_NAME`    | `file:storage/local.db` | Created on first migration                     |
+| `TRUST_HOST`      | `true`                  | Also trust the address each request arrives on |
+| `CLIENT_URL`      | `http://localhost:5173` | Extra trusted origins, added to the one above  |
+| `BETTER_AUTH_URL` | first `CLIENT_URL`      | Public origin of the auth API                  |
+| `TRUST_PROXY`     | unset                   | Leave unset locally                            |
+
+With `TRUST_HOST` on, an `Origin` is accepted when it matches the host the
+request arrived at, so reaching the dev server over your LAN works without
+listing that address. Set it to `false` to accept only `CLIENT_URL`, which is
+how the app behaved before this option existed.
 
 Upgrading an existing clone? `DB_FILE_NAME` used to default to `file:local.db`.
 An `.env` you already have keeps working untouched, but if you replace it from


### PR DESCRIPTION
#79 made the app accept whichever address a request arrives on, but the change never reached two documents that describe configuration.

DOCKERHUB.md is the worse of the two, because it is the Docker Hub listing — the first thing a self-hoster reads, and it is synced to the live listing on release. It stated:

  CLIENT_URL must match the address you open in the browser, or sign-in
  is rejected.

That has not been true since 1.2.0, and the `docker run` example passed `-e CLIENT_URL=http://localhost:8080` — the exact configuration that produces "403 Invalid origin" for anyone browsing from another machine, which is how this whole problem was found in the first place. Someone following the listing today would copy it, reach the app from their laptop, and conclude it is broken.

Drops CLIENT_URL from the example, states that LAN, VPN and domain access need no configuration, keeps the reason it is not "trust anyone" (Origin must still match Host), and adds the two settings an HTTPS deployment does need.

LOCAL_SETUP.md's environment table omitted TRUST_HOST entirely and still described CLIENT_URL as origins that "must match your browser URL".

Verified against the published ghcr.io/teamcoderz/wordyme:1.2.1 using the exact command now in the listing: sign-up from a LAN-style host 200, from a public domain 200, cross-site origin 403. DOCKERHUB.md is 4,368 bytes, well inside Docker Hub's 25,000-byte cap.

## Summary

<!-- Briefly describe what this PR does and why it's needed. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close issues when merged. -->

Fixes #

## Type of Change

<!-- Examples: Bug fix, New feature, Breaking change, Refactor, Documentation, Performance improvement -->

## Changes

<!-- List key changes in bullet points. Be specific. -->

-
-

## How to Test

<!-- Provide clear steps for reviewers to verify your changes work as expected. -->

1.
2.
3.

**Expected result:**

## Screenshots

<!-- Required for UI changes. Include before/after screenshots or videos. Remove this section if not a UI change. -->
