### PR TITLE
chore(ci): allow CI and the SPDX check to be run manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,17 @@ on:
   push:
     branches:
       - main
+  # Manual runs, from Actions → CI → Run workflow. A check that only ever fires
+  # on an event you cannot replay leaves you stuck when the failure was GitHub's
+  # rather than the code's. `pr-title` and the arm64 cache warm both gate on
+  # event type, so a manual run does exactly the two jobs worth repeating:
+  # lint/type-check/build, and the Docker health check.
+  #
+  # To clear a required check on a pull request, prefer "Re-run all jobs" on
+  # that pull request's own run: it reports against the same commit, which is
+  # what the branch ruleset reads. This is for asking "is CI itself broken?"
+  # against a branch, outside any pull request.
+  workflow_dispatch:
 
 concurrency:
   # Supersede in-flight runs for the same ref. A superseded run tells you

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+  # Manual runs, from Actions → SPDX Header Check → Run workflow. Same reasoning
+  # as CI: a required check you cannot replay is a trap when the failure was
+  # GitHub's rather than the code's.
+  workflow_dispatch:
 
 jobs:
   license-check:


### PR DESCRIPTION
## Summary

Neither `ci.yml` nor `license-header.yml` could be started on demand — both fired only on `pull_request` and `push` to main. When GitHub itself is why a run dies, there was no way to ask *"is CI broken, or is my branch?"* without pushing a commit or reopening someone else's pull request.

This came out of last night's outage, which left #91 with all three required checks stuck on *"Expected — waiting for status to be reported"* and no operator-side way to retry them.

Adds a **Run workflow** button to each. Two lines of actual change; the rest is comments.

## Related Issues

None. Follow-up to the outage that stranded the checks on #91.

## Type of Change

Chore / developer experience (CI). Non-breaking — adds a trigger, changes no job logic.

## Changes

- `.github/workflows/ci.yml` — added `workflow_dispatch:` to the `on:` block
- `.github/workflows/license-header.yml` — same

Points worth a reviewer's attention:

- **The existing job conditions make this land correctly with no further changes.** `pr-title` gates on `if: github.event_name == 'pull_request'` and `docker-arm64-cache` on `if: github.event_name == 'push'`, so both skip on a manual run. A dispatch does exactly the two jobs worth repeating — `Lint, type-check, build` and `Docker stack health`.
- **This is deliberately not the way to clear a stuck required check.** A dispatched run targets a *branch*, while the branch ruleset reads check runs against the pull request's commit. **"Re-run all jobs" on the pull request's own run** is the tool for that, and it already existed — the gap was only that nothing could be started outside a pull request at all. Both cases are spelled out in the comments so nobody reaches for the wrong one under pressure.
- No job, step, permission or action version changed.

## How to Test

1. Confirm both files still parse and stay Prettier-clean:

   ```bash
   pnpm exec prettier --check .github/workflows/ci.yml .github/workflows/license-header.yml
   ```

2. After merge, check the button exists: **Actions → CI** (left sidebar) → a **Run workflow** dropdown should appear top right. Same under **Actions → SPDX Header Check**.

3. Run CI manually against `main` from that dropdown.

**Expected result:**

1. `All matched files use Prettier code style!`
2. The **Run workflow** button appears on both. It only shows once the workflow is on the default branch — that is GitHub's rule, not a fault in this change, so it will not be visible on this pull request's own branch.
3. The run starts and shows four jobs: `Lint, type-check, build` ✅, `Docker stack health` ✅, with `Conventional PR title` and `Warm the arm64 build cache` both **skipped**, since neither applies outside their event.

Step 1 was run against this branch. Steps 2 and 3 can only be verified after merge, because of GitHub's default-branch rule for `workflow_dispatch`.

## Screenshots

Not a UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the ability to manually run continuous integration checks.
  * Added the ability to manually run license header validation.
  * Existing event-based job conditions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->