### PR TITLE
fix(dx): correct the prepare fallback message, which named the wrong cause

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "license:check": "node scripts/spdx-license-cli.mjs check",
     "check-types": "turbo run check-types",
     "start": "turbo start",
-    "prepare": "lefthook install || echo 'lefthook: hooks not installed, git unavailable. Expected during Docker builds; otherwise run: pnpm exec lefthook install'"
+    "prepare": "lefthook install || echo 'lefthook: hooks not installed. Expected during Docker builds, which have no Git; otherwise run: pnpm exec lefthook install'"
   },
   "devDependencies": {
     "@release-it/conventional-changelog": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "license:check": "node scripts/spdx-license-cli.mjs check",
     "check-types": "turbo run check-types",
     "start": "turbo start",
-    "prepare": "lefthook install || echo 'lefthook: no git repository, skipping hook install'"
+    "prepare": "lefthook install || echo 'lefthook: hooks not installed, git unavailable. Expected during Docker builds; otherwise run: pnpm exec lefthook install'"
   },
   "devDependencies": {
     "@release-it/conventional-changelog": "^10.0.6",


### PR DESCRIPTION
## Summary

The `prepare` guard added in #89 works — Docker builds pass and hooks install on a real checkout — but the message it prints names the wrong cause. It says "no git repository" when what actually happens in the build image is that the `git` binary is missing entirely. Anyone debugging a build would go hunting for a `.git` that was never the problem.

One line changed. No behaviour change.

## Related Issues

None. Follow-up to #89.

## Type of Change

Bug fix (developer experience / diagnostics). Non-breaking.

## Changes

- `package.json` — reworded the `prepare` script's fallback message:
  - **Before:** `lefthook install || echo 'lefthook: no git repository, skipping hook install'`
  - **After:** `lefthook install || echo 'lefthook: hooks not installed, git unavailable. Expected during Docker builds; otherwise run: pnpm exec lefthook install'`
- The new text does three things the old one did not: names the real cause, states that seeing it during a Docker build is expected so nobody chases it, and gives the exact command that fixes the case that does matter — a developer whose hooks silently did not install and who otherwise finds out when CI fails their first pull request for a missing licence header.

## How to Test

1. Confirm hooks still install on a real checkout:

   ```bash
   rm -f .git/hooks/pre-commit && pnpm install && ls .git/hooks/pre-commit
   ```

2. Confirm the guard still exits `0` when git is unavailable, so it cannot fail an image build:

   ```bash
   mkdir /tmp/nogit && cd /tmp/nogit && cp <repo>/lefthook.yml .
   PATH="<repo>/node_modules/.bin:$PATH" sh -c "lefthook install || echo 'guard fired'"; echo "exit: $?"
   ```

3. Confirm a real image build succeeds and prints the corrected line:

   ```bash
   docker build -t wordyme-guard:test . 2>&1 | grep -A1 'prepare\$'
   ```

**Expected result:**

1. `.git/hooks/pre-commit` exists again, and the install log shows `prepare: sync hooks: ✔️ (pre-commit)`.
2. `guard fired`, `exit: 0`.
3. Build exits `0` and prints `lefthook: hooks not installed, git unavailable. Expected during Docker builds; otherwise run: pnpm exec lefthook install`.

All three were run against this branch before pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup messaging for Docker builds without Git.
  * Added a recovery command for installing development hooks when automatic setup is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->