### PR TITLE
fix(deps): raise the nanoid floor to ^5.1.16 and bump dompurify and pnpm/action-setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       # Before setup-node: `cache: 'pnpm'` shells out to pnpm to locate the
       # store, so pnpm has to exist first.
       - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -84,7 +84,7 @@ jobs:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - **deps:** raise the axios floor to ^1.18.0 to clear its advisories ([#90](https://github.com/TeamCoderz/WordyMe/issues/90)) ([a09c174](https://github.com/TeamCoderz/WordyMe/commit/a09c1741fe55fd9b8f9a661614dd7580a9e5389d))
+- **deps:** raise the nanoid floor to ^5.1.16 to clear CVE-2026-67214
 - **dx:** correct the prepare fallback message, which named the wrong cause ([#94](https://github.com/TeamCoderz/WordyMe/issues/94)) ([5b5a4d4](https://github.com/TeamCoderz/WordyMe/commit/5b5a4d4857e46809c42b6a5798c00364c90ac3a6)), closes [#89](https://github.com/TeamCoderz/WordyMe/issues/89)
 - **pdf:** serve the PDFium engine and fallback fonts from our own origin ([#93](https://github.com/TeamCoderz/WordyMe/issues/93)) ([25cec37](https://github.com/TeamCoderz/WordyMe/commit/25cec378389f14f3431ca3b7dc50986aba390364))
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -32,7 +32,7 @@
     "express": "^5.2.1",
     "formidable": "^3.5.4",
     "morgan": "^1.11.0",
-    "nanoid": "^5.1.6",
+    "nanoid": "^5.1.16",
     "p-queue": "^9.1.0",
     "socket.io": "^4.8.3",
     "zod": "^4.3.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -41,7 +41,7 @@
     "cropperjs": "^2.1.0",
     "date-fns": "^4.1.0",
     "day-time-greet": "^1.0.6",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.13",
     "mobile-drag-drop": "3.0.0-rc.0",
     "react": "^19.2.4",
     "react-cropper": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       "lodash": "^4.18.0",
       "lodash-es": "^4.18.0",
       "mermaid": "^10.9.4",
-      "nanoid": "^5.1.6",
+      "nanoid": "^5.1.16",
       "path-to-regexp": "^8.4.2",
       "picomatch": "^4.0.5",
       "qs": "^6.15.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "overrides": {
       "minimatch@3.1.5>brace-expansion": "1.1.16",
       "defu": "^6.1.7",
-      "dompurify": "^3.4.12",
+      "dompurify": "^3.4.13",
       "engine.io": "^6.6.7",
       "esbuild": "^0.25.0",
       "flatted": "^3.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   lodash: ^4.18.0
   lodash-es: ^4.18.0
   mermaid: ^10.9.4
-  nanoid: ^5.1.6
+  nanoid: ^5.1.16
   path-to-regexp: ^8.4.2
   picomatch: ^4.0.5
   qs: ^6.15.2
@@ -101,8 +101,8 @@ importers:
         specifier: ^1.11.0
         version: 1.11.0
       nanoid:
-        specifier: ^5.1.6
-        version: 5.1.7
+        specifier: ^5.1.16
+        version: 5.1.16
       p-queue:
         specifier: ^9.1.0
         version: 9.1.0
@@ -7272,8 +7272,8 @@ packages:
   nan@2.25.0:
     resolution: {integrity: sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==}
 
-  nanoid@5.1.7:
-    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -10309,7 +10309,7 @@ snapshots:
       jotai-scope: 0.7.2(jotai@2.11.0(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       lodash.debounce: 4.0.8
       lodash.throttle: 4.1.1
-      nanoid: 5.1.7
+      nanoid: 5.1.16
       open-color: 1.9.1
       pako: 2.0.3
       perfect-freehand: 1.2.0
@@ -10342,7 +10342,7 @@ snapshots:
     dependencies:
       '@excalidraw/markdown-to-text': 0.1.2
       mermaid: 10.9.5
-      nanoid: 5.1.7
+      nanoid: 5.1.16
     transitivePeerDependencies:
       - supports-color
 
@@ -10910,7 +10910,7 @@ snapshots:
       '@floating-ui/dom': 1.7.6
       '@types/css-tree': 2.3.11
       css-tree: 3.2.1
-      nanoid: 5.1.7
+      nanoid: 5.1.16
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -12175,7 +12175,7 @@ snapshots:
   '@scalar/types@0.7.3':
     dependencies:
       '@scalar/helpers': 0.4.1
-      nanoid: 5.1.7
+      nanoid: 5.1.16
       type-fest: 5.4.4
       zod: 4.3.6
 
@@ -15758,7 +15758,7 @@ snapshots:
   nan@2.25.0:
     optional: true
 
-  nanoid@5.1.7: {}
+  nanoid@5.1.16: {}
 
   nanostores@1.2.0: {}
 
@@ -16118,13 +16118,13 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 5.1.7
+      nanoid: 5.1.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.8:
     dependencies:
-      nanoid: 5.1.7
+      nanoid: 5.1.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   minimatch@3.1.5>brace-expansion: 1.1.16
   defu: ^6.1.7
-  dompurify: ^3.4.12
+  dompurify: ^3.4.13
   engine.io: ^6.6.7
   esbuild: ^0.25.0
   flatted: ^3.4.4
@@ -240,8 +240,8 @@ importers:
         specifier: ^1.0.6
         version: 1.0.6
       dompurify:
-        specifier: ^3.4.12
-        version: 3.4.12
+        specifier: ^3.4.13
+        version: 3.4.13
       mobile-drag-drop:
         specifier: 3.0.0-rc.0
         version: 3.0.0-rc.0
@@ -5581,8 +5581,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -12541,7 +12541,7 @@ snapshots:
 
   '@types/dompurify@3.2.0':
     dependencies:
-      dompurify: 3.4.12
+      dompurify: 3.4.13
 
   '@types/esrecurse@4.3.1': {}
 
@@ -13909,7 +13909,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -15490,7 +15490,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.13
       dayjs: 1.11.20
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       elkjs: 0.9.3
       katex: 0.16.38
       khroma: 2.1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security-sensitive dependencies to newer versions, including protections for a documented `nanoid` vulnerability.
  * Updated the web application’s sanitization library.

* **Chores**
  * Refreshed CI and release workflow tooling to a newer pinned version.
  * Documented the dependency security updates in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->