### PR TITLE
fix(brand): call the app WordyMe everywhere it names itself

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -84,7 +84,7 @@ app.get(
       { title: 'WordyMe API', url: '/api/docs/openapi.json' },
       { title: 'Better-Auth API', url: '/api/auth/open-api/generate-schema' },
     ],
-    pageTitle: 'Wordy API Documentation',
+    pageTitle: 'WordyMe API Documentation',
   }),
 );
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -16,7 +16,7 @@
       content="Centralized platform for students to manage educational information"
     />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <title>Wordy</title>
+    <title>WordyMe</title>
   </head>
   <body class="bg-background text-base antialiased">
     <div id="app"></div>

--- a/apps/web/src/components/Layout/app-header.tsx
+++ b/apps/web/src/components/Layout/app-header.tsx
@@ -57,14 +57,32 @@ export const AppHeader = () => {
         )}
       >
         <div className="flex w-full h-14 justify-between items-center overflow-hidden">
+          {/* Fixed from xs (400px) up, so the logo, wordmark, toggle and divider
+              hold their positions at every width anyone resizes a window to —
+              anything breakpoint-dependent slides them sideways instead. Width
+              tracks --sidebar-width to stay in line with the sidebar below it;
+              that variable is 16rem everywhere the header can see it, since the
+              18rem mobile override is scoped to the sidebar's own Sheet.
+
+              Below xs it has to give. The fixed block is 256px and the controls
+              on the right need 143px, so 399px is the floor — under that the
+              parent is overflow-hidden and the avatar gets clipped, which is
+              the only route to Settings and Log out. So on the smallest phones
+              the wordmark drops and the block shrinks to its contents, taking
+              the row to ~96px. The mark alone still identifies the app. */}
           <div
             className={cn(
-              'flex justify-between items-center gap-2 h-full px-4 shrink-0 w-56 sm:w-(--sidebar-width) sm:border-r',
+              'flex justify-between items-center gap-2 h-full pl-2 pr-4 shrink-0 border-r',
+              'w-auto xs:w-(--sidebar-width)',
             )}
           >
-            <Link to="/" className="flex items-center font-logo gap-2 shrink-0" data-new-tab="true">
-              <img src={logo} alt="Wordy" className="size-8" />
-              <p className="font-extrabold text-lg font-logo">Wordy</p>
+            <Link
+              to="/"
+              className="flex items-center font-logo gap-1.5 shrink-0"
+              data-new-tab="true"
+            >
+              <img src={logo} alt="WordyMe" className="size-8" />
+              <p className="font-extrabold text-lg font-logo hidden xs:block">WordyMe</p>
             </Link>
             <SidebarTrigger variant="outline" className="size-9 p-2!" />
           </div>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -54,8 +54,8 @@ export default defineConfig(({ mode }) => {
           'maskable-512.png',
         ],
         manifest: {
-          name: 'Wordy',
-          short_name: 'Wordy',
+          name: 'WordyMe',
+          short_name: 'WordyMe',
           description: 'Centralized platform for students to manage educational information',
           theme_color: '#000000',
           background_color: '#ffffff',

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -3,6 +3,14 @@
 @import 'tw-animate-css';
 @import './themes.css';
 
+@theme {
+  /* Tailwind's smallest default breakpoint is sm at 40rem, which leaves every
+     phone in one bucket. 25rem (400px) splits it: iPhone SE and the standard
+     iPhone sit below, everything from the Plus sizes up sits above. Gives
+     `xs:` and `max-xs:` variants. */
+  --breakpoint-xs: 25rem;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;


### PR DESCRIPTION
## Summary

Updates the app name from "Wordy" to "WordyMe" everywhere the product names itself — browser tab, header wordmark, PWA manifest, and backend page title — and reworks the header's small-screen behavior so the logo and wordmark stay pinned to the left edge at every width, with the wordmark dropping out below a new `xs` (25rem) breakpoint instead of ever clipping the avatar. App internally reflets the repo name.

## Related Issues

None — branding follow-up for the WordyMe naming update

Fixes # — n/a

## Type of Change

Branding fix + responsive UI adjustment.

## Changes

- `apps/web/index.html` — browser tab title is now **WordyMe**.
- `apps/web/vite.config.ts` — PWA manifest `name` and `short_name` are now **WordyMe** (what users see when installing the app).
- `apps/backend/src/app.ts` — backend-rendered page title is now **WordyMe**.
- `apps/web/src/components/Layout/app-header.tsx` — wordmark text and logo alt-text read **WordyMe**; the logo/wordmark block is pinned to the viewport's left edge (`pl-2`) at all widths; logo-to-wordmark spacing set to `gap-1.5`; below the new `xs` breakpoint the wordmark hides (`hidden xs:block`) and the block shrinks (`w-auto xs:w-(--sidebar-width)`) so the header never clips.
- `packages/ui/src/styles/globals.css` — adds the custom `xs` breakpoint at **25rem** to the Tailwind theme.
- Deliberately **not** changed: the `persist({ name: 'Wordy' })` localStorage key — renaming it would silently reset existing users' UI state for zero user-visible benefit.

## How to Test

1. `pnpm dev`, open the web app — the browser tab reads **WordyMe**, and the header shows the logo + **WordyMe** wordmark at the left edge.
2. Narrow the window below ~400px — the wordmark disappears, the logo and sidebar toggle stay in place, and the right-side avatar is never clipped.
3. Widen back past 400px — the wordmark returns with no layout jump.
4. Check the PWA install prompt (or devtools → Application → Manifest) — name and short name read **WordyMe**.

**Expected result:** the product says "WordyMe" in every self-naming surface; the header logo position is stable at every viewport width; no clipping at any width; existing users keep their persisted UI state.

## Screenshots

*Visual change verified locally at multiple viewport widths; screenshots omitted.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Branding**
  * Updated the application, browser page, API documentation, and installed app name from “Wordy” to “WordyMe.”
  * Refreshed the header logo text to display the new product name.

* **User Interface**
  * Improved the header’s responsive layout across screen sizes, including sidebar alignment, spacing, borders, and mobile visibility.
  * Added responsive breakpoint support for more consistent layouts on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->