### PR TITLE
feat(ui): refresh the dark theme

### DIFF
--- a/packages/editor/src/theme.css
+++ b/packages/editor/src/theme.css
@@ -795,19 +795,81 @@ iframe {
     border-top-color: #eee;
   }
 
+  /* Code blocks and syntax highlighting, matched to the app's dark palette.
+     These live here rather than in the design tokens because the editor
+     package carries its own stylesheet and never reads them. */
+
   .dark .LexicalTheme__code {
-    background-color: rgb(30, 30, 30);
-    color: #9cdcfe;
+    /* The raised-surface shade, not the document surface. A code block sits on
+       the page rather than being the page, so it has to lift off it — matched
+       to the same shade as cards and menus so every raised thing agrees. Set
+       equal to the document surface and the block vanishes, which is exactly
+       what happened first time round.
+
+       The body text was previously #9cdcfe — a colour reserved elsewhere for
+       *variables* — so every unhighlighted character rendered as though it
+       were one. */
+    background-color: #202122; /* raised surface */
+    color: #bfbfbf; /* body text */
   }
 
   .dark .LexicalTheme__code:before {
-    background-color: #333;
-    color: #858585;
-    border-right-color: #1e1e1e;
+    /* The gutter shares the block's surface, so only the divider separates
+       them. It is lighter than the block rather than darker: on a raised dark
+       surface a darker rule reads as a gap punched through it, a lighter one
+       as a seam. Light mode goes the other way because there the block is
+       darker than the page it sits on. */
+    background-color: #202122; /* raised surface */
+    color: #858889; /* line numbers */
+    border-right-color: #2a2b2c; /* divider */
   }
 
   .dark .LexicalTheme__code:after {
-    color: #858585;
+    color: #858889; /* line numbers */
+  }
+
+  /* Syntax highlighting. These classes had no dark rules at all, so dark mode
+     was showing Prism's default *light* palette — #905 magenta, #690 green,
+     #07a blue — over a dark block. Lexical groups several Prism token types
+     onto each class, so each takes the colour of whichever kind dominates it. */
+
+  .dark .LexicalTheme__tokenComment {
+    color: #8b949e; /* comment */
+  }
+
+  .dark .LexicalTheme__tokenPunctuation {
+    color: #d4d4d4; /* punctuation */
+  }
+
+  .dark .LexicalTheme__tokenProperty {
+    color: #b5cea8; /* constant.numeric */
+  }
+
+  .dark .LexicalTheme__tokenSelector {
+    color: #a5d6ff; /* string */
+  }
+
+  .dark .LexicalTheme__tokenOperator {
+    color: #d4d4d4; /* keyword.operator */
+  }
+
+  .dark .LexicalTheme__tokenAttr {
+    color: #ff7b72; /* keyword */
+  }
+
+  .dark .LexicalTheme__tokenVariable {
+    color: #ffa657; /* variable */
+  }
+
+  .dark .LexicalTheme__tokenFunction {
+    color: #d2a8ff; /* entity.name.function */
+  }
+
+  /* Inline code had no dark rule either, so it kept the light pill —
+     rgb(225 230 235 / 44%) — which is why it reads as a pale block. */
+  .dark .LexicalTheme__textCode {
+    background-color: #262626; /* textPreformat.background */
+    color: #8c8c8c; /* textPreformat.foreground */
   }
 
   .dark .LexicalTheme__tableCell {

--- a/packages/ui/src/styles/themes.css
+++ b/packages/ui/src/styles/themes.css
@@ -192,41 +192,46 @@
 
 .dark {
   color-scheme: dark;
-  --background: oklch(0.2603 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.23 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.23 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(0.2891 0 0);
-  --input: oklch(0.2478 0 0);
-  --ring: oklch(0.556 0 0);
-  --sidebar: oklch(0.2478 0 0);
-  --sidebar-foreground: oklch(0.708 0 0);
-  --sidebar-primary: oklch(0.922 0 0);
-  --sidebar-primary-foreground: oklch(0.205 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.708 0 0);
-  --sidebar-border: oklch(0.23 0 0);
-  --sidebar-ring: oklch(0.551 0.027 264.364);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-
-  --top-bar-primary-background: oklch(0.2478 0 0);
-  --top-bar-secondary-background: oklch(0.2478 0 0);
-  --home-card-background: oklch(0.2478 0 0);
+  /* Dark palette. The greys are deliberately cool rather than neutral —
+     #121314, #191A1B and #2A2B2C are all R<G<B. That tint is the character of
+     the theme: a neutral grey of the same lightness reads as flat and slightly
+     wrong beside it, which is hard to spot by eye and easy to "correct" by
+     accident. Translucent surfaces are pre-composited over the surface they
+     actually sit on, so every token here is opaque. */
+  --background: oklch(0.186 0.0026 247.966); /* #121314 document surface */
+  --foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+  --card: oklch(0.2471 0.0024 247.923); /* #202122 raised panel */
+  --card-foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+  --popover: oklch(0.2471 0.0024 247.923); /* #202122 command palette */
+  --popover-foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+  --primary: oklch(0.5482 0.0964 233.03); /* #297AA0 primary action */
+  --primary-foreground: oklch(1 0 0); /* #FFFFFF primary action text */
+  --secondary: oklch(0.2686 0 0); /* #262626 inline code surface */
+  --secondary-foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+  --muted: oklch(0.2686 0 0); /* #262626 inline code surface */
+  --muted-foreground: oklch(0.6401 0 0); /* #8C8C8C secondary text */
+  --accent: oklch(0.2925 0.0023 247.904); /* #2B2C2D row hover, over the side panel */
+  --accent-foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+  --destructive: oklch(0.7377 0.1377 32.501); /* #F48771 error text */
+  --border: oklch(0.2884 0.0023 247.906); /* #2A2B2C panel divider */
+  --input: oklch(0.2171 0.0025 247.941); /* #191A1B field surface */
+  --ring: oklch(0.5088 0.0789 229.571); /* #2D6E8A focus ring, over the document surface */
+  --sidebar: oklch(0.2171 0.0025 247.941); /* #191A1B side panel */
+  --sidebar-foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+  --sidebar-primary: oklch(0.5482 0.0964 233.03); /* #297AA0 primary action */
+  --sidebar-primary-foreground: oklch(1 0 0); /* #FFFFFF primary action text */
+  --sidebar-accent: oklch(0.2925 0.0023 247.904); /* #2B2C2D row hover, over the side panel */
+  --sidebar-accent-foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+  --sidebar-border: oklch(0.2884 0.0023 247.906); /* #2A2B2C panel divider */
+  --sidebar-ring: oklch(0.5088 0.0789 229.571); /* #2D6E8A focus ring, over the document surface */
+  --chart-1: oklch(0.7046 0.1464 252.851); /* #57A3F8 chart blue */
+  --chart-2: oklch(0.7881 0.1253 144.273); /* #86CF86 chart green */
+  --chart-3: oklch(0.807 0.0873 76.925); /* #E0B97F chart amber */
+  --chart-4: oklch(0.6773 0.1328 306.996); /* #AD80D7 chart violet */
+  --chart-5: oklch(0.7317 0.1313 31.916); /* #EF8773 chart red */
+  --top-bar-primary-background: oklch(0.2171 0.0025 247.941); /* #191A1B title bar */
+  --top-bar-secondary-background: oklch(0.2171 0.0025 247.941); /* #191A1B tab strip */
+  --home-card-background: oklch(0.2471 0.0024 247.923); /* #202122 raised panel */
 }
 .theme-new-york {
   --background: oklch(1 0 0);
@@ -266,47 +271,60 @@
   --top-bar-secondary-background: oklch(0.9851 0 0);
   --home-card-background: oklch(0.9851 0 0);
   @variant dark {
-    --background: oklch(0.2603 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.23 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.23 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.2891 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(0.2891 0 0);
-    --input: oklch(0.2478 0 0);
-    --ring: oklch(0.556 0 0);
-    --sidebar: oklch(0.2478 0 0);
-    --sidebar-foreground: oklch(0.708 0 0);
-    --sidebar-primary: oklch(0.922 0 0);
-    --sidebar-primary-foreground: oklch(0.205 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(0.708 0 0);
-    --sidebar-border: oklch(0.2891 0 0);
-    --sidebar-ring: oklch(0.551 0.027 264.364);
-    --chart-1: oklch(0.488 0.243 264.376);
-    --chart-2: oklch(0.696 0.17 162.48);
-    --chart-3: oklch(0.769 0.188 70.08);
-    --chart-4: oklch(0.627 0.265 303.9);
-    --chart-5: oklch(0.645 0.246 16.439);
-
-    --top-bar-primary-background: oklch(0.2478 0 0);
-    --top-bar-secondary-background: oklch(0.2478 0 0);
-    --home-card-background: oklch(0.2478 0 0);
+    /* Dark palette. The greys are deliberately cool rather than neutral —
+       #121314, #191A1B and #2A2B2C are all R<G<B. That tint is the character of
+       the theme: a neutral grey of the same lightness reads as flat and slightly
+       wrong beside it, which is hard to spot by eye and easy to "correct" by
+       accident. Translucent surfaces are pre-composited over the surface they
+       actually sit on, so every token here is opaque. */
+    --background: oklch(0.186 0.0026 247.966); /* #121314 document surface */
+    --foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+    --card: oklch(0.2471 0.0024 247.923); /* #202122 raised panel */
+    --card-foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+    --popover: oklch(0.2471 0.0024 247.923); /* #202122 command palette */
+    --popover-foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+    --primary: oklch(0.5482 0.0964 233.03); /* #297AA0 primary action */
+    --primary-foreground: oklch(1 0 0); /* #FFFFFF primary action text */
+    --secondary: oklch(0.2686 0 0); /* #262626 inline code surface */
+    --secondary-foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+    --muted: oklch(0.2686 0 0); /* #262626 inline code surface */
+    --muted-foreground: oklch(0.6401 0 0); /* #8C8C8C secondary text */
+    --accent: oklch(0.2925 0.0023 247.904); /* #2B2C2D row hover, over the side panel */
+    --accent-foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+    --destructive: oklch(0.7377 0.1377 32.501); /* #F48771 error text */
+    --border: oklch(0.2884 0.0023 247.906); /* #2A2B2C panel divider */
+    --input: oklch(0.2171 0.0025 247.941); /* #191A1B field surface */
+    --ring: oklch(0.5088 0.0789 229.571); /* #2D6E8A focus ring, over the document surface */
+    --sidebar: oklch(0.2171 0.0025 247.941); /* #191A1B side panel */
+    --sidebar-foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+    --sidebar-primary: oklch(0.5482 0.0964 233.03); /* #297AA0 primary action */
+    --sidebar-primary-foreground: oklch(1 0 0); /* #FFFFFF primary action text */
+    --sidebar-accent: oklch(0.2925 0.0023 247.904); /* #2B2C2D row hover, over the side panel */
+    --sidebar-accent-foreground: oklch(0.8047 0 0); /* #BFBFBF body text */
+    --sidebar-border: oklch(0.2884 0.0023 247.906); /* #2A2B2C panel divider */
+    --sidebar-ring: oklch(
+      0.5088 0.0789 229.571
+    ); /* #2D6E8A focus ring, over the document surface */
+    --chart-1: oklch(0.7046 0.1464 252.851); /* #57A3F8 chart blue */
+    --chart-2: oklch(0.7881 0.1253 144.273); /* #86CF86 chart green */
+    --chart-3: oklch(0.807 0.0873 76.925); /* #E0B97F chart amber */
+    --chart-4: oklch(0.6773 0.1328 306.996); /* #AD80D7 chart violet */
+    --chart-5: oklch(0.7317 0.1313 31.916); /* #EF8773 chart red */
+    --top-bar-primary-background: oklch(0.2171 0.0025 247.941); /* #191A1B title bar */
+    --top-bar-secondary-background: oklch(0.2171 0.0025 247.941); /* #191A1B tab strip */
+    --home-card-background: oklch(0.2471 0.0024 247.923); /* #202122 raised panel */
   }
   &.color-default,
   & .color-default {
     --primary: oklch(0.2046 0 0);
     @variant dark {
-      --primary: oklch(0.922 0 0);
+      /* Applied at runtime — 'default' is the first colour variant of this
+         theme, so this rule wins over the --primary set above and is what
+         actually paints buttons. shadcn's convention here is a near-white
+         primary, which would leave every button pale while the rest of the
+         palette moved; it follows the palette's own primary instead. Light
+         mode is untouched. */
+      --primary: oklch(0.5482 0.0964 233.03); /* #297AA0 primary action */
     }
   }
 
@@ -944,7 +962,14 @@
   --top-bar-primary-background: oklch(0.9851 0 0);
   --top-bar-secondary-background: oklch(0.9851 0 0);
   @variant dark {
-    --top-bar-primary-background: oklch(0.269 0 0);
+    /* This block is applied at runtime and comes after the theme blocks, so it
+       is what actually paints the header — the value set alongside the rest of
+       the palette never survives to here. The header, the tab strip and the
+       side panel are all the same shade deliberately: that is what makes the
+       chrome read as a single surface with the document inset into it, rather
+       than as three stacked bars. */
+    --top-bar-primary-background: oklch(0.2171 0.0025 247.941); /* #191A1B title bar */
+    --top-bar-secondary-background: oklch(0.2171 0.0025 247.941); /* #191A1B tab strip */
   }
 }
 


### PR DESCRIPTION
## Summary

Refreshes the dark theme with a calmer, deeper palette: the document surface, sidebar, and top bar get distinct dark tones instead of one flat color, the primary accent moves to a desaturated blue that sits better on dark surfaces, and the editor's code blocks — previously invisible in dark mode because their background matched the document — get a proper raised surface, a visible gutter divider, and a full set of syntax highlighting colors tuned for dark backgrounds. Light mode is untouched.

## Related Issues

None — visual refresh of the default dark theme, agreed in design review.

Fixes # — n/a

## Type of Change

UI enhancement (theme refresh, dark mode only).

## Changes

- `packages/ui/src/styles/themes.css` — reworked dark palette: document surface `#121314`, sidebar `#191A1B`, primary accent `#297AA0`, with matched borders, cards, popovers and sidebar tokens; the `.color-default` and `.top-bar-default` variants get explicit dark-mode overrides so themed headers follow the new surfaces.
- `packages/editor/src/theme.css` — dark-mode code blocks get a raised surface (`#202122`) distinct from the document background, a gutter divider (`#2a2b2c`), and dark-tuned syntax scopes: muted gray comments, light-blue strings, red keywords, orange variables, purple functions.
- All color comments describe the color's **functional role** (document surface, raised surface, divider) so future edits don't depend on knowing where the values came from.

## How to Test

1. `pnpm dev`, open the web app, and switch the appearance to **dark** (Settings → theme).
2. Check the overall app: the document area, sidebar, and top bar should be three subtly distinct dark surfaces — no flat single-color look, no pure-black anywhere.
3. Open a document containing a code block: the block must be clearly visible against the page, with a visible line-number gutter divider.
4. Type some code in the block (comments, strings, keywords) — syntax colors should be legible and distinct.
5. Switch back to **light** mode — everything must look exactly as it does on `main` (no light-mode changes in this PR).

**Expected result:** dark mode has visible depth across surfaces, readable code blocks with dark-tuned syntax colors, and light mode is pixel-identical to before.

## Screenshots

*(Attaching: dark mode before/after of the main app view, and a code block in dark mode before/after.)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark-mode styling for code blocks, gutters, line numbers, syntax highlighting, and inline code.
  * Refreshed dark-theme colors across surfaces, text, controls, sidebars, charts, and application chrome.
  * Updated dark-mode title bars and tab strips for a more consistent appearance.
  * Updated the dark New York theme and default dark accent color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->