### PR TITLE
fix(web): proxy /socket.io in development so real-time features connect

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -104,6 +104,20 @@ export default defineConfig(({ mode }) => {
       proxy: {
         '/api': { target: 'http://localhost:3000', changeOrigin: true },
         '/storage': { target: 'http://localhost:3000', changeOrigin: true },
+        // Socket.io connects to the current origin, because VITE_BACKEND_URL is
+        // forced empty in development (above) so that nothing bakes a hostname
+        // into a production bundle. Without this entry the handshake reaches
+        // Vite, falls through to the SPA fallback, and the client is handed
+        // index.html where it expects an Engine.IO packet — so it fails and
+        // retries every few seconds, forever.
+        //
+        // ws: true is not optional. The handshake advertises
+        // `upgrades: ["websocket"]`, so the transport switches immediately
+        // afterwards, and the upgrade fails without it even once polling works.
+        //
+        // Production needs no equivalent: the backend serves the web bundle and
+        // the socket from one origin, which is why this only ever broke locally.
+        '/socket.io': { target: 'http://localhost:3000', changeOrigin: true, ws: true },
       },
     },
     preview: {


### PR DESCRIPTION
## Summary

Fixes real-time features (live collaboration, presence, update notifications) being silently broken in local development. The Socket.io client connects to the current origin — the Vite dev server — but Vite had no proxy rule for `/socket.io`, so the handshake fell through to the SPA fallback and received `index.html` where the client expected an Engine.IO packet. The client then failed and retried every few seconds, forever. Production was never affected, because there the backend serves both the web bundle and the socket from one origin.

## Related Issues

None — found while testing real-time behavior against the local setup guide.

Fixes # — n/a

## Type of Change

Bug fix (development environment only; zero production impact).

## Changes

- `apps/web/vite.config.ts` — adds a `/socket.io` entry to the dev-server proxy, targeting the backend at `http://localhost:3000`, alongside the existing `/api` and `/storage` rules.
- `ws: true` is set deliberately: the Socket.io handshake advertises a WebSocket upgrade and the transport switches immediately after connecting, so without WebSocket proxying the connection would fail right after the initial polling succeeded.
- A comment in the config explains why the rule exists and why production needs no equivalent — so it doesn't get "cleaned up" later by someone who can't reproduce the problem in a production build.

## How to Test

1. On `main`, run `pnpm dev`, open the web app, and watch the browser devtools Network tab (filter: `socket.io`) — requests repeat every few seconds and the responses are HTML, not socket frames.
2. Switch to this branch, restart `pnpm dev`, and reload the app.
3. Check the Network tab again — one `/socket.io` polling request succeeds, followed by a WebSocket connection (Status 101) that stays open.
4. Open the same document in two browser windows — real-time features work between them.

**Expected result:** the socket connects once and stays connected in development; no retry loop; real-time features function locally exactly as they do in production.

## Screenshots

Not a UI change — section not applicable (the Network-tab before/after from step 1 vs step 3 can be attached if useful).