### PR TITLE
docs: describe WordyMe as a self-hosted personal wiki

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -230,7 +230,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(needs.check.outputs.version, '-') }}
           labels: |
             org.opencontainers.image.title=WordyMe
-            org.opencontainers.image.description=Centralized platform for students to manage educational information
+            org.opencontainers.image.description=Your own private wiki. Self-hosted notes and documentation, light enough to run on a Raspberry Pi.
             org.opencontainers.image.vendor=TeamCoderz Ltd
             org.opencontainers.image.url=https://teamcoderz.org
             org.opencontainers.image.licenses=AGPL-3.0-or-later
@@ -351,7 +351,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(needs.check.outputs.version, '-') }}
           labels: |
             org.opencontainers.image.title=WordyMe
-            org.opencontainers.image.description=Centralized platform for students to manage educational information
+            org.opencontainers.image.description=Your own private wiki. Self-hosted notes and documentation, light enough to run on a Raspberry Pi.
             org.opencontainers.image.vendor=TeamCoderz Ltd
             org.opencontainers.image.url=https://teamcoderz.org
             org.opencontainers.image.licenses=AGPL-3.0-or-later
@@ -436,7 +436,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(needs.check.outputs.version, '-') }}
           labels: |
             org.opencontainers.image.title=WordyMe
-            org.opencontainers.image.description=Centralized platform for students to manage educational information
+            org.opencontainers.image.description=Your own private wiki. Self-hosted notes and documentation, light enough to run on a Raspberry Pi.
             org.opencontainers.image.vendor=TeamCoderz Ltd
             org.opencontainers.image.url=https://teamcoderz.org
             org.opencontainers.image.licenses=AGPL-3.0-or-later
@@ -492,7 +492,7 @@ jobs:
           # A literal rather than the repository description, which is optional
           # on GitHub and would blank the listing if it were ever unset.
           # Docker Hub caps this at 100 characters.
-          short-description: 'Self-hosted note-taking and document management for students. AGPL-3.0.'
+          short-description: 'Self-hosted personal wiki and note-taking app. AGPL-3.0.'
           # A dedicated short page, not DOCKER.md: Docker Hub truncates
           # listings at 25,000 bytes and DOCKER.md is well past that.
           readme-filepath: ./DOCKERHUB.md

--- a/.github/workflows/verify-publishing.yml
+++ b/.github/workflows/verify-publishing.yml
@@ -352,7 +352,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: ${{ env.DOCKERHUB_IMAGE }}
-          short-description: 'Self-hosted note-taking and document management for students. AGPL-3.0.'
+          short-description: 'Self-hosted personal wiki and note-taking app. AGPL-3.0.'
           # A dedicated short page, not DOCKER.md: Docker Hub truncates
           # listings at 25,000 bytes and DOCKER.md is well past that. This step
           # stays fatal here on purpose — the release workflow marks it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We're thrilled to have you here. Whether you're a first-time contributor or an e
 - **Learn and grow** — Work with modern technologies like React 19, TypeScript, and Turborepo
 - **Build your portfolio** — Meaningful open source contributions that showcase your skills
 - **Join a community** — Connect with developers who share your passion
-- **Make an impact** — Help students worldwide manage their educational information better
+- **Make an impact** — Help people own their notes and documentation instead of renting them
 
 > **Before you start:** Please search [existing issues](https://github.com/TeamCoderz/WordyMe/issues) and [pull requests](https://github.com/TeamCoderz/WordyMe/pulls) to see if someone else is working on something similar.
 
@@ -92,7 +92,7 @@ pnpm license:check     # check tracked and untracked applicable files (full-repo
 
 ## Commercial Features
 
-WordyMe™ follows an Open Core model. If you are interested in developing features intended for large institutions (e.g., SAML/SSO, advanced audit logging), please contact us first. These features often belong in our Enterprise version, and we can discuss how to best collaborate.
+WordyMe™ follows an Open Core model. If you are interested in developing features intended for large organizations (e.g., SAML/SSO, advanced audit logging), please contact us first. These features often belong in our Enterprise version, and we can discuss how to best collaborate.
 
 ---
 

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,8 +1,8 @@
 # WordyMe
 
-**A lightweight note-taking app you can self-host anywhere. Even on your Raspberry Pi.**
+**A lightweight personal wiki you can self-host anywhere. Even on your Raspberry Pi.**
 
-WordyMe is a centralized platform for students to manage educational information: rich documents with diagram (Mermaid), math (KaTeX) and music-notation support, organized into spaces, with revision history, favorites and real-time updates.
+WordyMe is a self-hosted personal wiki and note-taking app: rich documents with diagram (Mermaid), math (KaTeX) and music-notation support, organized into spaces, with revision history, favorites and real-time updates.
 
 - **One container, one port.** The web app and API are served from the same origin — no separate frontend, no reverse-proxy gymnastics required.
 - **`linux/amd64` and `linux/arm64`** in every tag. Runs on a normal server, an Apple Silicon Mac, or a Raspberry Pi 4/5.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 <img src="https://img.shields.io/badge/PRs-Welcome-brightgreen" alt="PRs Welcome">
 </p>
 
-WordyMe™ is a centralized platform for students to manage educational information. It provides a rich note-taking experience with support for documents, spaces, and a powerful editor with diagram and math support.
+WordyMe™ is a lightweight self-hosted personal wiki and note-taking app. Rich editor, one Docker container, runs anywhere — even a Raspberry Pi. Documents are organized into spaces, with diagram and math support, revision history and real-time updates.
 
 🏛 Open Core & Mission  
-WordyMe™ is built and maintained by TeamCoderz Ltd with a mission to keep powerful educational tools accessible.
+WordyMe™ is built and maintained by TeamCoderz Ltd with a mission to keep powerful, private tools in the hands of the people who use them.
 
 The Core: This repository contains the open-source core of WordyMe™, licensed under AGPL-3.0.  
-The Enterprise: We will offer a PRO version for institutions requiring Service Documentation Management, permission control, advanced SSO, audit logs, managed compliance and more. All of this will be available in our Next Generation ERP Solution: [ReactSuite](https://www.linkedin.com/showcase/reactsuite)
+The Enterprise: We will offer a PRO version for organizations requiring Service Documentation Management, permission control, advanced SSO, audit logs, managed compliance and more. All of this will be available in our next-generation ERP solution: [ReactSuite](https://www.linkedin.com/showcase/reactsuite)
 
 🚀 Overview  
 WordyMe™ is a full-stack application built as a monorepo using Turborepo. It consists of a modern React web application and an Express.js backend API, along with shared packages for editor functionality, UI components, and type definitions.

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -13,7 +13,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Centralized platform for students to manage educational information"
+      content="Your own private wiki. Self-hosted notes and documentation, light enough to run on a Raspberry Pi."
     />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <title>WordyMe</title>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -56,7 +56,8 @@ export default defineConfig(({ mode }) => {
         manifest: {
           name: 'WordyMe',
           short_name: 'WordyMe',
-          description: 'Centralized platform for students to manage educational information',
+          description:
+            'Your own private wiki. Self-hosted notes and documentation, light enough to run on a Raspberry Pi.',
           theme_color: '#000000',
           background_color: '#ffffff',
           display: 'standalone',


### PR DESCRIPTION
## Summary

The public copy still described WordyMe as "a centralized platform for students to manage educational information" — positioning the product has moved away from. Worse, the wording was inconsistent across four places that each reach a different audience, and two of them are the first thing anyone sees: the page **meta description** (what search engines index and what every shared link preview shows) and the **OCI image label**, which is baked into every published release. This replaces the education framing everywhere with one consistent description.

**"Personal wiki" is deliberate, not a synonym for "wiki."** Signup is only available while the database has no users (`apps/backend/src/lib/auth.ts:23`), so an instance holds exactly one account. The qualified term reaches people searching for a self-hosted wiki without promising collaboration the product does not offer — the unqualified word would attract users who would install it, find no way to add a teammate, and leave.

## Related Issues

None — follow-up to the WordyMe branding work.

Fixes # — n/a

## Type of Change

Documentation / copy. No behavior changes.

## Changes

- `README.md` — opening description rewritten; the mission line no longer references educational tools; the PRO paragraph now addresses "organizations" rather than "institutions", which read as schools.
- `DOCKERHUB.md` — headline and opening paragraph rewritten (this is the Docker Hub landing page).
- `CONTRIBUTING.md` — the "Make an impact" line and the Open Core paragraph no longer reference students or institutions.
- `apps/web/index.html` — meta description: *"Your own private wiki. Self-hosted notes and documentation, light enough to run on a Raspberry Pi."*
- `apps/web/vite.config.ts` — PWA manifest description matched to the same line.
- `.github/workflows/release-publish.yml` — the `org.opencontainers.image.description` label (3 occurrences, one per build target) and the Docker Hub short description.
- `.github/workflows/verify-publishing.yml` — the same short description, kept in sync.

Deliberately left alone: `'school'` / `'university'` in `icon-picker.tsx` (icon names users choose from, not copy), and the "campus NAT" examples in the Docker docs (technical illustrations of shared-IP rate limits).

## How to Test

1. `pnpm --filter web build`, then confirm the new line appears in `dist/index.html` (meta description) and `dist/manifest.webmanifest` (`description`).
2. `grep -ri "student\|educational\|edtech" --include="*.md" --include="*.html" --include="*.yml" .` (excluding `node_modules`, `dist`) returns nothing.
3. Read `README.md` and `DOCKERHUB.md` top-to-bottom — the description reads consistently in both.
4. The workflow changes take effect on the next release: the published image's `org.opencontainers.image.description` label and the Docker Hub short description update automatically.

**Expected result:** one description, used everywhere; no education framing left in public copy.

## Screenshots

Not a UI change — section not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated product messaging to present WordyMe as a lightweight, private, self-hosted wiki and note-taking app.
  * Highlighted Docker and Raspberry Pi deployment, revision history, and real-time updates.
  * Refined contribution and commercial feature descriptions to reflect broader personal and organizational use.

* **Chores**
  * Updated marketplace, application, and PWA descriptions to consistently reflect the new positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->