### PR TITLE
fix(backend): resolve critical data-loss, availability and security defects

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -291,45 +291,80 @@ The application uses Docker volumes to persist data:
 
 ### Backup Database
 
-The database is a single file. It runs in SQLite's rollback-journal mode
-(`journal_mode=delete`, verifiable with `PRAGMA journal_mode`), **not** WAL, so
-there are no persistent `-wal` or `-shm` companion files to collect. A copy of
-`local.db` is the whole database.
+The database runs in SQLite's write-ahead-log mode (`journal_mode=WAL`,
+verifiable with `PRAGMA journal_mode`). Recent commits live in a companion
+`local.db-wal` file until SQLite folds them back into `local.db`, so **a copy of
+`local.db` on its own is not the whole database** — taken at the wrong moment it
+is missing your most recent edits, and on a young instance it can be missing
+everything.
 
-The safest backup is taken with the service stopped, so no write can land
-mid-copy:
+Two consequences worth knowing before you rely on a backup:
+
+- **Back up the whole `/app/storage` volume, not just `local.db`.** The database
+  holds document metadata, but the text of every revision lives in
+  `storage/revisions/` and uploads live in `storage/attachments/`. A database
+  restored without those files gives you a document list where nothing opens.
+- **Keep the volume on local disk.** WAL requires all readers to share memory
+  with the writer, which network filesystems (NFS, SMB, most NAS mounts) do not
+  provide. Pointing the volume at one risks corruption.
+
+Stopping the service first is still the safest option, and it now leaves a
+self-contained `local.db`: shutdown checkpoints the WAL back into the main file
+before exiting.
 
 ```bash
 docker compose stop wordyme
 ```
 
+Copy into a directory that does not already exist, so each backup stands alone —
+`docker compose cp` into an existing directory nests the copy inside it, leaving
+the previous backup at the path you would restore from:
+
 ```bash
-docker compose cp wordyme:/app/storage/local.db ./backup-local.db
+docker compose cp wordyme:/app/storage "./wordyme-backup-$(date +%Y%m%d-%H%M%S)"
 ```
 
 ```bash
 docker compose start wordyme
 ```
 
-Stopping costs almost nothing — shutdown completes in well under a second.
+That directory is the whole backup: `local.db` plus `revisions/`,
+`attachments/`, `images/` and `covers/`.
 
-Copying while the service is running usually works, but a write landing during
-the copy can produce a torn file that only reveals itself when you try to
-restore it. If you take live backups, verify them.
+To back up without stopping, let SQLite write the database copy for you — this
+is safe against a concurrent write, where a plain file copy is not. The target
+must not already exist, so remove any previous one first:
+
+```bash
+docker compose exec wordyme sh -c 'rm -f /app/storage/backup.db && node -e "const{createClient}=require(\"@libsql/client\");createClient({url:process.env.DB_FILE_NAME}).execute(\"VACUUM INTO \x27/app/storage/backup.db\x27\").then(()=>console.log(\"ok\"),e=>{console.error(e.message);process.exit(1)})"'
+```
+
+Then collect `backup.db` **and** the `revisions/`, `attachments/`, `images/` and
+`covers/` directories — the database alone restores a document list where
+nothing opens. Delete `backup.db` from the volume afterwards so it is not swept
+into later backups. If you take live backups, verify one by restoring it.
 
 ### Restore Database
 
-Restoring takes three steps, and skipping either of the last two fails in ways
-that are hard to spot:
+Restoring takes three steps, and getting the middle one wrong fails in ways that
+are hard to spot:
 
 - **Stop the service first.** Replacing `local.db` underneath a running SQLite
   is not safe.
+- **Restore the content files too, not only the database.** The text of every
+  revision and every upload lives beside `local.db` in the same volume. A
+  database restored on its own gives you a workspace where every document is
+  listed and none will open.
 - **Clear any leftover journal.** If the process was killed mid-write, a
-  `local.db-journal` can survive. On the next open SQLite treats it as an
-  interrupted transaction and rolls part of it back — into the file you just
-  restored. The command below removes it, along with `-wal`/`-shm`, which this
-  configuration does not use but which would matter if the journal mode ever
-  changed.
+  `local.db-journal`, `local.db-wal` or `local.db-shm` can survive. On the next
+  open SQLite treats them as belonging to the file you just restored and replays
+  or rolls back part of them into it. The command below removes all three.
+
+  This is correct when the backup is a **self-contained** `local.db` — one taken
+  with the service stopped, or produced by `VACUUM INTO`. If instead you saved
+  `local.db` together with its own `-wal` and `-shm`, restore all three and do
+  **not** delete them, or you will discard the writes they carry.
+
 - **Fix the file ownership.** `docker cp` preserves the ownership of the file on
   your machine, so the restored database arrives owned by your host user rather
   than the container's `nodejs` user. The result is a container that looks
@@ -343,10 +378,11 @@ docker compose stop wordyme
 ```
 
 ```bash
-# 2. Clear any leftover journal and stream the backup in. Streaming rather than
-#    `docker compose cp` means the file is written by the container's own user,
-#    so the ownership is correct and no chown is needed.
-docker compose run --rm -T --entrypoint sh wordyme -c 'rm -f /app/storage/local.db-journal /app/storage/local.db-wal /app/storage/local.db-shm && cat > /app/storage/local.db' < ./backup-local.db
+# 2. Clear any leftover journal and stream the whole backup in — database and
+#    content files together. Streaming rather than `docker compose cp` means
+#    everything is written by the container's own user, so the ownership is
+#    correct and no chown is needed. Use your backup directory's real name.
+tar cf - -C ./wordyme-backup-YYYYmmdd-HHMMSS . | docker compose run --rm -T --entrypoint sh wordyme -c 'rm -f /app/storage/local.db-journal /app/storage/local.db-wal /app/storage/local.db-shm && cd /app/storage && tar xf -'
 ```
 
 ```bash
@@ -354,8 +390,10 @@ docker compose run --rm -T --entrypoint sh wordyme -c 'rm -f /app/storage/local.
 docker compose start wordyme
 ```
 
-Then **verify by signing in**, not by checking that the container is healthy —
-it reports healthy either way.
+Then **verify by opening a document**, not by signing in and not by checking that
+the container is healthy. A database restored without its content files lets you
+sign in and lists every document, and the container reports healthy throughout —
+the damage only shows when a document fails to open.
 
 > **Why not `docker compose cp`?** It preserves the ownership of the file on
 > your machine, so the database arrives owned by your host user instead of the
@@ -364,6 +402,29 @@ it reports healthy either way.
 > `SQLITE_READONLY`. Streaming the bytes in avoids this entirely. Note also that
 > `chown` inside the container is not an option here: `cap_drop: ALL` removes
 > `CAP_CHOWN` and `CAP_DAC_OVERRIDE`, so not even root can do it.
+
+### Reclaiming Orphaned Files
+
+Deleting a document removes its rows and its files together. Deletions made by
+older versions removed only the rows, so their revision and attachment files are
+still on the volume, referenced by nothing. `prune-orphans.mjs` finds them.
+
+It reports and exits, changing nothing:
+
+```bash
+docker compose exec wordyme node prune-orphans.mjs
+```
+
+Remove what it listed:
+
+```bash
+docker compose exec wordyme node prune-orphans.mjs --delete
+```
+
+It refuses to run unless `DB_FILE_NAME` points at a database with the expected
+tables and at least one account, and it ignores anything modified in the last
+hour so an upload in flight is never swept. Even so, run the report first and
+read it: pointed at the wrong database, every live file looks unreferenced.
 
 ## Environment Variables
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -298,6 +298,13 @@ verifiable with `PRAGMA journal_mode`). Recent commits live in a companion
 is missing your most recent edits, and on a young instance it can be missing
 everything.
 
+Writes also run with `synchronous=NORMAL`, which lets SQLite return from a
+commit before the operating system has flushed it to disk. That is a deliberate
+trade for speed on the small machines this image targets, and it is safe against
+the app or the container dying — WAL still recovers a consistent database. The
+window it opens is narrow and specific: a **host** power cut or kernel panic can
+cost the last few commits. On a server without a UPS, take backups accordingly.
+
 Two consequences worth knowing before you rely on a backup:
 
 - **Back up the whole `/app/storage` volume, not just `local.db`.** The database

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -342,7 +342,12 @@ docker compose exec wordyme sh -c 'rm -f /app/storage/backup.db && node -e "cons
 Then collect `backup.db` **and** the `revisions/`, `attachments/`, `images/` and
 `covers/` directories — the database alone restores a document list where
 nothing opens. Delete `backup.db` from the volume afterwards so it is not swept
-into later backups. If you take live backups, verify one by restoring it.
+into later backups.
+
+Before restoring a live backup, rename `backup.db` to `local.db` inside your
+backup directory. The service only ever opens `local.db` — restore the file
+under its backup name and the app silently keeps running on the old database
+beside it. If you take live backups, verify one by restoring it.
 
 ### Restore Database
 
@@ -355,6 +360,9 @@ are hard to spot:
   revision and every upload lives beside `local.db` in the same volume. A
   database restored on its own gives you a workspace where every document is
   listed and none will open.
+- **The database must be named `local.db`.** A live backup produced
+  `backup.db`; rename it to `local.db` in your backup directory before
+  restoring, or the app keeps running on the old database beside it.
 - **Clear any leftover journal.** If the process was killed mid-write, a
   `local.db-journal`, `local.db-wal` or `local.db-shm` can survive. On the next
   open SQLite treats them as belonging to the file you just restored and replays
@@ -423,8 +431,11 @@ docker compose exec wordyme node prune-orphans.mjs --delete
 
 It refuses to run unless `DB_FILE_NAME` points at a database with the expected
 tables and at least one account, and it ignores anything modified in the last
-hour so an upload in flight is never swept. Even so, run the report first and
-read it: pointed at the wrong database, every live file looks unreferenced.
+hour, which keeps an upload in flight out of the sweep. The check is a
+snapshot, not a lock — for certainty, run `--delete` with the service stopped
+(`docker compose stop wordyme`, then `docker compose run --rm wordyme node
+prune-orphans.mjs --delete`). Always run the report first and read it: pointed
+at the wrong database, every live file looks unreferenced.
 
 ## Environment Variables
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ EXPOSE 8080
 # Hits the liveness probe, which does no database work — a container part-way
 # through its startup migrations must not be reported as broken.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
-    CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.PORT||8080)+'/api/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
+    CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.PORT||8080)+'/api/health/ready',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 
 ENTRYPOINT ["/sbin/tini", "--"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,7 @@ COPY --from=builder /app/pruned-backend .
 COPY --from=builder /app/apps/backend/dist ./dist
 COPY --from=builder /app/apps/backend/drizzle ./drizzle
 COPY --from=builder /app/apps/backend/src/scripts/run-migrations.mjs ./run-migrations.mjs
+COPY --from=builder /app/apps/backend/src/scripts/prune-orphans.mjs ./prune-orphans.mjs
 
 # Served by Express from the same origin as the API. Resolved relative to
 # ./dist, not the working directory — see apps/backend/src/lib/web.ts.
@@ -119,7 +120,7 @@ COPY --from=builder /app/apps/web/dist ./web
 # 0744 produces an image where the non-root user cannot traverse it, and
 # migrations fail with a confusing "Can't find meta/_journal.json". Normalise
 # to read-for-all, execute only where it already applies.
-RUN chmod -R a+rX ./dist ./drizzle ./web ./run-migrations.mjs
+RUN chmod -R a+rX ./dist ./drizzle ./web ./run-migrations.mjs ./prune-orphans.mjs
 
 RUN mkdir -p storage && chown -R nodejs:nodejs storage
 

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -8,9 +8,13 @@
 # committed to a public repository is a published secret, and an empty value
 # behaves exactly like no value at all.
 #
-# Better Auth does NOT fail when this is unset — it silently falls back to a
-# hard-coded default that is identical in every install, so anyone could forge a
-# session. Append your own, so the file ends up with exactly one entry:
+# Required in production: the server refuses to start without it, because Better
+# Auth would otherwise fall back to a hard-coded default that is identical in
+# every install, and anyone could forge a session. In development it may be left
+# unset, which uses that shared default — never do so on anything reachable.
+#
+# Must be at least 32 characters. Append your own, so the file ends up with
+# exactly one entry:
 #
 #   echo "BETTER_AUTH_SECRET=$(openssl rand -base64 32)" >> .env
 #

--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -1,3 +1,5 @@
 local.db
+local.db-shm
+local.db-wal
 storage/*
 !storage/.gitkeep

--- a/apps/backend/drizzle/0003_current_revision_set_null.sql
+++ b/apps/backend/drizzle/0003_current_revision_set_null.sql
@@ -1,0 +1,92 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_documents` (
+	`id` text PRIMARY KEY NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`name` text NOT NULL,
+	`handle` text NOT NULL,
+	`icon` text,
+	`position` text,
+	`current_revision_id` text,
+	`user_id` text NOT NULL,
+	`parent_id` text,
+	`document_type` text DEFAULT 'note' NOT NULL,
+	`space_id` text,
+	`is_container` integer DEFAULT false NOT NULL,
+	`client_id` text,
+	FOREIGN KEY (`current_revision_id`) REFERENCES `revisions`(`id`) ON UPDATE cascade ON DELETE set null,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE cascade ON DELETE cascade,
+	FOREIGN KEY (`parent_id`) REFERENCES `documents`(`id`) ON UPDATE cascade ON DELETE cascade,
+	FOREIGN KEY (`space_id`) REFERENCES `documents`(`id`) ON UPDATE cascade ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_documents`("id", "created_at", "updated_at", "name", "handle", "icon", "position", "current_revision_id", "user_id", "parent_id", "document_type", "space_id", "is_container", "client_id") SELECT "id", "created_at", "updated_at", "name", "handle", "icon", "position", "current_revision_id", "user_id", "parent_id", "document_type", "space_id", "is_container", "client_id" FROM `documents`;--> statement-breakpoint
+DROP TABLE `documents`;--> statement-breakpoint
+ALTER TABLE `__new_documents` RENAME TO `documents`;--> statement-breakpoint
+
+CREATE TRIGGER `documents_sync_document_search_index_after_insert`
+AFTER INSERT ON `documents`
+BEGIN
+	INSERT INTO `document_search_index` (
+		`id`,
+		`created_at`,
+		`updated_at`,
+		`document_id`,
+		`user_id`,
+		`current_revision_id`,
+		`title`,
+		`body`
+	) VALUES (
+		NEW.`id`,
+		NEW.`created_at`,
+		NEW.`updated_at`,
+		NEW.`id`,
+		NEW.`user_id`,
+		NEW.`current_revision_id`,
+		NEW.`name`,
+		COALESCE((SELECT `text` FROM `revisions` WHERE `id` = NEW.`current_revision_id`), '')
+	);
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER `documents_sync_document_search_index_after_update_name`
+AFTER UPDATE OF `name` ON `documents`
+BEGIN
+	UPDATE `document_search_index`
+		SET
+			`title` = NEW.`name`,
+			`updated_at` = NEW.`updated_at`
+		WHERE `document_id` = NEW.`id`;
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER `documents_sync_document_search_index_after_update_user`
+AFTER UPDATE OF `user_id` ON `documents`
+BEGIN
+	UPDATE `document_search_index`
+		SET
+			`user_id` = NEW.`user_id`,
+			`updated_at` = NEW.`updated_at`
+		WHERE `document_id` = NEW.`id`;
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER `documents_sync_document_search_index_after_update_current_revision`
+AFTER UPDATE OF `current_revision_id` ON `documents`
+BEGIN
+	UPDATE `document_search_index`
+		SET
+			`current_revision_id` = NEW.`current_revision_id`,
+			`body` = COALESCE((SELECT `text` FROM `revisions` WHERE `id` = NEW.`current_revision_id`), ''),
+			`updated_at` = NEW.`updated_at`
+		WHERE `document_id` = NEW.`id`;
+END;
+--> statement-breakpoint
+
+CREATE TRIGGER `documents_sync_document_search_index_after_delete`
+AFTER DELETE ON `documents`
+BEGIN
+	DELETE FROM `document_search_index` WHERE `document_id` = OLD.`id`;
+END;
+--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/apps/backend/drizzle/0004_document_indexes.sql
+++ b/apps/backend/drizzle/0004_document_indexes.sql
@@ -1,0 +1,7 @@
+CREATE INDEX `documents_user_id_idx` ON `documents` (`user_id`);--> statement-breakpoint
+CREATE INDEX `documents_parent_id_idx` ON `documents` (`parent_id`);--> statement-breakpoint
+CREATE INDEX `documents_space_id_idx` ON `documents` (`space_id`);--> statement-breakpoint
+CREATE INDEX `documents_handle_idx` ON `documents` (`handle`);--> statement-breakpoint
+CREATE INDEX `documents_current_revision_id_idx` ON `documents` (`current_revision_id`);--> statement-breakpoint
+CREATE INDEX `revisions_document_id_created_at_idx` ON `revisions` (`document_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `revisions_user_id_idx` ON `revisions` (`user_id`);

--- a/apps/backend/drizzle/meta/0003_snapshot.json
+++ b/apps/backend/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1145 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2f438703-3726-471b-914c-f8b2d3fbdb7a",
+  "prevId": "86887677-0076-4b53-ae68-cf5afbc46581",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "document_search_index": {
+      "name": "document_search_index",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "document_search_index_document_id_unique": {
+          "name": "document_search_index_document_id_unique",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": true
+        },
+        "document_search_index_user_id_idx": {
+          "name": "document_search_index_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "document_search_index_current_revision_id_idx": {
+          "name": "document_search_index_current_revision_id_idx",
+          "columns": [
+            "current_revision_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "document_search_index_document_id_documents_id_fk": {
+          "name": "document_search_index_document_id_documents_id_fk",
+          "tableFrom": "document_search_index",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "document_search_index_user_id_users_id_fk": {
+          "name": "document_search_index_user_id_users_id_fk",
+          "tableFrom": "document_search_index",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "document_search_index_current_revision_id_revisions_id_fk": {
+          "name": "document_search_index_current_revision_id_revisions_id_fk",
+          "tableFrom": "document_search_index",
+          "tableTo": "revisions",
+          "columnsFrom": [
+            "current_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "document_views": {
+      "name": "document_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "document_views_user_document_index": {
+          "name": "document_views_user_document_index",
+          "columns": [
+            "user_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "document_views_user_id_users_id_fk": {
+          "name": "document_views_user_id_users_id_fk",
+          "tableFrom": "document_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "document_views_document_id_documents_id_fk": {
+          "name": "document_views_document_id_documents_id_fk",
+          "tableFrom": "document_views",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'note'"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_container": {
+          "name": "is_container",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "documents_current_revision_id_revisions_id_fk": {
+          "name": "documents_current_revision_id_revisions_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "revisions",
+          "columnsFrom": [
+            "current_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "documents_user_id_users_id_fk": {
+          "name": "documents_user_id_users_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "documents_parent_id_documents_id_fk": {
+          "name": "documents_parent_id_documents_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "documents_space_id_documents_id_fk": {
+          "name": "documents_space_id_documents_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "editor_settings": {
+      "name": "editor_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keep_previous_revision": {
+          "name": "keep_previous_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "autosave": {
+          "name": "autosave",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "editor_settings_user_id_unique": {
+          "name": "editor_settings_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "editor_settings_user_id_users_id_fk": {
+          "name": "editor_settings_user_id_users_id_fk",
+          "tableFrom": "editor_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "favorites": {
+      "name": "favorites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "favorites_user_document_unique": {
+          "name": "favorites_user_document_unique",
+          "columns": [
+            "user_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "favorites_document_id_documents_id_fk": {
+          "name": "favorites_document_id_documents_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "revisions": {
+      "name": "revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision_name": {
+          "name": "revision_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "revisions_document_id_documents_id_fk": {
+          "name": "revisions_document_id_documents_id_fk",
+          "tableFrom": "revisions",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "revisions_user_id_users_id_fk": {
+          "name": "revisions_user_id_users_id_fk",
+          "tableFrom": "revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_images": {
+      "name": "user_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_type": {
+          "name": "image_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "zoom": {
+          "name": "zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_images_user_id_users_id_fk": {
+          "name": "user_images_user_id_users_id_fk",
+          "tableFrom": "user_images",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_meta": {
+          "name": "image_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "cover_meta": {
+          "name": "cover_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/backend/drizzle/meta/0004_snapshot.json
+++ b/apps/backend/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1197 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d1ee3feb-ad88-4aab-8b4b-0243be38bec0",
+  "prevId": "2f438703-3726-471b-914c-f8b2d3fbdb7a",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "document_search_index": {
+      "name": "document_search_index",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "document_search_index_document_id_unique": {
+          "name": "document_search_index_document_id_unique",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": true
+        },
+        "document_search_index_user_id_idx": {
+          "name": "document_search_index_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "document_search_index_current_revision_id_idx": {
+          "name": "document_search_index_current_revision_id_idx",
+          "columns": [
+            "current_revision_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "document_search_index_document_id_documents_id_fk": {
+          "name": "document_search_index_document_id_documents_id_fk",
+          "tableFrom": "document_search_index",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "document_search_index_user_id_users_id_fk": {
+          "name": "document_search_index_user_id_users_id_fk",
+          "tableFrom": "document_search_index",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "document_search_index_current_revision_id_revisions_id_fk": {
+          "name": "document_search_index_current_revision_id_revisions_id_fk",
+          "tableFrom": "document_search_index",
+          "tableTo": "revisions",
+          "columnsFrom": [
+            "current_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "document_views": {
+      "name": "document_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "document_views_user_document_index": {
+          "name": "document_views_user_document_index",
+          "columns": [
+            "user_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "document_views_user_id_users_id_fk": {
+          "name": "document_views_user_id_users_id_fk",
+          "tableFrom": "document_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "document_views_document_id_documents_id_fk": {
+          "name": "document_views_document_id_documents_id_fk",
+          "tableFrom": "document_views",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'note'"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_container": {
+          "name": "is_container",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "documents_user_id_idx": {
+          "name": "documents_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "documents_parent_id_idx": {
+          "name": "documents_parent_id_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "documents_space_id_idx": {
+          "name": "documents_space_id_idx",
+          "columns": [
+            "space_id"
+          ],
+          "isUnique": false
+        },
+        "documents_handle_idx": {
+          "name": "documents_handle_idx",
+          "columns": [
+            "handle"
+          ],
+          "isUnique": false
+        },
+        "documents_current_revision_id_idx": {
+          "name": "documents_current_revision_id_idx",
+          "columns": [
+            "current_revision_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "documents_current_revision_id_revisions_id_fk": {
+          "name": "documents_current_revision_id_revisions_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "revisions",
+          "columnsFrom": [
+            "current_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "documents_user_id_users_id_fk": {
+          "name": "documents_user_id_users_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "documents_parent_id_documents_id_fk": {
+          "name": "documents_parent_id_documents_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "documents_space_id_documents_id_fk": {
+          "name": "documents_space_id_documents_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "editor_settings": {
+      "name": "editor_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keep_previous_revision": {
+          "name": "keep_previous_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "autosave": {
+          "name": "autosave",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "editor_settings_user_id_unique": {
+          "name": "editor_settings_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "editor_settings_user_id_users_id_fk": {
+          "name": "editor_settings_user_id_users_id_fk",
+          "tableFrom": "editor_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "favorites": {
+      "name": "favorites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "favorites_user_document_unique": {
+          "name": "favorites_user_document_unique",
+          "columns": [
+            "user_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "favorites_document_id_documents_id_fk": {
+          "name": "favorites_document_id_documents_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "revisions": {
+      "name": "revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision_name": {
+          "name": "revision_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "revisions_document_id_created_at_idx": {
+          "name": "revisions_document_id_created_at_idx",
+          "columns": [
+            "document_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "revisions_user_id_idx": {
+          "name": "revisions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "revisions_document_id_documents_id_fk": {
+          "name": "revisions_document_id_documents_id_fk",
+          "tableFrom": "revisions",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "revisions_user_id_users_id_fk": {
+          "name": "revisions_user_id_users_id_fk",
+          "tableFrom": "revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_images": {
+      "name": "user_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_type": {
+          "name": "image_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "zoom": {
+          "name": "zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_images_user_id_users_id_fk": {
+          "name": "user_images_user_id_users_id_fk",
+          "tableFrom": "user_images",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_meta": {
+          "name": "image_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "cover_meta": {
+          "name": "cover_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1786896367702,
       "tag": "0003_current_revision_set_null",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1786906559166,
+      "tag": "0004_document_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776110400000,
       "tag": "0002_disable_signup_after_bootstrap",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1786896367702,
+      "tag": "0003_current_revision_set_null",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,7 +9,8 @@
     "build": "tsc",
     "lint": "eslint .",
     "check-types": "tsc --noEmit",
-    "drizzle-kit": "bun node_modules/drizzle-kit/bin.cjs"
+    "drizzle-kit": "bun node_modules/drizzle-kit/bin.cjs",
+    "prune-orphans": "node src/scripts/prune-orphans.mjs"
   },
   "exports": {
     "./*": "./src/schemas/*",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -31,6 +31,9 @@ import { healthRouter } from './routes/health.js';
 import { authStateRouter } from './routes/auth-state.js';
 import { updatesRouter } from './routes/updates.js';
 
+const API_BODY_LIMIT = '5mb';
+const IMPORT_BODY_LIMIT = '50mb';
+
 const app: Express = express();
 const server = createServer(app);
 
@@ -61,7 +64,9 @@ app.use('/api/auth', express.text({ type: '*/*', limit: '100kb' }));
 
 app.all('/api/auth/{*any}', toNodeHandler(auth));
 
-app.use('/api', express.json({ limit: '5mb' }));
+app.use('/api/documents/import', express.json({ limit: IMPORT_BODY_LIMIT }));
+
+app.use('/api', express.json({ limit: API_BODY_LIMIT }));
 
 app.use('/api/documents', documentsRouter);
 app.use('/api/revisions', revisionsRouter);

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -61,7 +61,7 @@ app.use('/api/auth', express.text({ type: '*/*', limit: '100kb' }));
 
 app.all('/api/auth/{*any}', toNodeHandler(auth));
 
-app.use(express.json({ limit: '5mb' }));
+app.use('/api', express.json({ limit: '5mb' }));
 
 app.use('/api/documents', documentsRouter);
 app.use('/api/revisions', revisionsRouter);

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -6,83 +6,121 @@
 import 'dotenv/config';
 import z from 'zod';
 
-export const envSchema = z.object({
-  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
-  PORT: z.coerce.number().default(3000),
-  DB_FILE_NAME: z.string().default('file:storage/local.db'),
-  /**
-   * Set only when a reverse proxy sits in front of the app. Accepts a hop count
-   * (`1`) or a comma-separated list of trusted addresses/subnets
-   * (`10.0.0.0/8`). Leave unset when the app is reached directly.
-   *
-   * `true` is deliberately rejected. It makes Express take the left-most
-   * `X-Forwarded-For` entry, which any client can prepend — so a value meant to
-   * identify the caller becomes attacker-controlled.
-   */
-  TRUST_PROXY: z.preprocess(
-    (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
-    z
+export const envSchema = z
+  .object({
+    NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+    PORT: z.coerce.number().default(3000),
+    DB_FILE_NAME: z.string().default('file:storage/local.db'),
+    /**
+     * Set only when a reverse proxy sits in front of the app. Accepts a hop count
+     * (`1`) or a comma-separated list of trusted addresses/subnets
+     * (`10.0.0.0/8`). Leave unset when the app is reached directly.
+     *
+     * `true` is deliberately rejected. It makes Express take the left-most
+     * `X-Forwarded-For` entry, which any client can prepend — so a value meant to
+     * identify the caller becomes attacker-controlled.
+     */
+    TRUST_PROXY: z.preprocess(
+      (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
+      z
+        .string()
+        .optional()
+        .refine((val) => val !== 'true', {
+          message:
+            'TRUST_PROXY=true is unsafe: Express would trust the left-most X-Forwarded-For entry, which any client can forge. Use a hop count (e.g. TRUST_PROXY=1) or a list of trusted proxy addresses/subnets instead.',
+        })
+        .transform((val) => {
+          if (val === undefined || val === 'false') return false;
+          return /^\d+$/.test(val) ? Number(val) : val;
+        }),
+    ),
+    /**
+     * Accept a request whose `Origin` matches the host it arrived on, so the app
+     * works at whatever address users reach it by — a LAN IP, a hostname, a
+     * Tailscale address, a public domain — without naming each one up front.
+     *
+     * On by default because a container cannot know the address users type, and
+     * the alternative is a 403 at sign-up that reads as a broken app. CSRF
+     * protection is unaffected: a browser always sets `Host` to the server it is
+     * talking to, so a cross-site request still fails the origin match.
+     *
+     * Set `false` to trust only the origins named in `CLIENT_URL`.
+     */
+    TRUST_HOST: z.preprocess(
+      (val) => {
+        if (typeof val !== 'string') return val;
+        const normalised = val.trim().toLowerCase();
+        if (normalised === '') return undefined;
+        if (['true', '1', 'yes', 'on'].includes(normalised)) return true;
+        if (['false', '0', 'no', 'off'].includes(normalised)) return false;
+        return val;
+      },
+      z.boolean({ error: 'TRUST_HOST must be true or false.' }).default(true),
+    ),
+    /** Public origin of the auth API (same as the web app when using the Nginx proxy). Overrides first CLIENT_URL for Better Auth `baseURL`. */
+    BETTER_AUTH_URL: z.preprocess(
+      (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
+      z.url().optional(),
+    ),
+    /**
+     * Signs every session token. Better Auth falls back to a public default when
+     * this is unset, and refuses to use it in production — which surfaces as a
+     * 500 on every authenticated request rather than a startup failure. Required
+     * here so the process stops at boot with an actionable message instead.
+     */
+    BETTER_AUTH_SECRET: z.preprocess(
+      (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
+      z
+        .string()
+        .min(
+          32,
+          'BETTER_AUTH_SECRET must be at least 32 characters. Generate one with: openssl rand -base64 32',
+        )
+        .optional(),
+    ),
+
+    UPDATE_CHECK: z.preprocess(
+      (val) => {
+        if (typeof val !== 'string') return val;
+        const normalised = val.trim().toLowerCase();
+        if (normalised === '') return undefined;
+        if (['true', '1', 'yes', 'on'].includes(normalised)) return true;
+        if (['false', '0', 'no', 'off'].includes(normalised)) return false;
+        return val;
+      },
+      z.boolean({ error: 'UPDATE_CHECK must be true or false.' }).default(true),
+    ),
+    CLIENT_URL: z
       .string()
-      .optional()
-      .refine((val) => val !== 'true', {
+      .default('http://localhost:5173')
+      .transform((s) =>
+        s
+          .split(',')
+          .map((u) => u.trim())
+          .filter(Boolean),
+      )
+      .pipe(z.array(z.url())),
+  })
+  .superRefine((value, ctx) => {
+    if (value.NODE_ENV === 'production' && !value.BETTER_AUTH_SECRET) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['BETTER_AUTH_SECRET'],
         message:
-          'TRUST_PROXY=true is unsafe: Express would trust the left-most X-Forwarded-For entry, which any client can forge. Use a hop count (e.g. TRUST_PROXY=1) or a list of trusted proxy addresses/subnets instead.',
-      })
-      .transform((val) => {
-        if (val === undefined || val === 'false') return false;
-        return /^\d+$/.test(val) ? Number(val) : val;
-      }),
-  ),
-  /**
-   * Accept a request whose `Origin` matches the host it arrived on, so the app
-   * works at whatever address users reach it by — a LAN IP, a hostname, a
-   * Tailscale address, a public domain — without naming each one up front.
-   *
-   * On by default because a container cannot know the address users type, and
-   * the alternative is a 403 at sign-up that reads as a broken app. CSRF
-   * protection is unaffected: a browser always sets `Host` to the server it is
-   * talking to, so a cross-site request still fails the origin match.
-   *
-   * Set `false` to trust only the origins named in `CLIENT_URL`.
-   */
-  TRUST_HOST: z.preprocess(
-    (val) => {
-      if (typeof val !== 'string') return val;
-      const normalised = val.trim().toLowerCase();
-      if (normalised === '') return undefined;
-      if (['true', '1', 'yes', 'on'].includes(normalised)) return true;
-      if (['false', '0', 'no', 'off'].includes(normalised)) return false;
-      return val;
-    },
-    z.boolean({ error: 'TRUST_HOST must be true or false.' }).default(true),
-  ),
-  /** Public origin of the auth API (same as the web app when using the Nginx proxy). Overrides first CLIENT_URL for Better Auth `baseURL`. */
-  BETTER_AUTH_URL: z.preprocess(
-    (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
-    z.string().url().optional(),
-  ),
+          'BETTER_AUTH_SECRET must be set in production, or every authenticated request fails. Generate one with: openssl rand -base64 32',
+      });
+    }
+  });
 
-  UPDATE_CHECK: z.preprocess(
-    (val) => {
-      if (typeof val !== 'string') return val;
-      const normalised = val.trim().toLowerCase();
-      if (normalised === '') return undefined;
-      if (['true', '1', 'yes', 'on'].includes(normalised)) return true;
-      if (['false', '0', 'no', 'off'].includes(normalised)) return false;
-      return val;
-    },
-    z.boolean({ error: 'UPDATE_CHECK must be true or false.' }).default(true),
-  ),
-  CLIENT_URL: z
-    .string()
-    .default('http://localhost:5173')
-    .transform((s) =>
-      s
-        .split(',')
-        .map((u) => u.trim())
-        .filter(Boolean),
-    )
-    .pipe(z.array(z.url())),
-});
+const parsedEnv = envSchema.safeParse(process.env);
 
-export const env = envSchema.parse(process.env);
+if (!parsedEnv.success) {
+  console.error('\n  ✖  Invalid environment configuration:\n');
+  for (const issue of parsedEnv.error.issues) {
+    console.error(`     ${issue.path.join('.') || '(root)'}: ${issue.message}`);
+  }
+  console.error('');
+  process.exit(1);
+}
+
+export const env = parsedEnv.data;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -5,7 +5,7 @@
 
 import server from './app.js';
 import { env } from './env.js';
-import { configureDatabase } from './lib/db.js';
+import { checkpointDatabase, configureDatabase } from './lib/db.js';
 import { originConfig } from './lib/auth.js';
 import { clientUrlWarning } from './lib/client-url.js';
 import { getSocket } from './lib/socket.js';
@@ -79,6 +79,7 @@ const shutdown = async (signal: string) => {
     });
 
     await dbWritesQueue.onIdle();
+    await checkpointDatabase();
 
     console.log('Shutdown complete.');
     process.exit(0);

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -87,3 +87,12 @@ const shutdown = async (signal: string) => {
 
 process.on('SIGTERM', () => void shutdown('SIGTERM'));
 process.on('SIGINT', () => void shutdown('SIGINT'));
+
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled promise rejection:', reason);
+});
+
+process.on('uncaughtException', (error) => {
+  console.error('Uncaught exception, exiting:', error);
+  process.exit(1);
+});

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -5,6 +5,7 @@
 
 import server from './app.js';
 import { env } from './env.js';
+import { configureDatabase } from './lib/db.js';
 import { originConfig } from './lib/auth.js';
 import { clientUrlWarning } from './lib/client-url.js';
 import { getSocket } from './lib/socket.js';
@@ -18,6 +19,8 @@ import { startUpdateChecks, stopUpdateChecks } from './services/updates.js';
  * the process anyway and the graceful path achieved nothing.
  */
 const SHUTDOWN_TIMEOUT_MS = 8_000;
+
+await configureDatabase();
 
 server.listen(env.PORT, () => {
   console.log(`Server is running on http://localhost:${env.PORT}`);

--- a/apps/backend/src/lib/auth.ts
+++ b/apps/backend/src/lib/auth.ts
@@ -13,7 +13,7 @@ import { env } from '../env.js';
 import { users } from '../models/auth.js';
 import { getEditorSettings, setEditorSettings } from '../services/editor-settings.js';
 import { createDocument } from '../services/documents.js';
-import { dbWritesQueue } from '../queues/db-writes.js';
+import { enqueueDbWrite } from '../queues/db-writes.js';
 
 export const adapter = drizzleAdapter(db, {
   provider: 'sqlite',
@@ -84,7 +84,7 @@ export const options = {
           }
         },
         after: async (user) => {
-          dbWritesQueue.add(() =>
+          enqueueDbWrite(() =>
             createDocument(
               {
                 name: 'My Workspace',
@@ -96,7 +96,7 @@ export const options = {
               user.id,
             ),
           );
-          dbWritesQueue.add(() => setEditorSettings(user.id, {}));
+          enqueueDbWrite(() => setEditorSettings(user.id, {}));
         },
       },
     },

--- a/apps/backend/src/lib/db.ts
+++ b/apps/backend/src/lib/db.ts
@@ -4,7 +4,34 @@
  */
 
 import { drizzle } from 'drizzle-orm/libsql';
+import { sql } from 'drizzle-orm';
 import { env } from '../env.js';
 import * as schema from '../models/index.js';
 
 export const db = drizzle(env.DB_FILE_NAME, { schema });
+
+export const configureDatabase = async () => {
+  await db.run(sql`PRAGMA journal_mode = WAL`);
+  await db.run(sql`PRAGMA synchronous = NORMAL`);
+};
+
+const BUSY_RETRIES = 7;
+const BUSY_BASE_DELAY_MS = 25;
+const BUSY_MAX_DELAY_MS = 800;
+
+const isBusy = (error: unknown) =>
+  error instanceof Error && /SQLITE_BUSY|database is locked/i.test(error.message);
+
+export const withWriteRetry = async <T>(operation: () => Promise<T>): Promise<T> => {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt >= BUSY_RETRIES || !isBusy(error)) throw error;
+      const delay = Math.ceil(
+        Math.random() * Math.min(BUSY_BASE_DELAY_MS * 2 ** attempt, BUSY_MAX_DELAY_MS),
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+};

--- a/apps/backend/src/lib/db.ts
+++ b/apps/backend/src/lib/db.ts
@@ -15,6 +15,38 @@ export const configureDatabase = async () => {
   await db.run(sql`PRAGMA synchronous = NORMAL`);
 };
 
+const CHECKPOINT_ATTEMPTS = 5;
+const CHECKPOINT_RETRY_DELAY_MS = 100;
+
+export const checkpointDatabase = async () => {
+  for (let attempt = 1; attempt <= CHECKPOINT_ATTEMPTS; attempt += 1) {
+    try {
+      const result = await db.$client.execute('PRAGMA wal_checkpoint(TRUNCATE)');
+      const busy = Number(result.rows[0]?.busy ?? 0);
+
+      if (busy === 0) break;
+
+      if (attempt === CHECKPOINT_ATTEMPTS) {
+        console.warn(
+          'WAL checkpoint still blocked by another connection; a backup needs local.db together with its -wal and -shm files to be complete.',
+        );
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, CHECKPOINT_RETRY_DELAY_MS));
+    } catch (error) {
+      console.error('WAL checkpoint failed:', error);
+      break;
+    }
+  }
+
+  try {
+    db.$client.close();
+  } catch (error) {
+    console.error('Closing the database connection failed:', error);
+  }
+};
+
 const BUSY_RETRIES = 7;
 const BUSY_BASE_DELAY_MS = 25;
 const BUSY_MAX_DELAY_MS = 800;
@@ -28,9 +60,8 @@ export const withWriteRetry = async <T>(operation: () => Promise<T>): Promise<T>
       return await operation();
     } catch (error) {
       if (attempt >= BUSY_RETRIES || !isBusy(error)) throw error;
-      const delay = Math.ceil(
-        Math.random() * Math.min(BUSY_BASE_DELAY_MS * 2 ** attempt, BUSY_MAX_DELAY_MS),
-      );
+      const cap = Math.min(BUSY_BASE_DELAY_MS * 2 ** attempt, BUSY_MAX_DELAY_MS);
+      const delay = Math.ceil(cap / 2 + (Math.random() * cap) / 2);
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }

--- a/apps/backend/src/lib/db.ts
+++ b/apps/backend/src/lib/db.ts
@@ -11,6 +11,7 @@ import * as schema from '../models/index.js';
 export const db = drizzle(env.DB_FILE_NAME, { schema });
 
 export const configureDatabase = async () => {
+  await db.run(sql`PRAGMA foreign_keys = ON`);
   await db.run(sql`PRAGMA journal_mode = WAL`);
   await db.run(sql`PRAGMA synchronous = NORMAL`);
 };

--- a/apps/backend/src/lib/docs.ts
+++ b/apps/backend/src/lib/docs.ts
@@ -237,7 +237,7 @@ export const openApiDocument = createDocument({
         requestBody: {
           required: true,
           content: {
-            'application/json': { schema: importDocumentSchema },
+            'application/json': { schema: importDocumentSchema.out },
           },
         },
         responses: {

--- a/apps/backend/src/lib/socket.ts
+++ b/apps/backend/src/lib/socket.ts
@@ -7,7 +7,7 @@ import { Server } from 'socket.io';
 import { type Server as HttpServer } from 'node:http';
 import { ioRequireAuth } from '../middlewares/auth.js';
 import { userHasDocument } from '../services/access.js';
-import { SocketEventKey, SocketEventsMap } from '../schemas/realtime.js';
+import { SocketEventKey, SocketEventsMap, spaceIdSchema } from '../schemas/realtime.js';
 import { env } from '../env.js';
 
 let io: Server | null = null;
@@ -25,16 +25,27 @@ export const initializeSocket = (server: HttpServer) => {
       console.log(`Socket disconnected: ${socket.id} - ${socket.user.id}`);
     });
 
-    socket.on('subscribeToSpace', async (spaceId: string) => {
-      const hasAccess = await userHasDocument(socket.user.id, spaceId);
-      if (!hasAccess) {
+    socket.on('subscribeToSpace', async (spaceId: unknown) => {
+      const parsed = spaceIdSchema.safeParse(spaceId);
+      if (!parsed.success) {
         return;
       }
-      socket.join(`space:${spaceId}`);
+      try {
+        const hasAccess = await userHasDocument(socket.user.id, parsed.data);
+        if (hasAccess) {
+          socket.join(`space:${parsed.data}`);
+        }
+      } catch (error) {
+        console.error(`subscribeToSpace failed for ${socket.user.id}:`, error);
+      }
     });
 
-    socket.on('unsubscribeFromSpace', (spaceId: string) => {
-      socket.leave(`space:${spaceId}`);
+    socket.on('unsubscribeFromSpace', (spaceId: unknown) => {
+      const parsed = spaceIdSchema.safeParse(spaceId);
+      if (!parsed.success) {
+        return;
+      }
+      socket.leave(`space:${parsed.data}`);
     });
   });
 

--- a/apps/backend/src/lib/storage.ts
+++ b/apps/backend/src/lib/storage.ts
@@ -8,13 +8,11 @@ import path from 'path';
 export const STORAGE_DIR = path.join(process.cwd(), 'storage');
 
 export const resolvePhysicalPath = (relativePath: string) => {
-  if (relativePath.startsWith('/storage') || relativePath.startsWith('storage')) {
-    relativePath = relativePath.replace(/^\/?storage\/?/, '');
-  }
+  const root = path.resolve(STORAGE_DIR);
+  const resolvedPath = path.resolve(root, relativePath.replace(/^\/?storage(?:\/|$)/, ''));
+  const relativeToRoot = path.relative(root, resolvedPath);
 
-  const resolvedPath = path.resolve(STORAGE_DIR, relativePath);
-
-  if (!resolvedPath.startsWith(path.resolve(STORAGE_DIR))) {
+  if (relativeToRoot === '' || relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
     throw new Error(`Path traversal detected: ${relativePath}`);
   }
 

--- a/apps/backend/src/models/documents.ts
+++ b/apps/backend/src/models/documents.ts
@@ -28,7 +28,7 @@ export const documentsTable = sqliteTable('documents', {
   icon: text('icon'),
   position: text('position'),
   currentRevisionId: text('current_revision_id').references((): SQLiteColumn => revisionsTable.id, {
-    onDelete: 'cascade',
+    onDelete: 'set null',
     onUpdate: 'cascade',
   }),
   userId: text('user_id')

--- a/apps/backend/src/models/documents.ts
+++ b/apps/backend/src/models/documents.ts
@@ -4,7 +4,7 @@
  */
 
 import crypto from 'node:crypto';
-import { SQLiteColumn, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { SQLiteColumn, index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { enumType } from '../utils/drizzle.js';
 import { users } from './auth.js';
 import { revisionsTable } from './revisions.js';
@@ -12,45 +12,58 @@ import { relations } from 'drizzle-orm';
 import { documentViewsTable } from './document-views.js';
 import { favoritesTable } from './favorites.js';
 
-export const documentsTable = sqliteTable('documents', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  createdAt: integer('created_at', { mode: 'timestamp_ms' })
-    .notNull()
-    .$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
-    .notNull()
-    .$defaultFn(() => new Date())
-    .$onUpdateFn(() => new Date()),
-  name: text('name').notNull(),
-  handle: text('handle').notNull(),
-  icon: text('icon'),
-  position: text('position'),
-  currentRevisionId: text('current_revision_id').references((): SQLiteColumn => revisionsTable.id, {
-    onDelete: 'set null',
-    onUpdate: 'cascade',
-  }),
-  userId: text('user_id')
-    .notNull()
-    .references(() => users.id, {
+export const documentsTable = sqliteTable(
+  'documents',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .$defaultFn(() => new Date())
+      .$onUpdateFn(() => new Date()),
+    name: text('name').notNull(),
+    handle: text('handle').notNull(),
+    icon: text('icon'),
+    position: text('position'),
+    currentRevisionId: text('current_revision_id').references(
+      (): SQLiteColumn => revisionsTable.id,
+      {
+        onDelete: 'set null',
+        onUpdate: 'cascade',
+      },
+    ),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      }),
+    parentId: text('parent_id').references((): SQLiteColumn => documentsTable.id, {
       onDelete: 'cascade',
       onUpdate: 'cascade',
     }),
-  parentId: text('parent_id').references((): SQLiteColumn => documentsTable.id, {
-    onDelete: 'cascade',
-    onUpdate: 'cascade',
-  }),
-  documentType: enumType(['space', 'folder', 'note'] as const, 'document_type')
-    .notNull()
-    .default('note'),
-  spaceId: text('space_id').references((): SQLiteColumn => documentsTable.id, {
-    onDelete: 'cascade',
-    onUpdate: 'cascade',
-  }),
-  isContainer: integer('is_container', { mode: 'boolean' }).notNull().default(false),
-  clientId: text('client_id'),
-});
+    documentType: enumType(['space', 'folder', 'note'] as const, 'document_type')
+      .notNull()
+      .default('note'),
+    spaceId: text('space_id').references((): SQLiteColumn => documentsTable.id, {
+      onDelete: 'cascade',
+      onUpdate: 'cascade',
+    }),
+    isContainer: integer('is_container', { mode: 'boolean' }).notNull().default(false),
+    clientId: text('client_id'),
+  },
+  (table) => [
+    index('documents_user_id_idx').on(table.userId),
+    index('documents_parent_id_idx').on(table.parentId),
+    index('documents_space_id_idx').on(table.spaceId),
+    index('documents_handle_idx').on(table.handle),
+    index('documents_current_revision_id_idx').on(table.currentRevisionId),
+  ],
+);
 
 export const documentRelations = relations(documentsTable, ({ one, many }) => ({
   user: one(users, {

--- a/apps/backend/src/models/revisions.ts
+++ b/apps/backend/src/models/revisions.ts
@@ -4,38 +4,45 @@
  */
 
 import crypto from 'node:crypto';
-import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { documentsTable } from './documents.js';
 import { relations } from 'drizzle-orm';
 import { users } from './auth.js';
 
-export const revisionsTable = sqliteTable('revisions', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  createdAt: integer('created_at', { mode: 'timestamp_ms' })
-    .notNull()
-    .$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
-    .notNull()
-    .$defaultFn(() => new Date())
-    .$onUpdateFn(() => new Date()),
-  documentId: text('document_id')
-    .notNull()
-    .references(() => documentsTable.id, {
-      onDelete: 'cascade',
-      onUpdate: 'cascade',
-    }),
-  userId: text('user_id')
-    .notNull()
-    .references(() => users.id, {
-      onDelete: 'cascade',
-      onUpdate: 'cascade',
-    }),
-  revisionName: text('revision_name'),
-  text: text('text').notNull(),
-  checksum: text('checksum'),
-});
+export const revisionsTable = sqliteTable(
+  'revisions',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    createdAt: integer('created_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .$defaultFn(() => new Date())
+      .$onUpdateFn(() => new Date()),
+    documentId: text('document_id')
+      .notNull()
+      .references(() => documentsTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      }),
+    revisionName: text('revision_name'),
+    text: text('text').notNull(),
+    checksum: text('checksum'),
+  },
+  (table) => [
+    index('revisions_document_id_created_at_idx').on(table.documentId, table.createdAt),
+    index('revisions_user_id_idx').on(table.userId),
+  ],
+);
 
 export const revisionRelations = relations(revisionsTable, ({ one }) => ({
   document: one(documentsTable, {

--- a/apps/backend/src/queues/db-writes.ts
+++ b/apps/backend/src/queues/db-writes.ts
@@ -6,3 +6,9 @@
 import PQueue from 'p-queue';
 
 export const dbWritesQueue = new PQueue({ concurrency: 1 });
+
+export const enqueueDbWrite = (task: () => Promise<unknown>): void => {
+  void dbWritesQueue.add(task).catch((error) => {
+    console.error('Queued database write failed:', error);
+  });
+};

--- a/apps/backend/src/routes/documents.ts
+++ b/apps/backend/src/routes/documents.ts
@@ -29,10 +29,22 @@ import {
 } from '../services/documents.js';
 import { searchDocuments } from '../services/search.js';
 import { userHasDocument } from '../services/access.js';
-import { HttpInternalServerError, HttpNotFound, HttpUnprocessableEntity } from '@httpx/exception';
+import {
+  HttpException,
+  HttpInternalServerError,
+  HttpNotFound,
+  HttpUnprocessableEntity,
+} from '@httpx/exception';
 import { getCurrentRevisionByDocumentId, getRevisionsByDocumentId } from '../services/revisions.js';
+import { once } from 'node:events';
 import { copyDocumentSchema, importDocumentSchema } from '../schemas/operations.js';
-import { copyDocument, exportDocumentTree, importDocumentTree } from '../services/operations.js';
+import {
+  MAX_EXPORT_BYTES,
+  copyDocument,
+  estimateExportBytes,
+  importDocumentTree,
+  streamDocumentTree,
+} from '../services/operations.js';
 import { dbWritesQueue, enqueueDbWrite } from '../queues/db-writes.js';
 import { paginationQuerySchema } from '../schemas/pagination.js';
 
@@ -246,13 +258,25 @@ router.post(
         'The document does not exist or is not accessible by the authenticated user.',
       );
     }
-    const exportedDocument = await exportDocumentTree(req.params.documentId);
-    if (!exportedDocument) {
-      throw new HttpInternalServerError(
-        'Internal server error. The export operation failed unexpectedly.',
+    const estimatedBytes = await estimateExportBytes(req.params.documentId);
+
+    if (estimatedBytes > MAX_EXPORT_BYTES) {
+      throw new HttpException(
+        413,
+        `This document tree is about ${Math.ceil(estimatedBytes / (1024 * 1024))}MB once exported, above the ${MAX_EXPORT_BYTES / (1024 * 1024)}MB limit. Export a smaller part of the tree, or back up the storage volume instead.`,
       );
     }
-    res.status(200).json(exportedDocument);
+
+    res.status(200);
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+
+    for await (const chunk of streamDocumentTree(req.params.documentId)) {
+      if (!res.write(chunk)) {
+        await once(res, 'drain');
+      }
+    }
+
+    res.end();
   },
 );
 

--- a/apps/backend/src/routes/documents.ts
+++ b/apps/backend/src/routes/documents.ts
@@ -33,7 +33,7 @@ import { HttpInternalServerError, HttpNotFound, HttpUnprocessableEntity } from '
 import { getCurrentRevisionByDocumentId, getRevisionsByDocumentId } from '../services/revisions.js';
 import { copyDocumentSchema, importDocumentSchema } from '../schemas/operations.js';
 import { copyDocument, exportDocumentTree, importDocumentTree } from '../services/operations.js';
-import { dbWritesQueue } from '../queues/db-writes.js';
+import { dbWritesQueue, enqueueDbWrite } from '../queues/db-writes.js';
 import { paginationQuerySchema } from '../schemas/pagination.js';
 
 const router: Router = Router();
@@ -99,7 +99,7 @@ router.get(
       throw new HttpNotFound('Document with the specified handle not found or not accessible.');
     }
     if (req.query.updateLastViewed === true) {
-      dbWritesQueue.add(() => viewDocument(document.id, req.user!.id));
+      enqueueDbWrite(() => viewDocument(document.id, req.user!.id));
     }
     res.status(200).json(document);
   },
@@ -114,7 +114,7 @@ router.get(
       throw new HttpNotFound('Document not found or the user does not have access to it.');
     }
     if (req.query.updateLastViewed === true) {
-      dbWritesQueue.add(() => viewDocument(document.id, req.user!.id));
+      enqueueDbWrite(() => viewDocument(document.id, req.user!.id));
     }
     res.status(200).json(document);
   },

--- a/apps/backend/src/routes/documents.ts
+++ b/apps/backend/src/routes/documents.ts
@@ -36,7 +36,8 @@ import {
   HttpUnprocessableEntity,
 } from '@httpx/exception';
 import { getCurrentRevisionByDocumentId, getRevisionsByDocumentId } from '../services/revisions.js';
-import { once } from 'node:events';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { copyDocumentSchema, importDocumentSchema } from '../schemas/operations.js';
 import {
   MAX_EXPORT_BYTES,
@@ -284,25 +285,23 @@ router.post(
     res.status(200);
     res.setHeader('Content-Type', 'application/json; charset=utf-8');
 
-    let written = 0;
-
-    for await (const chunk of streamDocumentTree(req.params.documentId)) {
-      written += Buffer.byteLength(chunk);
-
-      if (written > MAX_EXPORT_BYTES) {
-        console.error(
-          `Export of ${req.params.documentId} exceeded ${MAX_EXPORT_BYTES} bytes mid-stream; aborting the response.`,
-        );
-        res.destroy();
-        return;
+    const cappedExport = async function* () {
+      let written = 0;
+      for await (const chunk of streamDocumentTree(req.params.documentId)) {
+        written += Buffer.byteLength(chunk);
+        if (written > MAX_EXPORT_BYTES) {
+          throw new Error(`Export exceeded ${MAX_EXPORT_BYTES} bytes mid-stream.`);
+        }
+        yield chunk;
       }
+    };
 
-      if (!res.write(chunk)) {
-        await once(res, 'drain');
-      }
+    try {
+      await pipeline(Readable.from(cappedExport()), res);
+    } catch (error) {
+      console.error(`Export of ${req.params.documentId} failed mid-stream:`, error);
+      if (!res.destroyed) res.destroy();
     }
-
-    res.end();
   },
 );
 

--- a/apps/backend/src/routes/documents.ts
+++ b/apps/backend/src/routes/documents.ts
@@ -237,6 +237,20 @@ router.post(
         'The document does not exist or is not accessible by the authenticated user.',
       );
     }
+
+    const { parentId, spaceId } = req.body;
+
+    if (parentId && !(await userHasDocument(req.user!.id, parentId))) {
+      throw new HttpNotFound(
+        'The specified parentId or spaceId does not exist or is not accessible by the authenticated user.',
+      );
+    }
+    if (spaceId && !(await userHasDocument(req.user!.id, spaceId))) {
+      throw new HttpNotFound(
+        'The specified parentId or spaceId does not exist or is not accessible by the authenticated user.',
+      );
+    }
+
     const copiedDocument = await dbWritesQueue.add(() =>
       copyDocument(req.params.documentId, req.body, req.user!.id),
     );
@@ -270,7 +284,19 @@ router.post(
     res.status(200);
     res.setHeader('Content-Type', 'application/json; charset=utf-8');
 
+    let written = 0;
+
     for await (const chunk of streamDocumentTree(req.params.documentId)) {
+      written += Buffer.byteLength(chunk);
+
+      if (written > MAX_EXPORT_BYTES) {
+        console.error(
+          `Export of ${req.params.documentId} exceeded ${MAX_EXPORT_BYTES} bytes mid-stream; aborting the response.`,
+        );
+        res.destroy();
+        return;
+      }
+
       if (!res.write(chunk)) {
         await once(res, 'drain');
       }

--- a/apps/backend/src/routes/documents.ts
+++ b/apps/backend/src/routes/documents.ts
@@ -85,6 +85,19 @@ router.post(
   '/with-revision',
   validate({ body: createDocumentWithRevisionSchema }),
   async (req, res) => {
+    const { parentId, spaceId } = req.body;
+
+    if (parentId && !(await userHasDocument(req.user!.id, parentId))) {
+      throw new HttpNotFound(
+        'The specified parentId or spaceId does not exist or is not accessible by the authenticated user.',
+      );
+    }
+    if (spaceId && !(await userHasDocument(req.user!.id, spaceId))) {
+      throw new HttpNotFound(
+        'The specified parentId or spaceId does not exist or is not accessible by the authenticated user.',
+      );
+    }
+
     const document = await createDocumentWithRevision(req.body, req.user!.id);
     res.status(201).json(document);
   },

--- a/apps/backend/src/routes/health.ts
+++ b/apps/backend/src/routes/health.ts
@@ -18,6 +18,44 @@ healthRouter.get('/', (_req, res) => {
   res.status(200).json({ status: 'ok' });
 });
 
+healthRouter.get('/ready', async (_req, res) => {
+  const start = Date.now();
+  res.setHeader('Cache-Control', 'no-store');
+
+  try {
+    const integrity = await db.$client.execute('PRAGMA quick_check(1)');
+    const verdict = String(integrity.rows[0]?.quick_check ?? '').toLowerCase();
+
+    if (verdict !== 'ok') {
+      return res.status(503).json({
+        status: 'unready',
+        db: 'corrupt',
+        detail: verdict || 'quick_check returned no result',
+        latencyMs: Date.now() - start,
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    const version = await db.$client.execute('PRAGMA user_version');
+    await db.$client.execute(`PRAGMA user_version = ${Number(version.rows[0]?.user_version ?? 0)}`);
+
+    return res.status(200).json({
+      status: 'ready',
+      db: 'writable',
+      latencyMs: Date.now() - start,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    return res.status(503).json({
+      status: 'unready',
+      db: 'not-writable',
+      detail: error instanceof Error ? error.message : 'unknown error',
+      latencyMs: Date.now() - start,
+      timestamp: new Date().toISOString(),
+    });
+  }
+});
+
 healthRouter.get('/db', async (_req, res) => {
   const start = Date.now();
 

--- a/apps/backend/src/routes/health.ts
+++ b/apps/backend/src/routes/health.ts
@@ -4,7 +4,7 @@
  */
 
 import { Router } from 'express';
-import { db } from '../lib/db.js';
+import { db, withWriteRetry } from '../lib/db.js';
 
 export const healthRouter = Router();
 
@@ -23,21 +23,12 @@ healthRouter.get('/ready', async (_req, res) => {
   res.setHeader('Cache-Control', 'no-store');
 
   try {
-    const integrity = await db.$client.execute('PRAGMA quick_check(1)');
-    const verdict = String(integrity.rows[0]?.quick_check ?? '').toLowerCase();
-
-    if (verdict !== 'ok') {
-      return res.status(503).json({
-        status: 'unready',
-        db: 'corrupt',
-        detail: verdict || 'quick_check returned no result',
-        latencyMs: Date.now() - start,
-        timestamp: new Date().toISOString(),
-      });
-    }
-
-    const version = await db.$client.execute('PRAGMA user_version');
-    await db.$client.execute(`PRAGMA user_version = ${Number(version.rows[0]?.user_version ?? 0)}`);
+    await withWriteRetry(async () => {
+      const version = await db.$client.execute('PRAGMA user_version');
+      await db.$client.execute(
+        `PRAGMA user_version = ${Number(version.rows[0]?.user_version ?? 0)}`,
+      );
+    });
 
     return res.status(200).json({
       status: 'ready',

--- a/apps/backend/src/routes/storage.ts
+++ b/apps/backend/src/routes/storage.ts
@@ -13,8 +13,8 @@ import { HttpNotFound, HttpUnprocessableEntity } from '@httpx/exception';
 import { resolvePhysicalPath } from '../lib/storage.js';
 import { getRevisionContentUrl } from '../services/revision-contents.js';
 import { documentIdParamSchema } from '../schemas/documents.js';
+import { attachmentFileParamSchema, userFileParamSchema } from '../schemas/storage.js';
 import { mkdir } from 'node:fs/promises';
-import z from 'zod';
 import { getAttachmentUrl } from '../services/attachments.js';
 import { safeFilename } from '../utils/strings.js';
 import { imageMetaSchema } from '../schemas/images.js';
@@ -90,7 +90,7 @@ router.post(
 
 router.get(
   '/attachments/:documentId/:filename',
-  validate({ params: documentIdParamSchema.extend({ filename: z.string() }) }),
+  validate({ params: attachmentFileParamSchema }),
   async (req, res, next) => {
     const { documentId, filename } = req.params;
 
@@ -144,12 +144,21 @@ router.delete('/images', async (req, res) => {
   res.status(204).send();
 });
 
-router.get('/images/:userId/:filename', async (req, res, next) => {
-  const { userId, filename } = req.params;
-  res.sendFile(resolvePhysicalPath(`images/${userId}/${filename}`), (err) => {
-    if (err) next(new HttpNotFound('Profile image not found'));
-  });
-});
+router.get(
+  '/images/:userId/:filename',
+  validate({ params: userFileParamSchema }),
+  async (req, res, next) => {
+    const { userId, filename } = req.params;
+
+    if (userId !== req.user!.id) {
+      throw new HttpNotFound('Profile image not found');
+    }
+
+    res.sendFile(resolvePhysicalPath(`images/${userId}/${filename}`), (err) => {
+      if (err) next(new HttpNotFound('Profile image not found'));
+    });
+  },
+);
 
 router.put('/covers', async (req, res) => {
   const uploadDir = resolvePhysicalPath(`covers/${req.user!.id}`);
@@ -189,11 +198,20 @@ router.delete('/covers', async (req, res) => {
   res.status(204).send();
 });
 
-router.get('/covers/:userId/:filename', async (req, res, next) => {
-  const { userId, filename } = req.params;
-  res.sendFile(resolvePhysicalPath(`covers/${userId}/${filename}`), (err) => {
-    if (err) next(new HttpNotFound('Cover image not found'));
-  });
-});
+router.get(
+  '/covers/:userId/:filename',
+  validate({ params: userFileParamSchema }),
+  async (req, res, next) => {
+    const { userId, filename } = req.params;
+
+    if (userId !== req.user!.id) {
+      throw new HttpNotFound('Cover image not found');
+    }
+
+    res.sendFile(resolvePhysicalPath(`covers/${userId}/${filename}`), (err) => {
+      if (err) next(new HttpNotFound('Cover image not found'));
+    });
+  },
+);
 
 export { router as storageRouter };

--- a/apps/backend/src/routes/storage.ts
+++ b/apps/backend/src/routes/storage.ts
@@ -29,6 +29,12 @@ const router: Router = Router();
 
 router.use(requireAuth);
 
+router.use((_req, res, next) => {
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Content-Security-Policy', "default-src 'none'; sandbox");
+  next();
+});
+
 router.get(
   '/revisions/:revisionId',
   validate({ params: revisionIdParamSchema }),

--- a/apps/backend/src/routes/storage.ts
+++ b/apps/backend/src/routes/storage.ts
@@ -68,15 +68,7 @@ router.post(
       maxFileSize: 10 * 1024 * 1024, // 10MB
       keepExtensions: true,
       filename: safeFilename,
-    });
-
-    form.on('fileBegin', (name) => {
-      if (name !== 'attachments') {
-        throw new HttpUnprocessableEntity({
-          message:
-            'Invalid upload. Either no file was provided, the field name was incorrect (expected "attachments"), or the file exceeds the 10MB size limit.',
-        });
-      }
+      filter: (part) => part.name === 'attachments',
     });
 
     const [, files] = await form.parse(req);
@@ -129,17 +121,8 @@ router.put('/images', async (req, res) => {
       return `image${ext}`;
     },
     filter(part) {
-      return part.mimetype?.startsWith('image/') || false;
+      return part.name === 'image' && (part.mimetype?.startsWith('image/') || false);
     },
-  });
-
-  form.on('fileBegin', (name) => {
-    if (name !== 'image') {
-      throw new HttpUnprocessableEntity({
-        message:
-          'Invalid upload. Either no file was provided, the field name was incorrect (expected "image").',
-      });
-    }
   });
 
   const [fields, files] = await form.parse(req);
@@ -183,17 +166,8 @@ router.put('/covers', async (req, res) => {
       return `cover${ext}`;
     },
     filter(part) {
-      return part.mimetype?.startsWith('image/') || false;
+      return part.name === 'cover' && (part.mimetype?.startsWith('image/') || false);
     },
-  });
-
-  form.on('fileBegin', (name) => {
-    if (name !== 'cover') {
-      throw new HttpUnprocessableEntity({
-        message:
-          'Invalid upload. Either no file was provided, the field name was incorrect (expected "cover").',
-      });
-    }
   });
 
   const [fields, files] = await form.parse(req);

--- a/apps/backend/src/schemas/documents.ts
+++ b/apps/backend/src/schemas/documents.ts
@@ -60,16 +60,20 @@ export const createDocumentWithRevisionSchema = createDocumentSchema.extend({
   revision: createRevisionSchema.omit({ documentId: true }),
 });
 
-export const updateDocumentSchema = createUpdateSchema(documentsTable).omit({
-  id: true,
-  userId: true,
-  clientId: true,
-  createdAt: true,
-  updatedAt: true,
-  handle: true,
-  isContainer: true,
-  documentType: true,
-});
+export const updateDocumentSchema = createUpdateSchema(documentsTable)
+  .omit({
+    id: true,
+    userId: true,
+    clientId: true,
+    createdAt: true,
+    updatedAt: true,
+    handle: true,
+    isContainer: true,
+    documentType: true,
+  })
+  .extend({
+    expectedCurrentRevisionId: z.uuid().nullable().optional(),
+  });
 
 export const plainDocumentSchema = createSelectSchema(documentsTable, {
   documentType: z.enum(['space', 'folder', 'note']),

--- a/apps/backend/src/schemas/documents.ts
+++ b/apps/backend/src/schemas/documents.ts
@@ -8,6 +8,7 @@ import z from 'zod';
 import { documentsTable } from '../models/documents.js';
 import { revisionsTable } from '../models/revisions.js';
 import { createRevisionSchema, revisionDetailsSchema } from './revisions.js';
+import { MAX_PAGE_SIZE } from './pagination.js';
 
 export const documentHandleParamSchema = createSelectSchema(documentsTable).pick({ handle: true });
 
@@ -28,7 +29,7 @@ export const documentFiltersSchema = z.object({
   order: z.enum(['asc', 'desc']).optional(),
   isContainer: z.stringbool().optional(),
   days: z.coerce.number().min(1).optional(),
-  limit: z.coerce.number().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).optional(),
 });
 
 export const searchDocumentsQuerySchema = z.object({

--- a/apps/backend/src/schemas/operations.ts
+++ b/apps/backend/src/schemas/operations.ts
@@ -8,6 +8,7 @@ import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { documentsTable } from '../models/documents.js';
 import { revisionsTable } from '../models/revisions.js';
 import { Attachment } from '../services/attachments.js';
+export const MAX_IMPORT_DEPTH = 100;
 
 export const attachmentSchema = z.object({
   filename: z
@@ -50,13 +51,38 @@ export const exportedDocumentSchema: z.ZodType<ExportedDocument> = z.lazy(() =>
   }),
 );
 
-export const importDocumentSchema = z.object({
-  spaceId: z.uuid().optional().nullable(),
-  parentId: z.uuid().optional().nullable(),
-  position: z.string().optional().nullable(),
-  type: z.enum(['space', 'folder', 'note']),
-  document: exportedDocumentSchema,
-});
+const importTreeDepth = (root: ExportedDocument): number => {
+  let maxDepth = 0;
+  const stack: Array<{ node: ExportedDocument; depth: number }> = [{ node: root, depth: 1 }];
+
+  while (stack.length > 0) {
+    const { node, depth } = stack.pop()!;
+    if (depth > maxDepth) maxDepth = depth;
+    for (const child of node.children) stack.push({ node: child, depth: depth + 1 });
+    for (const child of node.spaceRootChildren) stack.push({ node: child, depth: depth + 1 });
+  }
+
+  return maxDepth;
+};
+
+export const importDocumentSchema = z
+  .object({
+    spaceId: z.uuid().optional().nullable(),
+    parentId: z.uuid().optional().nullable(),
+    position: z.string().optional().nullable(),
+    type: z.enum(['space', 'folder', 'note']),
+    document: exportedDocumentSchema,
+  })
+  .superRefine((value, ctx) => {
+    const depth = importTreeDepth(value.document);
+    if (depth > MAX_IMPORT_DEPTH) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Document tree is nested ${depth} levels deep; the maximum is ${MAX_IMPORT_DEPTH}.`,
+        path: ['document'],
+      });
+    }
+  });
 
 export const copyDocumentSchema = createInsertSchema(documentsTable).omit({
   id: true,

--- a/apps/backend/src/schemas/operations.ts
+++ b/apps/backend/src/schemas/operations.ts
@@ -8,8 +8,13 @@ import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { documentsTable } from '../models/documents.js';
 import { revisionsTable } from '../models/revisions.js';
 import { Attachment } from '../services/attachments.js';
-import { documentTreeDepth, normalizeDocumentTreeContent } from '../utils/operations.js';
+import {
+  documentTreeDepth,
+  documentTreeNodeCount,
+  normalizeDocumentTreeContent,
+} from '../utils/operations.js';
 export const MAX_IMPORT_DEPTH = 100;
+export const MAX_IMPORT_NODES = 5000;
 
 export const attachmentSchema = z.object({
   filename: z
@@ -53,11 +58,23 @@ export const exportedDocumentSchema: z.ZodType<ExportedDocument> = z.lazy(() =>
 );
 
 const importDepthGuard = z.unknown().superRefine((value, ctx) => {
-  const depth = documentTreeDepth((value as { document?: unknown } | null)?.document);
+  const root = (value as { document?: unknown } | null)?.document;
+  const depth = documentTreeDepth(root);
+
   if (depth > MAX_IMPORT_DEPTH) {
     ctx.addIssue({
       code: 'custom',
       message: `Document tree is nested ${depth} levels deep; the maximum is ${MAX_IMPORT_DEPTH}.`,
+      path: ['document'],
+    });
+  }
+
+  const nodes = documentTreeNodeCount(root);
+
+  if (nodes > MAX_IMPORT_NODES) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `Document tree holds ${nodes} documents; the maximum is ${MAX_IMPORT_NODES}.`,
       path: ['document'],
     });
   }

--- a/apps/backend/src/schemas/operations.ts
+++ b/apps/backend/src/schemas/operations.ts
@@ -8,6 +8,7 @@ import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { documentsTable } from '../models/documents.js';
 import { revisionsTable } from '../models/revisions.js';
 import { Attachment } from '../services/attachments.js';
+import { documentTreeDepth, normalizeDocumentTreeContent } from '../utils/operations.js';
 export const MAX_IMPORT_DEPTH = 100;
 
 export const attachmentSchema = z.object({
@@ -51,38 +52,31 @@ export const exportedDocumentSchema: z.ZodType<ExportedDocument> = z.lazy(() =>
   }),
 );
 
-const importTreeDepth = (root: ExportedDocument): number => {
-  let maxDepth = 0;
-  const stack: Array<{ node: ExportedDocument; depth: number }> = [{ node: root, depth: 1 }];
-
-  while (stack.length > 0) {
-    const { node, depth } = stack.pop()!;
-    if (depth > maxDepth) maxDepth = depth;
-    for (const child of node.children) stack.push({ node: child, depth: depth + 1 });
-    for (const child of node.spaceRootChildren) stack.push({ node: child, depth: depth + 1 });
+const importDepthGuard = z.unknown().superRefine((value, ctx) => {
+  const depth = documentTreeDepth((value as { document?: unknown } | null)?.document);
+  if (depth > MAX_IMPORT_DEPTH) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `Document tree is nested ${depth} levels deep; the maximum is ${MAX_IMPORT_DEPTH}.`,
+      path: ['document'],
+    });
   }
+});
 
-  return maxDepth;
-};
-
-export const importDocumentSchema = z
-  .object({
-    spaceId: z.uuid().optional().nullable(),
-    parentId: z.uuid().optional().nullable(),
-    position: z.string().optional().nullable(),
-    type: z.enum(['space', 'folder', 'note']),
-    document: exportedDocumentSchema,
+export const importDocumentSchema = importDepthGuard
+  .transform((value) => {
+    normalizeDocumentTreeContent((value as { document?: unknown } | null)?.document);
+    return value;
   })
-  .superRefine((value, ctx) => {
-    const depth = importTreeDepth(value.document);
-    if (depth > MAX_IMPORT_DEPTH) {
-      ctx.addIssue({
-        code: 'custom',
-        message: `Document tree is nested ${depth} levels deep; the maximum is ${MAX_IMPORT_DEPTH}.`,
-        path: ['document'],
-      });
-    }
-  });
+  .pipe(
+    z.object({
+      spaceId: z.uuid().optional().nullable(),
+      parentId: z.uuid().optional().nullable(),
+      position: z.string().optional().nullable(),
+      type: z.enum(['space', 'folder', 'note']),
+      document: exportedDocumentSchema,
+    }),
+  );
 
 export const copyDocumentSchema = createInsertSchema(documentsTable).omit({
   id: true,

--- a/apps/backend/src/schemas/operations.ts
+++ b/apps/backend/src/schemas/operations.ts
@@ -10,8 +10,14 @@ import { revisionsTable } from '../models/revisions.js';
 import { Attachment } from '../services/attachments.js';
 
 export const attachmentSchema = z.object({
-  filename: z.string(),
-  url: z.string(),
+  filename: z
+    .string()
+    .min(1)
+    .max(255)
+    .refine((value) => !/[/\\\0]/.test(value) && value !== '.' && value !== '..', {
+      message: 'Attachment filename must be a bare file name, not a path.',
+    }),
+  url: z.string().startsWith('data:', 'Attachment url must be a data URL.'),
 });
 
 export const exportedRevisionSchema = createSelectSchema(revisionsTable, {

--- a/apps/backend/src/schemas/pagination.ts
+++ b/apps/backend/src/schemas/pagination.ts
@@ -5,9 +5,11 @@
 
 import z from 'zod';
 
+export const MAX_PAGE_SIZE = 100;
+
 export const paginationQuerySchema = z.object({
-  page: z.coerce.number().min(1).default(1),
-  limit: z.coerce.number().min(1).default(10),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(10),
 });
 
 export const paginatedResultSchema = <T extends z.ZodTypeAny>(itemSchema: T) =>

--- a/apps/backend/src/schemas/realtime.ts
+++ b/apps/backend/src/schemas/realtime.ts
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import z from 'zod';
 import { DocumentDetails, PlainDocument } from './documents.js';
 import { Favorite } from './favorites.js';
+
+export const spaceIdSchema = z.uuid();
 
 export type FavoriteRealtimeResponse = Favorite & { spaceId: string | null };
 

--- a/apps/backend/src/schemas/revisions.ts
+++ b/apps/backend/src/schemas/revisions.ts
@@ -40,7 +40,18 @@ export const updateRevisionContentSchema = createUpdateSchema(revisionsTable)
     content: z.string().min(1, 'Revision Content is required'),
   });
 
-export const updateRevisionSchema = updateRevisionNameSchema.or(updateRevisionContentSchema);
+export const updateRevisionSchema = createUpdateSchema(revisionsTable)
+  .pick({
+    revisionName: true,
+    text: true,
+    checksum: true,
+  })
+  .extend({
+    content: z.string().min(1, 'Revision Content is required').optional(),
+  })
+  .refine((value) => Object.values(value).some((field) => field !== undefined), {
+    message: 'Provide at least one field to update.',
+  });
 
 export const plainRevisionSchema = createSelectSchema(revisionsTable)
   .omit({ createdAt: true, updatedAt: true })

--- a/apps/backend/src/schemas/revisions.ts
+++ b/apps/backend/src/schemas/revisions.ts
@@ -51,6 +51,10 @@ export const updateRevisionSchema = createUpdateSchema(revisionsTable)
   })
   .refine((value) => Object.values(value).some((field) => field !== undefined), {
     message: 'Provide at least one field to update.',
+  })
+  .refine((value) => (value.text === undefined) === (value.content === undefined), {
+    message:
+      'Send text and content together; updating one without the other leaves search results disagreeing with the stored document.',
   });
 
 export const plainRevisionSchema = createSelectSchema(revisionsTable)

--- a/apps/backend/src/schemas/storage.ts
+++ b/apps/backend/src/schemas/storage.ts
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import z from 'zod';
+import { documentIdParamSchema } from './documents.js';
+
+export const storageFilenameSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .regex(/^[A-Za-z0-9_-][A-Za-z0-9._-]*$/, 'Invalid filename.');
+
+export const storageUserIdSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[A-Za-z0-9_-]+$/, 'Invalid user id.');
+
+export const attachmentFileParamSchema = documentIdParamSchema.extend({
+  filename: storageFilenameSchema,
+});
+
+export const userFileParamSchema = z.object({
+  userId: storageUserIdSchema,
+  filename: storageFilenameSchema,
+});
+
+export type AttachmentFileParams = z.output<typeof attachmentFileParamSchema>;
+export type UserFileParams = z.output<typeof userFileParamSchema>;

--- a/apps/backend/src/schemas/storage.ts
+++ b/apps/backend/src/schemas/storage.ts
@@ -10,7 +10,15 @@ export const storageFilenameSchema = z
   .string()
   .min(1)
   .max(255)
-  .regex(/^[A-Za-z0-9_-][A-Za-z0-9._-]*$/, 'Invalid filename.');
+  .refine(
+    (value) =>
+      !/[/\\\0]/.test(value) &&
+      value !== '.' &&
+      value !== '..' &&
+      !value.startsWith('.') &&
+      value.trim().length > 0,
+    'Invalid filename.',
+  );
 
 export const storageUserIdSchema = z
   .string()

--- a/apps/backend/src/scripts/prune-orphans.mjs
+++ b/apps/backend/src/scripts/prune-orphans.mjs
@@ -141,9 +141,35 @@ if (skippedRecent > 0) {
   );
 }
 
+const missingContent = [];
+
+for (const row of (await client.execute('select id, document_id from revisions')).rows) {
+  const revisionId = String(row.id);
+  const path = join(STORAGE_DIR, 'revisions', `${revisionId}.json`);
+  const exists = await stat(path).then(
+    () => true,
+    () => false,
+  );
+  if (!exists) missingContent.push({ revisionId, documentId: String(row.document_id) });
+}
+
+if (missingContent.length > 0) {
+  console.log(
+    `\n  ⚠  ${missingContent.length} ${missingContent.length === 1 ? 'revision references' : 'revisions reference'} a content file that is not on disk.`,
+  );
+  console.log('     Documents holding one of these as their current version will fail to open.');
+  for (const { revisionId, documentId } of missingContent.slice(0, 20)) {
+    console.log(`       revision ${revisionId}  (document ${documentId})`);
+  }
+  if (missingContent.length > 20) {
+    console.log(`       … and ${missingContent.length - 20} more`);
+  }
+  console.log('     This script never deletes rows. Restore these files from a backup.\n');
+}
+
 if (orphans.length === 0) {
   console.log(`No orphans found under ${STORAGE_DIR}.`);
-  process.exit(0);
+  process.exit(missingContent.length > 0 ? 2 : 0);
 }
 
 const sizes = await Promise.all(orphans.map(sizeOf));

--- a/apps/backend/src/scripts/prune-orphans.mjs
+++ b/apps/backend/src/scripts/prune-orphans.mjs
@@ -183,8 +183,9 @@ if (orphans.length > 20) console.log(`  … and ${orphans.length - 20} more`);
 
 if (!APPLY) {
   console.log('\nNothing removed. Re-run with --delete to remove them.');
-  process.exit(0);
+  process.exit(missingContent.length > 0 ? 2 : 0);
 }
 
 await Promise.all(orphans.map((path) => rm(path, { recursive: true, force: true })));
 console.log(`\nRemoved ${orphans.length} entries (${totalMb} MB).`);
+process.exit(missingContent.length > 0 ? 2 : 0);

--- a/apps/backend/src/scripts/prune-orphans.mjs
+++ b/apps/backend/src/scripts/prune-orphans.mjs
@@ -63,6 +63,19 @@ const refuse = (reason) => {
   process.exit(1);
 };
 
+const dbFilePath = DB_URL.startsWith('file:')
+  ? resolve(
+      process.cwd(),
+      DB_URL.slice('file:'.length)
+        .split('?')[0]
+        .replace(/^\/\/(?=\/)/, ''),
+    )
+  : null;
+
+if (dbFilePath && !(await stat(dbFilePath).catch(() => null))) {
+  refuse(`No database file exists at ${dbFilePath}.`);
+}
+
 let client;
 
 try {
@@ -79,13 +92,15 @@ const tables = new Set(
   ).rows.map((row) => String(row.name)),
 );
 
-if (!tables.has('revisions') || !tables.has('documents')) {
-  refuse('It has no documents/revisions tables, so it is empty or not a WordyMe database.');
+if (!tables.has('revisions') || !tables.has('documents') || !tables.has('users')) {
+  refuse('It has no documents/revisions/users tables, so it is empty or not a WordyMe database.');
 }
 
-const [{ n: userCount }] = (await client.execute('select count(*) as n from users')).rows;
+const userRows = (
+  await client.execute('select count(*) as n from users').catch(() => ({ rows: [] }))
+).rows;
 
-if (Number(userCount) === 0) {
+if (userRows.length === 0 || Number(userRows[0].n) === 0) {
   refuse('It has no user accounts, so it has never been initialised.');
 }
 

--- a/apps/backend/src/scripts/prune-orphans.mjs
+++ b/apps/backend/src/scripts/prune-orphans.mjs
@@ -1,0 +1,149 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Removes revision content files and attachment directories left behind by
+ * document deletions from before those deletions cleaned up after themselves.
+ *
+ * Reports what it would remove and exits. Pass --delete to actually remove.
+ * Deliberately not run at startup: pointed at the wrong DB_FILE_NAME it would
+ * find every file unreferenced and wipe the storage directory.
+ */
+
+import 'dotenv/config';
+import { createClient } from '@libsql/client';
+import { readdir, rm, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+const STORAGE_DIR = resolve(process.cwd(), 'storage');
+const APPLY = process.argv.includes('--delete');
+
+/**
+ * Content files are written before the row that references them commits, so a
+ * file that is merely new is not evidence of an orphan. Ignoring anything
+ * touched recently keeps a live create from being swept when this runs against
+ * a serving instance.
+ */
+const MIN_AGE_MS = 60 * 60 * 1000;
+const CUTOFF = Date.now() - MIN_AGE_MS;
+
+const DB_URL = process.env.DB_FILE_NAME ?? 'file:storage/local.db';
+
+const listDir = async (path) => readdir(path, { withFileTypes: true }).catch(() => []);
+
+const newestMtime = async (path) => {
+  const entry = await stat(path).catch(() => null);
+  if (!entry) return 0;
+  if (entry.isFile()) return entry.mtimeMs;
+  const children = await listDir(path);
+  const times = await Promise.all(children.map((child) => newestMtime(join(path, child.name))));
+  return Math.max(entry.mtimeMs, ...times, 0);
+};
+
+const settledLongEnough = async (path) => (await newestMtime(path)) < CUTOFF;
+
+const sizeOf = async (path) => {
+  const entry = await stat(path).catch(() => null);
+  if (!entry) return 0;
+  if (entry.isFile()) return entry.size;
+  const children = await listDir(path);
+  const sizes = await Promise.all(children.map((child) => sizeOf(join(path, child.name))));
+  return sizes.reduce((total, size) => total + size, 0);
+};
+
+const refuse = (reason) => {
+  console.error(`\n  ✖  Refusing to scan ${STORAGE_DIR}.\n`);
+  console.error(`     ${reason}`);
+  console.error(`     DB_FILE_NAME  ${DB_URL}`);
+  console.error(
+    `\n     Without the right database every file here looks unreferenced, so\n     removing them would delete live data. Point DB_FILE_NAME at the database\n     this storage directory belongs to and run again.\n`,
+  );
+  process.exit(1);
+};
+
+let client;
+
+try {
+  client = createClient({ url: DB_URL });
+} catch (error) {
+  refuse(`It could not be opened: ${error.message}`);
+}
+
+const tables = new Set(
+  (
+    await client
+      .execute("select name from sqlite_master where type = 'table'")
+      .catch(() => ({ rows: [] }))
+  ).rows.map((row) => String(row.name)),
+);
+
+if (!tables.has('revisions') || !tables.has('documents')) {
+  refuse('It has no documents/revisions tables, so it is empty or not a WordyMe database.');
+}
+
+const [{ n: userCount }] = (await client.execute('select count(*) as n from users')).rows;
+
+if (Number(userCount) === 0) {
+  refuse('It has no user accounts, so it has never been initialised.');
+}
+
+const knownRevisions = new Set(
+  (await client.execute('select id from revisions')).rows.map((row) => String(row.id)),
+);
+const knownDocuments = new Set(
+  (await client.execute('select id from documents')).rows.map((row) => String(row.id)),
+);
+
+const orphans = [];
+let skippedRecent = 0;
+
+for (const entry of await listDir(join(STORAGE_DIR, 'revisions'))) {
+  if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+  if (knownRevisions.has(entry.name.replace(/\.json$/, ''))) continue;
+  const path = join(STORAGE_DIR, 'revisions', entry.name);
+  if (!(await settledLongEnough(path))) {
+    skippedRecent += 1;
+    continue;
+  }
+  orphans.push(path);
+}
+
+for (const entry of await listDir(join(STORAGE_DIR, 'attachments'))) {
+  if (!entry.isDirectory() || knownDocuments.has(entry.name)) continue;
+  const path = join(STORAGE_DIR, 'attachments', entry.name);
+  if (!(await settledLongEnough(path))) {
+    skippedRecent += 1;
+    continue;
+  }
+  orphans.push(path);
+}
+
+if (skippedRecent > 0) {
+  console.log(
+    `Skipped ${skippedRecent} unreferenced ${skippedRecent === 1 ? 'entry' : 'entries'} modified in the last hour, in case they belong to an in-flight write.`,
+  );
+}
+
+if (orphans.length === 0) {
+  console.log(`No orphans found under ${STORAGE_DIR}.`);
+  process.exit(0);
+}
+
+const sizes = await Promise.all(orphans.map(sizeOf));
+const totalMb = (sizes.reduce((total, size) => total + size, 0) / 1024 / 1024).toFixed(2);
+
+console.log(
+  `${orphans.length} orphaned ${orphans.length === 1 ? 'entry' : 'entries'} (${totalMb} MB) under ${STORAGE_DIR}:`,
+);
+for (const path of orphans.slice(0, 20)) console.log(`  ${path.replace(STORAGE_DIR, 'storage')}`);
+if (orphans.length > 20) console.log(`  … and ${orphans.length - 20} more`);
+
+if (!APPLY) {
+  console.log('\nNothing removed. Re-run with --delete to remove them.');
+  process.exit(0);
+}
+
+await Promise.all(orphans.map((path) => rm(path, { recursive: true, force: true })));
+console.log(`\nRemoved ${orphans.length} entries (${totalMb} MB).`);

--- a/apps/backend/src/services/attachments.ts
+++ b/apps/backend/src/services/attachments.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { access, cp, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, cp, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { join } from 'node:path';
 import { resolvePhysicalPath } from '../lib/storage.js';
@@ -47,30 +47,6 @@ export const copyDocumentAttachments = async (
     recursive: true,
     errorOnExist: false,
   });
-};
-
-export const exportDocumentAttachments = async (documentId: string): Promise<Attachment[]> => {
-  const directory = resolvePhysicalPath(`attachments/${documentId}`);
-
-  const entries = await readdir(directory, { withFileTypes: true }).catch((error) => {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
-    throw error;
-  });
-
-  const filenames = entries
-    .filter((entry) => entry.isFile())
-    .map((entry) => entry.name)
-    .sort((a, b) => a.localeCompare(b));
-
-  if (filenames.length === 0) return [];
-
-  const filePromises = filenames.map(async (filename) => {
-    const buffer = await readFile(join(directory, filename));
-    return { filename, url: bufferToDataURL(buffer) };
-  });
-
-  const attachments = await Promise.all(filePromises);
-  return attachments;
 };
 
 export const listDocumentAttachmentFiles = async (documentId: string) => {

--- a/apps/backend/src/services/attachments.ts
+++ b/apps/backend/src/services/attachments.ts
@@ -7,6 +7,7 @@ import { access, cp, mkdir, readdir, readFile, writeFile } from 'node:fs/promise
 import { constants } from 'node:fs';
 import { join } from 'node:path';
 import { resolvePhysicalPath } from '../lib/storage.js';
+import { sanitizeStoredFilename } from '../utils/strings.js';
 
 export const getAttachmentUrl = (documentId: string, filename: string) => {
   return `/storage/attachments/${documentId}/${filename}`;
@@ -80,6 +81,8 @@ export const importDocumentAttachment = async (
   await mkdir(directory, { recursive: true });
 
   const buffer = dataURLToBuffer(attachment.url);
-  const filePath = join(directory, attachment.filename);
+  const filePath = resolvePhysicalPath(
+    `attachments/${documentId}/${sanitizeStoredFilename(attachment.filename)}`,
+  );
   await writeFile(filePath, buffer);
 };

--- a/apps/backend/src/services/attachments.ts
+++ b/apps/backend/src/services/attachments.ts
@@ -18,7 +18,7 @@ export type Attachment = {
   url: string;
 };
 
-const bufferToDataURL = (buffer: Buffer): string => {
+export const bufferToDataURL = (buffer: Buffer): string => {
   const base64 = buffer.toString('base64');
   return `data:${'application/octet-stream'};base64,${base64}`;
 };
@@ -71,6 +71,21 @@ export const exportDocumentAttachments = async (documentId: string): Promise<Att
 
   const attachments = await Promise.all(filePromises);
   return attachments;
+};
+
+export const listDocumentAttachmentFiles = async (documentId: string) => {
+  const directory = resolvePhysicalPath(`attachments/${documentId}`);
+
+  const entries = await readdir(directory, { withFileTypes: true }).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  });
+
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b))
+    .map((filename) => ({ filename, path: join(directory, filename) }));
 };
 
 export const deleteDocumentAttachments = async (documentId: string) => {

--- a/apps/backend/src/services/attachments.ts
+++ b/apps/backend/src/services/attachments.ts
@@ -7,6 +7,7 @@ import { access, cp, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { join } from 'node:path';
 import { resolvePhysicalPath } from '../lib/storage.js';
+import { nanoid } from 'nanoid';
 import { sanitizeStoredFilename } from '../utils/strings.js';
 
 export const getAttachmentUrl = (documentId: string, filename: string) => {
@@ -79,8 +80,20 @@ export const importDocumentAttachment = async (
   await mkdir(directory, { recursive: true });
 
   const buffer = dataURLToBuffer(attachment.url);
-  const filePath = resolvePhysicalPath(
-    `attachments/${documentId}/${sanitizeStoredFilename(attachment.filename)}`,
-  );
-  await writeFile(filePath, buffer);
+  const stored = sanitizeStoredFilename(attachment.filename);
+  const dot = stored.lastIndexOf('.');
+  const stem = dot > 0 ? stored.slice(0, dot) : stored;
+  const extension = dot > 0 ? stored.slice(dot) : '';
+
+  let candidate = stored;
+
+  for (;;) {
+    try {
+      await writeFile(join(directory, candidate), buffer, { flag: 'wx' });
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      candidate = `${stem}_${nanoid(6)}${extension}`;
+    }
+  }
 };

--- a/apps/backend/src/services/attachments.ts
+++ b/apps/backend/src/services/attachments.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { access, cp, mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { access, cp, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { join } from 'node:path';
 import { resolvePhysicalPath } from '../lib/storage.js';
@@ -71,6 +71,13 @@ export const exportDocumentAttachments = async (documentId: string): Promise<Att
 
   const attachments = await Promise.all(filePromises);
   return attachments;
+};
+
+export const deleteDocumentAttachments = async (documentId: string) => {
+  await rm(resolvePhysicalPath(`attachments/${documentId}`), {
+    recursive: true,
+    force: true,
+  }).catch((error) => console.error(`Failed to remove attachments for ${documentId}:`, error));
 };
 
 export const importDocumentAttachment = async (

--- a/apps/backend/src/services/documents.ts
+++ b/apps/backend/src/services/documents.ts
@@ -261,6 +261,8 @@ const emitDocumentUpdate = (document: typeof documentsTable.$inferSelect) => {
     emitToUser(document.userId, 'space:updated', document);
   } else if (document.spaceId) {
     emitToSpace(document.spaceId, 'document:updated', document);
+  } else {
+    emitToUser(document.userId, 'document:updated', document);
   }
 };
 

--- a/apps/backend/src/services/documents.ts
+++ b/apps/backend/src/services/documents.ts
@@ -20,7 +20,7 @@ import { favoritesTable } from '../models/favorites.js';
 import { PaginatedResult, PaginationQuery } from '../schemas/pagination.js';
 import { CollectionQuery } from '../utils/collections.js';
 import { DocumentListItem } from '../schemas/documents.js';
-import { dbWritesQueue } from '../queues/db-writes.js';
+import { enqueueDbWrite } from '../queues/db-writes.js';
 import { emitToSpace, emitToUser } from '../lib/socket.js';
 import { revisionsTable } from '../models/revisions.js';
 import { saveRevisionContent } from './revision-contents.js';
@@ -254,7 +254,7 @@ export const updateDocument = async (documentId: string, payload: UpdateDocument
     });
 
     for (const child of children) {
-      dbWritesQueue.add(() => updateDocument(child.id, { spaceId }));
+      enqueueDbWrite(() => updateDocument(child.id, { spaceId }));
     }
   }
 

--- a/apps/backend/src/services/documents.ts
+++ b/apps/backend/src/services/documents.ts
@@ -6,7 +6,7 @@
 import crypto from 'node:crypto';
 import { and, count, countDistinct, eq, getTableColumns, gt, inArray, max, sql } from 'drizzle-orm';
 import { SQLiteColumn } from 'drizzle-orm/sqlite-core';
-import { HttpUnprocessableEntity } from '@httpx/exception';
+import { HttpConflict, HttpUnprocessableEntity } from '@httpx/exception';
 import { db, withWriteRetry } from '../lib/db.js';
 import { documentsTable } from '../models/documents.js';
 import {
@@ -311,15 +311,31 @@ export const updateDocument = async (documentId: string, payload: UpdateDocument
     }
   }
 
+  const { expectedCurrentRevisionId, ...updates } = payload;
+
   const { document, moved } = await withWriteRetry(() =>
     db.transaction(async (tx) => {
       if (payload.parentId) {
         await assertNoParentCycle(documentId, payload.parentId, tx);
       }
 
+      if (expectedCurrentRevisionId !== undefined) {
+        const [current] = await tx
+          .select({ currentRevisionId: documentsTable.currentRevisionId })
+          .from(documentsTable)
+          .where(eq(documentsTable.id, documentId))
+          .limit(1);
+
+        if (current && current.currentRevisionId !== expectedCurrentRevisionId) {
+          throw new HttpConflict(
+            'This document was changed somewhere else since you opened it. Reload to get the latest version; your work was kept as a separate revision.',
+          );
+        }
+      }
+
       const [document] = await tx
         .update(documentsTable)
-        .set({ ...payload, handle })
+        .set({ ...updates, handle })
         .where(eq(documentsTable.id, documentId))
         .returning();
 

--- a/apps/backend/src/services/documents.ts
+++ b/apps/backend/src/services/documents.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { and, count, countDistinct, eq, getTableColumns, gt, max } from 'drizzle-orm';
+import crypto from 'node:crypto';
+import { and, count, countDistinct, eq, getTableColumns, gt, inArray, max, sql } from 'drizzle-orm';
 import { SQLiteColumn } from 'drizzle-orm/sqlite-core';
-import { db } from '../lib/db.js';
+import { db, withWriteRetry } from '../lib/db.js';
 import { documentsTable } from '../models/documents.js';
 import {
   CreateDocumentInput,
@@ -23,7 +24,8 @@ import { DocumentListItem } from '../schemas/documents.js';
 import { enqueueDbWrite } from '../queues/db-writes.js';
 import { emitToSpace, emitToUser } from '../lib/socket.js';
 import { revisionsTable } from '../models/revisions.js';
-import { saveRevisionContent } from './revision-contents.js';
+import { deleteRevisionContent, saveRevisionContent } from './revision-contents.js';
+import { deleteDocumentAttachments } from './attachments.js';
 
 export const orderByColumns = {
   name: documentsTable.name,
@@ -31,8 +33,15 @@ export const orderByColumns = {
   lastViewedAt: documentViewsTable.lastViewedAt,
 } satisfies Record<string, SQLiteColumn>;
 
-export const checkExistingDocumentHandle = async (handle: string) => {
-  const result = await db.select().from(documentsTable).where(eq(documentsTable.handle, handle));
+export const checkExistingDocumentHandle = async (
+  handle: string,
+  executor: Pick<typeof db, 'select'> = db,
+) => {
+  const result = await executor
+    .select({ id: documentsTable.id })
+    .from(documentsTable)
+    .where(eq(documentsTable.handle, handle))
+    .limit(1);
   return result.length > 0;
 };
 
@@ -174,48 +183,59 @@ export const createDocumentWithRevision = async (
   payload: CreateDocumentWithRevisionInput,
   userId: string,
 ) => {
-  const result = await db.transaction(async (tx) => {
-    let handle = slugify(payload.name);
-    if (await checkExistingDocumentHandle(handle)) {
-      handle = appendUniqueSuffix(handle);
-    }
-    const [document] = await tx
-      .insert(documentsTable)
-      .values({
-        ...payload,
-        handle,
-        userId,
-      })
-      .returning();
+  const revisionId = crypto.randomUUID();
+  await saveRevisionContent(payload.revision.content, revisionId);
 
-    const [revision] = await tx
-      .insert(revisionsTable)
-      .values({
-        documentId: document.id,
-        text: payload.revision.text,
-        checksum: payload.revision.checksum,
-        revisionName: payload.revision.revisionName,
-        userId,
-      })
-      .returning();
+  let result;
 
-    await saveRevisionContent(payload.revision.content, revision.id);
+  try {
+    result = await withWriteRetry(() =>
+      db.transaction(async (tx) => {
+        let handle = slugify(payload.name);
+        if (await checkExistingDocumentHandle(handle, tx)) {
+          handle = appendUniqueSuffix(handle);
+        }
+        const [document] = await tx
+          .insert(documentsTable)
+          .values({
+            ...payload,
+            handle,
+            userId,
+          })
+          .returning();
 
-    await tx
-      .update(documentsTable)
-      .set({
-        currentRevisionId: revision.id,
-      })
-      .where(eq(documentsTable.id, document.id));
+        const [revision] = await tx
+          .insert(revisionsTable)
+          .values({
+            id: revisionId,
+            documentId: document.id,
+            text: payload.revision.text,
+            checksum: payload.revision.checksum,
+            revisionName: payload.revision.revisionName,
+            userId,
+          })
+          .returning();
 
-    return {
-      ...document,
-      currentRevisionId: revision.id,
-      currentRevision: revision,
-      isFavorite: false,
-      lastViewedAt: null,
-    };
-  });
+        await tx
+          .update(documentsTable)
+          .set({
+            currentRevisionId: revision.id,
+          })
+          .where(eq(documentsTable.id, document.id));
+
+        return {
+          ...document,
+          currentRevisionId: revision.id,
+          currentRevision: revision,
+          isFavorite: false,
+          lastViewedAt: null,
+        };
+      }),
+    );
+  } catch (error) {
+    await deleteRevisionContent(revisionId);
+    throw error;
+  }
 
   if (payload.documentType === 'space') {
     emitToUser(userId, 'space:created', result);
@@ -284,12 +304,44 @@ export const getUserDocumentCount = async (userId: string): Promise<number> => {
 };
 
 export const deleteDocument = async (documentId: string) => {
-  const [document] = await db
-    .delete(documentsTable)
-    .where(eq(documentsTable.id, documentId))
-    .returning();
+  const { document, documentIds, revisionIds } = await withWriteRetry(() =>
+    db.transaction(async (tx) => {
+      const subtree = await tx.all<{ id: string }>(sql`
+        with recursive subtree(id) as (
+          select id from documents where id = ${documentId}
+          union
+          select d.id from documents d
+            join subtree s on d.parent_id = s.id or d.space_id = s.id
+        )
+        select id from subtree
+      `);
+      const documentIds = subtree.map((row) => row.id);
+
+      const revisionIds =
+        documentIds.length > 0
+          ? (
+              await tx
+                .select({ id: revisionsTable.id })
+                .from(revisionsTable)
+                .where(inArray(revisionsTable.documentId, documentIds))
+            ).map((row) => row.id)
+          : [];
+
+      const [document] = await tx
+        .delete(documentsTable)
+        .where(eq(documentsTable.id, documentId))
+        .returning();
+
+      return { document, documentIds, revisionIds };
+    }),
+  );
 
   if (!document) return;
+
+  await Promise.all([
+    ...revisionIds.map(deleteRevisionContent),
+    ...documentIds.map(deleteDocumentAttachments),
+  ]);
 
   if (document.documentType === 'space') {
     emitToUser(document.userId, 'space:deleted', document);

--- a/apps/backend/src/services/documents.ts
+++ b/apps/backend/src/services/documents.ts
@@ -264,8 +264,10 @@ const emitDocumentUpdate = (document: typeof documentsTable.$inferSelect) => {
   }
 };
 
-const descendantIds = async (documentId: string): Promise<string[]> => {
-  const rows = await db.all<{ id: string }>(sql`
+type SqlExecutor = Pick<typeof db, 'all'>;
+
+const descendantIds = async (documentId: string, executor: SqlExecutor = db): Promise<string[]> => {
+  const rows = await executor.all<{ id: string }>(sql`
     with recursive subtree(id) as (
       select id from documents where parent_id = ${documentId}
       union
@@ -277,14 +279,18 @@ const descendantIds = async (documentId: string): Promise<string[]> => {
   return rows.map((row) => row.id);
 };
 
-export const assertNoParentCycle = async (documentId: string, parentId: string) => {
+export const assertNoParentCycle = async (
+  documentId: string,
+  parentId: string,
+  executor: SqlExecutor = db,
+) => {
   if (parentId === documentId) {
     throw new HttpUnprocessableEntity({
       message: 'A document cannot be its own parent.',
     });
   }
 
-  const descendants = await descendantIds(documentId);
+  const descendants = await descendantIds(documentId, executor);
 
   if (descendants.includes(parentId)) {
     throw new HttpUnprocessableEntity({
@@ -294,7 +300,7 @@ export const assertNoParentCycle = async (documentId: string, parentId: string) 
 };
 
 export const updateDocument = async (documentId: string, payload: UpdateDocumentInput) => {
-  let handle;
+  let handle: string | undefined;
 
   if (payload.name) {
     handle = slugify(payload.name);
@@ -303,31 +309,40 @@ export const updateDocument = async (documentId: string, payload: UpdateDocument
     }
   }
 
-  if (payload.parentId) {
-    await assertNoParentCycle(documentId, payload.parentId);
-  }
+  const { document, moved } = await withWriteRetry(() =>
+    db.transaction(async (tx) => {
+      if (payload.parentId) {
+        await assertNoParentCycle(documentId, payload.parentId, tx);
+      }
 
-  const [document] = await db
-    .update(documentsTable)
-    .set({ ...payload, handle })
-    .where(eq(documentsTable.id, documentId))
-    .returning();
+      const [document] = await tx
+        .update(documentsTable)
+        .set({ ...payload, handle })
+        .where(eq(documentsTable.id, documentId))
+        .returning();
 
-  emitDocumentUpdate(document);
+      if (!payload.spaceId) {
+        return { document, moved: [] as (typeof documentsTable.$inferSelect)[] };
+      }
 
-  if (payload.spaceId) {
-    const ids = await descendantIds(documentId);
+      const ids = await descendantIds(documentId, tx);
 
-    if (ids.length > 0) {
-      const moved = await db
+      if (ids.length === 0) {
+        return { document, moved: [] as (typeof documentsTable.$inferSelect)[] };
+      }
+
+      const moved = await tx
         .update(documentsTable)
         .set({ spaceId: payload.spaceId })
         .where(inArray(documentsTable.id, ids))
         .returning();
 
-      moved.forEach(emitDocumentUpdate);
-    }
-  }
+      return { document, moved };
+    }),
+  );
+
+  emitDocumentUpdate(document);
+  moved.forEach(emitDocumentUpdate);
 
   return document;
 };

--- a/apps/backend/src/services/documents.ts
+++ b/apps/backend/src/services/documents.ts
@@ -4,7 +4,18 @@
  */
 
 import crypto from 'node:crypto';
-import { and, count, countDistinct, eq, getTableColumns, gt, inArray, max, sql } from 'drizzle-orm';
+import {
+  and,
+  count,
+  countDistinct,
+  eq,
+  getTableColumns,
+  gt,
+  inArray,
+  max,
+  ne,
+  sql,
+} from 'drizzle-orm';
 import { SQLiteColumn } from 'drizzle-orm/sqlite-core';
 import { HttpConflict, HttpUnprocessableEntity } from '@httpx/exception';
 import { db, withWriteRetry } from '../lib/db.js';
@@ -36,11 +47,16 @@ export const orderByColumns = {
 export const checkExistingDocumentHandle = async (
   handle: string,
   executor: Pick<typeof db, 'select'> = db,
+  excludeDocumentId?: string,
 ) => {
   const result = await executor
     .select({ id: documentsTable.id })
     .from(documentsTable)
-    .where(eq(documentsTable.handle, handle))
+    .where(
+      excludeDocumentId
+        ? and(eq(documentsTable.handle, handle), ne(documentsTable.id, excludeDocumentId))
+        : eq(documentsTable.handle, handle),
+    )
     .limit(1);
   return result.length > 0;
 };
@@ -326,10 +342,10 @@ export const updateDocument = async (documentId: string, payload: UpdateDocument
   let handle: string | undefined;
 
   if (payload.name) {
-    handle = slugify(payload.name);
-    if (await checkExistingDocumentHandle(handle)) {
-      handle = appendUniqueSuffix(handle);
-    }
+    const candidate = slugify(payload.name);
+    handle = (await checkExistingDocumentHandle(candidate, db, documentId))
+      ? appendUniqueSuffix(candidate)
+      : candidate;
   }
 
   const { expectedCurrentRevisionId, ...updates } = payload;

--- a/apps/backend/src/services/documents.ts
+++ b/apps/backend/src/services/documents.ts
@@ -281,22 +281,43 @@ const descendantIds = async (documentId: string, executor: SqlExecutor = db): Pr
   return rows.map((row) => row.id);
 };
 
-export const assertNoParentCycle = async (
+const subtreeIds = async (documentId: string, executor: SqlExecutor = db): Promise<string[]> => {
+  const rows = await executor.all<{ id: string }>(sql`
+    with recursive subtree(id) as (
+      select id from documents where parent_id = ${documentId} or space_id = ${documentId}
+      union
+      select d.id from documents d
+        join subtree s on d.parent_id = s.id or d.space_id = s.id
+    )
+    select id from subtree where id <> ${documentId}
+  `);
+
+  return rows.map((row) => row.id);
+};
+
+export const assertNoTreeCycle = async (
   documentId: string,
-  parentId: string,
+  targetId: string,
+  relation: 'parent' | 'space',
   executor: SqlExecutor = db,
 ) => {
-  if (parentId === documentId) {
+  if (targetId === documentId) {
     throw new HttpUnprocessableEntity({
-      message: 'A document cannot be its own parent.',
+      message:
+        relation === 'parent'
+          ? 'A document cannot be its own parent.'
+          : 'A document cannot be its own space.',
     });
   }
 
-  const descendants = await descendantIds(documentId, executor);
+  const descendants = await subtreeIds(documentId, executor);
 
-  if (descendants.includes(parentId)) {
+  if (descendants.includes(targetId)) {
     throw new HttpUnprocessableEntity({
-      message: 'A document cannot be moved inside one of its own descendants.',
+      message:
+        relation === 'parent'
+          ? 'A document cannot be moved inside one of its own descendants.'
+          : 'A document cannot be placed inside a space it contains.',
     });
   }
 };
@@ -316,7 +337,11 @@ export const updateDocument = async (documentId: string, payload: UpdateDocument
   const { document, moved } = await withWriteRetry(() =>
     db.transaction(async (tx) => {
       if (payload.parentId) {
-        await assertNoParentCycle(documentId, payload.parentId, tx);
+        await assertNoTreeCycle(documentId, payload.parentId, 'parent', tx);
+      }
+
+      if (payload.spaceId) {
+        await assertNoTreeCycle(documentId, payload.spaceId, 'space', tx);
       }
 
       if (expectedCurrentRevisionId !== undefined) {

--- a/apps/backend/src/services/documents.ts
+++ b/apps/backend/src/services/documents.ts
@@ -6,6 +6,7 @@
 import crypto from 'node:crypto';
 import { and, count, countDistinct, eq, getTableColumns, gt, inArray, max, sql } from 'drizzle-orm';
 import { SQLiteColumn } from 'drizzle-orm/sqlite-core';
+import { HttpUnprocessableEntity } from '@httpx/exception';
 import { db, withWriteRetry } from '../lib/db.js';
 import { documentsTable } from '../models/documents.js';
 import {
@@ -21,7 +22,6 @@ import { favoritesTable } from '../models/favorites.js';
 import { PaginatedResult, PaginationQuery } from '../schemas/pagination.js';
 import { CollectionQuery } from '../utils/collections.js';
 import { DocumentListItem } from '../schemas/documents.js';
-import { enqueueDbWrite } from '../queues/db-writes.js';
 import { emitToSpace, emitToUser } from '../lib/socket.js';
 import { revisionsTable } from '../models/revisions.js';
 import { deleteRevisionContent, saveRevisionContent } from './revision-contents.js';
@@ -256,6 +256,43 @@ export const viewDocument = async (documentId: string, userId: string) => {
     });
 };
 
+const emitDocumentUpdate = (document: typeof documentsTable.$inferSelect) => {
+  if (document.documentType === 'space') {
+    emitToUser(document.userId, 'space:updated', document);
+  } else if (document.spaceId) {
+    emitToSpace(document.spaceId, 'document:updated', document);
+  }
+};
+
+const descendantIds = async (documentId: string): Promise<string[]> => {
+  const rows = await db.all<{ id: string }>(sql`
+    with recursive subtree(id) as (
+      select id from documents where parent_id = ${documentId}
+      union
+      select d.id from documents d join subtree s on d.parent_id = s.id
+    )
+    select id from subtree where id <> ${documentId}
+  `);
+
+  return rows.map((row) => row.id);
+};
+
+export const assertNoParentCycle = async (documentId: string, parentId: string) => {
+  if (parentId === documentId) {
+    throw new HttpUnprocessableEntity({
+      message: 'A document cannot be its own parent.',
+    });
+  }
+
+  const descendants = await descendantIds(documentId);
+
+  if (descendants.includes(parentId)) {
+    throw new HttpUnprocessableEntity({
+      message: 'A document cannot be moved inside one of its own descendants.',
+    });
+  }
+};
+
 export const updateDocument = async (documentId: string, payload: UpdateDocumentInput) => {
   let handle;
 
@@ -266,16 +303,8 @@ export const updateDocument = async (documentId: string, payload: UpdateDocument
     }
   }
 
-  if (payload.spaceId) {
-    const spaceId = payload.spaceId;
-
-    const children = await db.query.documentsTable.findMany({
-      where: eq(documentsTable.parentId, documentId),
-    });
-
-    for (const child of children) {
-      enqueueDbWrite(() => updateDocument(child.id, { spaceId }));
-    }
+  if (payload.parentId) {
+    await assertNoParentCycle(documentId, payload.parentId);
   }
 
   const [document] = await db
@@ -284,10 +313,20 @@ export const updateDocument = async (documentId: string, payload: UpdateDocument
     .where(eq(documentsTable.id, documentId))
     .returning();
 
-  if (document.documentType === 'space') {
-    emitToUser(document.userId, 'space:updated', document);
-  } else if (document.spaceId) {
-    emitToSpace(document.spaceId, 'document:updated', document);
+  emitDocumentUpdate(document);
+
+  if (payload.spaceId) {
+    const ids = await descendantIds(documentId);
+
+    if (ids.length > 0) {
+      const moved = await db
+        .update(documentsTable)
+        .set({ spaceId: payload.spaceId })
+        .where(inArray(documentsTable.id, ids))
+        .returning();
+
+      moved.forEach(emitDocumentUpdate);
+    }
   }
 
   return document;

--- a/apps/backend/src/services/images.ts
+++ b/apps/backend/src/services/images.ts
@@ -8,8 +8,10 @@ import { db } from '../lib/db.js';
 import { users } from '../models/auth.js';
 import { ImageMeta } from '../schemas/images.js';
 import { resolvePhysicalPath } from '../lib/storage.js';
-import { readdir, rm } from 'node:fs/promises';
+import { readdir, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
+
+const PRUNE_MIN_AGE_MS = 60 * 60 * 1000;
 
 export const getUserImageUrl = async (userId: string, filename: string) => {
   return `storage/images/${userId}/${filename}`;
@@ -25,11 +27,16 @@ const pruneSiblings = async (directory: string, keep: string) => {
   await Promise.all(
     entries
       .filter((entry) => entry !== keep)
-      .map((entry) =>
-        rm(join(directory, entry), { force: true }).catch((error) =>
-          console.error(`Failed to remove stale upload ${entry}:`, error),
-        ),
-      ),
+      .map(async (entry) => {
+        const entryPath = join(directory, entry);
+        try {
+          const info = await stat(entryPath);
+          if (Date.now() - info.mtimeMs < PRUNE_MIN_AGE_MS) return;
+          await rm(entryPath, { force: true });
+        } catch (error) {
+          console.error(`Failed to remove stale upload ${entry}:`, error);
+        }
+      }),
   );
 };
 

--- a/apps/backend/src/services/images.ts
+++ b/apps/backend/src/services/images.ts
@@ -8,7 +8,8 @@ import { db } from '../lib/db.js';
 import { users } from '../models/auth.js';
 import { ImageMeta } from '../schemas/images.js';
 import { resolvePhysicalPath } from '../lib/storage.js';
-import { rm } from 'node:fs/promises';
+import { readdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
 
 export const getUserImageUrl = async (userId: string, filename: string) => {
   return `storage/images/${userId}/${filename}`;
@@ -18,10 +19,25 @@ export const getUserCoverUrl = async (userId: string, filename: string) => {
   return `storage/covers/${userId}/${filename}`;
 };
 
+const pruneSiblings = async (directory: string, keep: string) => {
+  const entries = await readdir(directory).catch(() => [] as string[]);
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry !== keep)
+      .map((entry) =>
+        rm(join(directory, entry), { force: true }).catch((error) =>
+          console.error(`Failed to remove stale upload ${entry}:`, error),
+        ),
+      ),
+  );
+};
+
 export const updateUserImage = async (userId: string, filename: string, imageMeta: ImageMeta) => {
   const imageUrl = await getUserImageUrl(userId, filename);
 
   await db.update(users).set({ image: imageUrl, imageMeta }).where(eq(users.id, userId));
+  await pruneSiblings(resolvePhysicalPath(`images/${userId}`), filename);
 
   return { url: imageUrl, meta: imageMeta };
 };
@@ -35,6 +51,7 @@ export const updateUserCover = async (userId: string, filename: string, coverMet
   const coverUrl = await getUserCoverUrl(userId, filename);
 
   await db.update(users).set({ cover: coverUrl, coverMeta }).where(eq(users.id, userId));
+  await pruneSiblings(resolvePhysicalPath(`covers/${userId}`), filename);
 
   return { url: coverUrl, meta: coverMeta };
 };

--- a/apps/backend/src/services/operations.ts
+++ b/apps/backend/src/services/operations.ts
@@ -26,7 +26,15 @@ export const copyDocument = async (
   documentId: string,
   payload: CopyDocumentInput,
   userId: string,
+  visitedDocuments: Set<string> = new Set(),
+  currentDepth: number = 0,
 ) => {
+  if (visitedDocuments.has(documentId) || currentDepth >= MAX_IMPORT_DEPTH) {
+    return false;
+  }
+
+  visitedDocuments.add(documentId);
+
   const originalDocument = await db.query.documentsTable.findFirst({
     where: eq(documentsTable.id, documentId),
   });
@@ -74,6 +82,8 @@ export const copyDocument = async (
           spaceId: child.spaceId === documentId ? newDocument.id : newDocument.spaceId,
         },
         userId,
+        visitedDocuments,
+        currentDepth + 1,
       ),
     ),
   );

--- a/apps/backend/src/services/operations.ts
+++ b/apps/backend/src/services/operations.ts
@@ -19,7 +19,6 @@ import {
   exportDocumentAttachments,
   importDocumentAttachment,
 } from './attachments.js';
-import { enqueueDbWrite } from '../queues/db-writes.js';
 import { readRevisionContent } from './revision-contents.js';
 
 export const copyDocument = async (
@@ -71,22 +70,20 @@ export const copyDocument = async (
     ),
   });
 
-  children.map((child) =>
-    enqueueDbWrite(() =>
-      copyDocument(
-        child.id,
-        {
-          name: child.name,
-          position: child.position,
-          parentId: child.parentId === documentId ? newDocument.id : null,
-          spaceId: child.spaceId === documentId ? newDocument.id : newDocument.spaceId,
-        },
-        userId,
-        visitedDocuments,
-        currentDepth + 1,
-      ),
-    ),
-  );
+  for (const child of children) {
+    await copyDocument(
+      child.id,
+      {
+        name: child.name,
+        position: child.position,
+        parentId: child.parentId === documentId ? newDocument.id : null,
+        spaceId: child.spaceId === documentId ? newDocument.id : newDocument.spaceId,
+      },
+      userId,
+      visitedDocuments,
+      currentDepth + 1,
+    );
+  }
 
   return newDocument;
 };
@@ -194,34 +191,30 @@ export const importDocumentTree = async (
   );
 
   for (const child of payload.document.children) {
-    enqueueDbWrite(() =>
-      importDocumentTree(
-        {
-          document: child,
-          type: child.type,
-          spaceId: payload.spaceId,
-          parentId: newDocument.id,
-          position: child.position,
-        },
-        userId,
-        currentDepth + 1,
-      ),
+    await importDocumentTree(
+      {
+        document: child,
+        type: child.type,
+        spaceId: payload.spaceId,
+        parentId: newDocument.id,
+        position: child.position,
+      },
+      userId,
+      currentDepth + 1,
     );
   }
 
   for (const spaceChild of payload.document.spaceRootChildren) {
-    enqueueDbWrite(() =>
-      importDocumentTree(
-        {
-          document: spaceChild,
-          type: spaceChild.type,
-          spaceId: newDocument.id,
-          parentId: null,
-          position: spaceChild.position,
-        },
-        userId,
-        currentDepth + 1,
-      ),
+    await importDocumentTree(
+      {
+        document: spaceChild,
+        type: spaceChild.type,
+        spaceId: newDocument.id,
+        parentId: null,
+        position: spaceChild.position,
+      },
+      userId,
+      currentDepth + 1,
     );
   }
 

--- a/apps/backend/src/services/operations.ts
+++ b/apps/backend/src/services/operations.ts
@@ -5,12 +5,7 @@
 
 import { and, eq, isNull, or } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import {
-  CopyDocumentInput,
-  ExportedDocument,
-  ImportDocumentInput,
-  MAX_IMPORT_DEPTH,
-} from '../schemas/operations.js';
+import { CopyDocumentInput, ImportDocumentInput, MAX_IMPORT_DEPTH } from '../schemas/operations.js';
 import { documentsTable } from '../models/documents.js';
 import { createDocument, createDocumentWithRevision } from './documents.js';
 import { getRevisionById } from './revisions.js';
@@ -18,7 +13,6 @@ import { readFile, stat } from 'node:fs/promises';
 import {
   bufferToDataURL,
   copyDocumentAttachments,
-  exportDocumentAttachments,
   importDocumentAttachment,
   listDocumentAttachmentFiles,
 } from './attachments.js';
@@ -89,72 +83,6 @@ export const copyDocument = async (
   }
 
   return newDocument;
-};
-
-export const exportDocumentTree = async (
-  documentId: string,
-  visitedDocuments: Set<string> = new Set(),
-  currentDepth: number = 0,
-): Promise<ExportedDocument> => {
-  if (visitedDocuments.has(documentId)) {
-    throw new Error(`Circular reference detected: document ${documentId} was already processed`);
-  }
-
-  if (currentDepth >= MAX_IMPORT_DEPTH) {
-    throw new Error(`Maximum depth reached: ${currentDepth} levels of nested documents`);
-  }
-
-  visitedDocuments.add(documentId);
-
-  const document = await db.query.documentsTable.findFirst({
-    where: eq(documentsTable.id, documentId),
-    with: {
-      currentRevision: true,
-    },
-  });
-
-  if (!document) {
-    throw new Error(`Document ${documentId} not found`);
-  }
-
-  const currentRevision = document.currentRevision;
-
-  const exportedDocument: ExportedDocument = {
-    name: document.name,
-    handle: document.handle,
-    icon: document.icon,
-    type: document.documentType,
-    position: document.position,
-    is_container: document.isContainer,
-    revision: currentRevision
-      ? {
-          text: currentRevision.text,
-          checksum: currentRevision.checksum,
-          content: await readRevisionContent(currentRevision.id),
-        }
-      : null,
-    attachments: await exportDocumentAttachments(documentId),
-    children: [],
-    spaceRootChildren: [],
-  };
-
-  const children = await db.query.documentsTable.findMany({
-    where: or(
-      eq(documentsTable.parentId, documentId),
-      and(eq(documentsTable.spaceId, documentId), isNull(documentsTable.parentId)),
-    ),
-  });
-
-  for (const child of children) {
-    const childResult = await exportDocumentTree(child.id, visitedDocuments, currentDepth + 1);
-    if (child.parentId === documentId) {
-      exportedDocument.children.push(childResult);
-    } else {
-      exportedDocument.spaceRootChildren.push(childResult);
-    }
-  }
-
-  return exportedDocument;
 };
 
 export const MAX_EXPORT_BYTES = 50 * 1024 * 1024;

--- a/apps/backend/src/services/operations.ts
+++ b/apps/backend/src/services/operations.ts
@@ -5,7 +5,12 @@
 
 import { and, eq, isNull, or } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { CopyDocumentInput, ExportedDocument, ImportDocumentInput } from '../schemas/operations.js';
+import {
+  CopyDocumentInput,
+  ExportedDocument,
+  ImportDocumentInput,
+  MAX_IMPORT_DEPTH,
+} from '../schemas/operations.js';
 import { documentsTable } from '../models/documents.js';
 import { createDocument, createDocumentWithRevision } from './documents.js';
 import { getRevisionById } from './revisions.js';
@@ -14,7 +19,7 @@ import {
   exportDocumentAttachments,
   importDocumentAttachment,
 } from './attachments.js';
-import { dbWritesQueue } from '../queues/db-writes.js';
+import { enqueueDbWrite } from '../queues/db-writes.js';
 import { readRevisionContent } from './revision-contents.js';
 
 export const copyDocument = async (
@@ -59,7 +64,7 @@ export const copyDocument = async (
   });
 
   children.map((child) =>
-    dbWritesQueue.add(() =>
+    enqueueDbWrite(() =>
       copyDocument(
         child.id,
         {
@@ -85,7 +90,7 @@ export const exportDocumentTree = async (
     throw new Error(`Circular reference detected: document ${documentId} was already processed`);
   }
 
-  if (currentDepth >= 100) {
+  if (currentDepth >= MAX_IMPORT_DEPTH) {
     throw new Error(`Maximum depth reached: ${currentDepth} levels of nested documents`);
   }
 
@@ -147,7 +152,7 @@ export const importDocumentTree = async (
   userId: string,
   currentDepth: number = 0,
 ): Promise<{ id: string; name: string }> => {
-  if (currentDepth >= 100) {
+  if (currentDepth >= MAX_IMPORT_DEPTH) {
     throw new Error(`Maximum depth reached: ${currentDepth} levels of nested documents`);
   }
 
@@ -179,7 +184,7 @@ export const importDocumentTree = async (
   );
 
   for (const child of payload.document.children) {
-    dbWritesQueue.add(() =>
+    enqueueDbWrite(() =>
       importDocumentTree(
         {
           document: child,
@@ -195,7 +200,7 @@ export const importDocumentTree = async (
   }
 
   for (const spaceChild of payload.document.spaceRootChildren) {
-    dbWritesQueue.add(() =>
+    enqueueDbWrite(() =>
       importDocumentTree(
         {
           document: spaceChild,

--- a/apps/backend/src/services/operations.ts
+++ b/apps/backend/src/services/operations.ts
@@ -14,12 +14,15 @@ import {
 import { documentsTable } from '../models/documents.js';
 import { createDocument, createDocumentWithRevision } from './documents.js';
 import { getRevisionById } from './revisions.js';
+import { readFile, stat } from 'node:fs/promises';
 import {
+  bufferToDataURL,
   copyDocumentAttachments,
   exportDocumentAttachments,
   importDocumentAttachment,
+  listDocumentAttachmentFiles,
 } from './attachments.js';
-import { readRevisionContent } from './revision-contents.js';
+import { getRevisionContentPhysicalPath, readRevisionContent } from './revision-contents.js';
 
 export const copyDocument = async (
   documentId: string,
@@ -152,6 +155,122 @@ export const exportDocumentTree = async (
   }
 
   return exportedDocument;
+};
+
+export const MAX_EXPORT_BYTES = 50 * 1024 * 1024;
+
+const BASE64_OVERHEAD = 4 / 3;
+
+const childDocumentsOf = async (documentId: string) =>
+  db.query.documentsTable.findMany({
+    where: or(
+      eq(documentsTable.parentId, documentId),
+      and(eq(documentsTable.spaceId, documentId), isNull(documentsTable.parentId)),
+    ),
+  });
+
+export const estimateExportBytes = async (
+  documentId: string,
+  visitedDocuments: Set<string> = new Set(),
+): Promise<number> => {
+  if (visitedDocuments.has(documentId)) return 0;
+  visitedDocuments.add(documentId);
+
+  const document = await db.query.documentsTable.findFirst({
+    where: eq(documentsTable.id, documentId),
+    with: { currentRevision: true },
+  });
+
+  if (!document) return 0;
+
+  let total = 512;
+
+  if (document.currentRevision) {
+    const revisionPath = getRevisionContentPhysicalPath(document.currentRevision.id);
+    total += await stat(revisionPath).then(
+      (info) => info.size,
+      () => 0,
+    );
+    total += document.currentRevision.text?.length ?? 0;
+  }
+
+  for (const file of await listDocumentAttachmentFiles(documentId)) {
+    const size = await stat(file.path).then(
+      (info) => info.size,
+      () => 0,
+    );
+    total += Math.ceil(size * BASE64_OVERHEAD) + file.filename.length + 64;
+  }
+
+  for (const child of await childDocumentsOf(documentId)) {
+    total += await estimateExportBytes(child.id, visitedDocuments);
+  }
+
+  return total;
+};
+
+export const streamDocumentTree = async function* (
+  documentId: string,
+  visitedDocuments: Set<string> = new Set(),
+  currentDepth: number = 0,
+): AsyncGenerator<string> {
+  if (visitedDocuments.has(documentId)) {
+    throw new Error(`Circular reference detected: document ${documentId} was already processed`);
+  }
+
+  if (currentDepth >= MAX_IMPORT_DEPTH) {
+    throw new Error(`Maximum depth reached: ${currentDepth} levels of nested documents`);
+  }
+
+  visitedDocuments.add(documentId);
+
+  const document = await db.query.documentsTable.findFirst({
+    where: eq(documentsTable.id, documentId),
+    with: { currentRevision: true },
+  });
+
+  if (!document) {
+    throw new Error(`Document ${documentId} not found`);
+  }
+
+  yield `{"name":${JSON.stringify(document.name)},"handle":${JSON.stringify(document.handle)},"icon":${JSON.stringify(document.icon)},"type":${JSON.stringify(document.documentType)},"position":${JSON.stringify(document.position)},"is_container":${JSON.stringify(document.isContainer)},"revision":`;
+
+  if (document.currentRevision) {
+    const content = await readRevisionContent(document.currentRevision.id);
+    yield `{"text":${JSON.stringify(document.currentRevision.text)},"checksum":${JSON.stringify(document.currentRevision.checksum)},"content":${JSON.stringify(content)}}`;
+  } else {
+    yield 'null';
+  }
+
+  yield ',"attachments":[';
+
+  const attachmentFiles = await listDocumentAttachmentFiles(documentId);
+
+  for (const [index, file] of attachmentFiles.entries()) {
+    if (index > 0) yield ',';
+    const buffer = await readFile(file.path);
+    yield `{"filename":${JSON.stringify(file.filename)},"url":${JSON.stringify(bufferToDataURL(buffer))}}`;
+  }
+
+  yield '],"children":[';
+
+  const children = await childDocumentsOf(documentId);
+  const nested = children.filter((child) => child.parentId === documentId);
+  const spaceRoot = children.filter((child) => child.parentId !== documentId);
+
+  for (const [index, child] of nested.entries()) {
+    if (index > 0) yield ',';
+    yield* streamDocumentTree(child.id, visitedDocuments, currentDepth + 1);
+  }
+
+  yield '],"spaceRootChildren":[';
+
+  for (const [index, child] of spaceRoot.entries()) {
+    if (index > 0) yield ',';
+    yield* streamDocumentTree(child.id, visitedDocuments, currentDepth + 1);
+  }
+
+  yield ']}';
 };
 
 export const importDocumentTree = async (

--- a/apps/backend/src/services/operations.ts
+++ b/apps/backend/src/services/operations.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { HttpInternalServerError } from '@httpx/exception';
 import { and, eq, isNull, or } from 'drizzle-orm';
 import { db } from '../lib/db.js';
 import { CopyDocumentInput, ImportDocumentInput, MAX_IMPORT_DEPTH } from '../schemas/operations.js';
@@ -115,10 +116,15 @@ export const estimateExportBytes = async (
 
   if (document.currentRevision) {
     const revisionPath = getRevisionContentPhysicalPath(document.currentRevision.id);
-    total += await stat(revisionPath).then(
-      (info) => info.size,
-      () => 0,
-    );
+    const info = await stat(revisionPath).catch(() => null);
+
+    if (!info) {
+      throw new HttpInternalServerError(
+        `The stored content for revision ${document.currentRevision.id} is missing from the storage volume, so this tree cannot be exported. Restore that file from a backup, or export a part of the tree that does not include this document.`,
+      );
+    }
+
+    total += info.size;
     total += document.currentRevision.text?.length ?? 0;
   }
 

--- a/apps/backend/src/services/revision-contents.ts
+++ b/apps/backend/src/services/revision-contents.ts
@@ -31,5 +31,8 @@ export const saveRevisionContent = async (content: string, revisionId: string) =
 
 export const deleteRevisionContent = async (revisionId: string) => {
   const physicalPath = resolvePhysicalPath(getRevisionContentUrl(revisionId));
-  return await unlink(physicalPath).catch(console.error);
+  return await unlink(physicalPath).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    console.error(`Failed to remove revision content ${revisionId}:`, error);
+  });
 };

--- a/apps/backend/src/services/revision-contents.ts
+++ b/apps/backend/src/services/revision-contents.ts
@@ -4,6 +4,7 @@
  */
 
 import { mkdir, readFile, writeFile, unlink } from 'fs/promises';
+import { HttpInternalServerError } from '@httpx/exception';
 import { resolvePhysicalPath } from '../lib/storage.js';
 import { dirname } from 'path';
 
@@ -17,9 +18,19 @@ export const getRevisionContentPhysicalPath = (revisionId: string) => {
 
 export const readRevisionContent = async (revisionId: string) => {
   const physicalPath = resolvePhysicalPath(getRevisionContentUrl(revisionId));
-  const buffer = await readFile(physicalPath);
-  const content = buffer.toString();
-  return content;
+
+  try {
+    const buffer = await readFile(physicalPath);
+    return buffer.toString();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+
+    console.error(`Revision content missing for revision ${revisionId} at ${physicalPath}`);
+
+    throw new HttpInternalServerError(
+      `The stored content for revision ${revisionId} is missing from the storage volume. It was expected at ${getRevisionContentUrl(revisionId)}. Restore that file from a backup, or open an older revision of this document.`,
+    );
+  }
 };
 
 export const saveRevisionContent = async (content: string, revisionId: string) => {

--- a/apps/backend/src/services/revisions.ts
+++ b/apps/backend/src/services/revisions.ts
@@ -4,6 +4,7 @@
  */
 
 import { desc, eq, and } from 'drizzle-orm';
+import { HttpConflict } from '@httpx/exception';
 import { db } from '../lib/db.js';
 import { revisionsTable } from '../models/revisions.js';
 import { CreateRevisionInput, UpdateRevisionInput } from '../schemas/revisions.js';
@@ -114,6 +115,18 @@ export const updateRevisionName = async (revisionId: string, payload: UpdateRevi
 };
 
 export const deleteRevisionById = async (revisionId: string) => {
+  const [current] = await db
+    .select({ id: documentsTable.id })
+    .from(documentsTable)
+    .where(eq(documentsTable.currentRevisionId, revisionId))
+    .limit(1);
+
+  if (current) {
+    throw new HttpConflict(
+      'This revision is the current version of its document and cannot be deleted. Save or restore another revision first.',
+    );
+  }
+
   const [deleted] = await db
     .delete(revisionsTable)
     .where(eq(revisionsTable.id, revisionId))

--- a/apps/backend/src/services/revisions.ts
+++ b/apps/backend/src/services/revisions.ts
@@ -113,15 +113,12 @@ export const getCurrentRevisionByDocumentId = async (documentId: string) => {
 
 export const updateRevisionName = async (revisionId: string, payload: UpdateRevisionInput) => {
   const { content, ...columns } = payload;
-  const hasColumnUpdates = Object.values(columns).some((field) => field !== undefined);
 
-  const [updatedRevision] = hasColumnUpdates
-    ? await db
-        .update(revisionsTable)
-        .set(columns)
-        .where(eq(revisionsTable.id, revisionId))
-        .returning()
-    : await db.select().from(revisionsTable).where(eq(revisionsTable.id, revisionId)).limit(1);
+  const [updatedRevision] = await db
+    .update(revisionsTable)
+    .set({ ...columns, updatedAt: new Date() })
+    .where(eq(revisionsTable.id, revisionId))
+    .returning();
 
   if (content) {
     await saveRevisionContent(content, revisionId);

--- a/apps/backend/src/services/revisions.ts
+++ b/apps/backend/src/services/revisions.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import crypto from 'node:crypto';
 import { desc, eq, and } from 'drizzle-orm';
 import { HttpConflict } from '@httpx/exception';
 import { db } from '../lib/db.js';
@@ -10,24 +11,34 @@ import { revisionsTable } from '../models/revisions.js';
 import { CreateRevisionInput, UpdateRevisionInput } from '../schemas/revisions.js';
 import { documentsTable } from '../models/documents.js';
 import {
+  deleteRevisionContent,
   getRevisionContentUrl,
   readRevisionContent,
   saveRevisionContent,
 } from './revision-contents.js';
 
 export const createRevision = async (payload: CreateRevisionInput, userId: string) => {
-  const [revision] = await db
-    .insert(revisionsTable)
-    .values({
-      documentId: payload.documentId,
-      text: payload.text,
-      checksum: payload.checksum,
-      revisionName: payload.revisionName,
-      userId,
-    })
-    .returning();
+  const revisionId = crypto.randomUUID();
+  await saveRevisionContent(payload.content, revisionId);
 
-  await saveRevisionContent(payload.content, revision.id);
+  let revision;
+
+  try {
+    [revision] = await db
+      .insert(revisionsTable)
+      .values({
+        id: revisionId,
+        documentId: payload.documentId,
+        text: payload.text,
+        checksum: payload.checksum,
+        revisionName: payload.revisionName,
+        userId,
+      })
+      .returning();
+  } catch (error) {
+    await deleteRevisionContent(revisionId);
+    throw error;
+  }
 
   if (payload.makeCurrentRevision) {
     await db
@@ -131,6 +142,10 @@ export const deleteRevisionById = async (revisionId: string) => {
     .delete(revisionsTable)
     .where(eq(revisionsTable.id, revisionId))
     .returning({ id: revisionsTable.id });
+
+  if (deleted) {
+    await deleteRevisionContent(deleted.id);
+  }
 
   return deleted;
 };

--- a/apps/backend/src/services/revisions.ts
+++ b/apps/backend/src/services/revisions.ts
@@ -112,14 +112,21 @@ export const getCurrentRevisionByDocumentId = async (documentId: string) => {
 };
 
 export const updateRevisionName = async (revisionId: string, payload: UpdateRevisionInput) => {
-  const [updatedRevision] = await db
-    .update(revisionsTable)
-    .set(payload)
-    .where(eq(revisionsTable.id, revisionId))
-    .returning();
-  if (payload.content) {
-    await saveRevisionContent(payload.content, revisionId);
+  const { content, ...columns } = payload;
+  const hasColumnUpdates = Object.values(columns).some((field) => field !== undefined);
+
+  const [updatedRevision] = hasColumnUpdates
+    ? await db
+        .update(revisionsTable)
+        .set(columns)
+        .where(eq(revisionsTable.id, revisionId))
+        .returning()
+    : await db.select().from(revisionsTable).where(eq(revisionsTable.id, revisionId)).limit(1);
+
+  if (content) {
+    await saveRevisionContent(content, revisionId);
   }
+
   return updatedRevision
     ? { ...updatedRevision, url: getRevisionContentUrl(updatedRevision.id) }
     : null;

--- a/apps/backend/src/utils/collections.ts
+++ b/apps/backend/src/utils/collections.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { and, asc, desc, eq, gte, isNotNull, like, SQL } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, isNotNull, sql, SQL } from 'drizzle-orm';
 import { SQLiteColumn, SQLiteSelect } from 'drizzle-orm/sqlite-core';
 import { PaginationQuery } from '../schemas/pagination.js';
 import { db } from '../lib/db.js';
@@ -29,7 +29,8 @@ export class CollectionQuery<Q extends SQLiteSelect> {
 
   search(column: SQLiteColumn, searchTerm: string | undefined): this {
     if (searchTerm !== undefined) {
-      this.whereClauses.push(like(column, `%${searchTerm}%`));
+      const escaped = searchTerm.replace(/[\\%_]/g, (character) => `\\${character}`);
+      this.whereClauses.push(sql`${column} like ${`%${escaped}%`} escape '\\'`);
     }
     return this;
   }
@@ -68,7 +69,6 @@ export class CollectionQuery<Q extends SQLiteSelect> {
   }
 
   async getPaginatedResult({ page, limit }: PaginationQuery) {
-    console.log(this.query.toSQL());
     const offset = (page - 1) * limit;
 
     const total = await db.$count(this.query.where(and(...this.whereClauses)));

--- a/apps/backend/src/utils/errors.ts
+++ b/apps/backend/src/utils/errors.ts
@@ -11,7 +11,7 @@ function isExpressError(err: unknown): err is HttpError {
   return err instanceof Error && ('status' in err || 'statusCode' in err);
 }
 
-function isFormidableError(err: unknown): err is Error & { httpCode: number } {
+function isFormidableError(err: unknown): err is Error & { httpCode: number; code?: number } {
   return (
     err instanceof Error &&
     'httpCode' in err &&
@@ -19,11 +19,24 @@ function isFormidableError(err: unknown): err is Error & { httpCode: number } {
   );
 }
 
-function isPayloadTooLargeError(err: unknown): err is Error & { type?: string } {
+const FORMIDABLE_CLIENT_MESSAGES: Record<number, string> = {
+  1006: 'Upload form fields are too large.',
+  1007: 'Upload form has too many fields.',
+  1009: 'Uploaded files exceed the maximum allowed total size.',
+  1015: 'Too many files uploaded.',
+  1016: 'Uploaded file exceeds the maximum allowed size.',
+};
+
+function isPayloadTooLargeError(err: unknown): err is Error & { type?: string; limit?: number } {
   return (
     err instanceof Error && 'type' in err && (err as { type?: string }).type === 'entity.too.large'
   );
 }
+
+const formatByteLimit = (limit: number | undefined) =>
+  typeof limit === 'number' && Number.isFinite(limit)
+    ? `${Math.round((limit / (1024 * 1024)) * 10) / 10}MB`
+    : 'the configured limit';
 
 export const toHttpException = (error: unknown): HttpException => {
   if (error instanceof HttpException) {
@@ -33,14 +46,18 @@ export const toHttpException = (error: unknown): HttpException => {
   if (isPayloadTooLargeError(error)) {
     return new HttpException(
       413,
-      'Request body is too large. Maximum allowed payload is 5MB. Please reduce the import size and try again.',
+      `Request body is too large. Maximum allowed payload is ${formatByteLimit(error.limit)}.`,
     );
   }
 
   if (isFormidableError(error)) {
-    return error.httpCode < 500
-      ? new HttpException(error.httpCode, error.message)
-      : new HttpException(500, 'Internal Server Error');
+    if (error.httpCode >= 500 || error.code === 1018) {
+      return new HttpException(500, 'Internal Server Error');
+    }
+    const message =
+      (error.code !== undefined ? FORMIDABLE_CLIENT_MESSAGES[error.code] : undefined) ??
+      'Invalid upload request.';
+    return new HttpException(error.httpCode, message);
   }
 
   if (isExpressError(error)) {

--- a/apps/backend/src/utils/errors.ts
+++ b/apps/backend/src/utils/errors.ts
@@ -11,6 +11,14 @@ function isExpressError(err: unknown): err is HttpError {
   return err instanceof Error && ('status' in err || 'statusCode' in err);
 }
 
+function isFormidableError(err: unknown): err is Error & { httpCode: number } {
+  return (
+    err instanceof Error &&
+    'httpCode' in err &&
+    typeof (err as { httpCode?: unknown }).httpCode === 'number'
+  );
+}
+
 function isPayloadTooLargeError(err: unknown): err is Error & { type?: string } {
   return (
     err instanceof Error && 'type' in err && (err as { type?: string }).type === 'entity.too.large'
@@ -29,6 +37,12 @@ export const toHttpException = (error: unknown): HttpException => {
     );
   }
 
+  if (isFormidableError(error)) {
+    return error.httpCode < 500
+      ? new HttpException(error.httpCode, error.message)
+      : new HttpException(500, 'Internal Server Error');
+  }
+
   if (isExpressError(error)) {
     const status = typeof error.status === 'number' ? error.status : error.statusCode;
     return new HttpException(status ?? 500, error.message);
@@ -40,10 +54,6 @@ export const toHttpException = (error: unknown): HttpException => {
       issues: error.issues as HttpValidationIssue[],
       cause: error,
     });
-  }
-
-  if (error instanceof Error) {
-    return new HttpException(500, error.message);
   }
 
   return new HttpException(500, 'Internal Server Error');

--- a/apps/backend/src/utils/operations.ts
+++ b/apps/backend/src/utils/operations.ts
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const CHILD_KEYS = ['children', 'spaceRootChildren'] as const;
+
+const walkDocumentTree = (
+  root: unknown,
+  visit: (node: Record<string, unknown>, depth: number) => void,
+) => {
+  const stack: Array<{ node: unknown; depth: number }> = [{ node: root, depth: 1 }];
+
+  while (stack.length > 0) {
+    const { node, depth } = stack.pop()!;
+    if (!node || typeof node !== 'object') continue;
+
+    const record = node as Record<string, unknown>;
+    visit(record, depth);
+
+    for (const key of CHILD_KEYS) {
+      const children = record[key];
+      if (!Array.isArray(children)) continue;
+      for (const child of children) stack.push({ node: child, depth: depth + 1 });
+    }
+  }
+};
+
+export const documentTreeDepth = (root: unknown): number => {
+  let maxDepth = 0;
+
+  walkDocumentTree(root, (_node, depth) => {
+    if (depth > maxDepth) maxDepth = depth;
+  });
+
+  return maxDepth;
+};
+
+export const normalizeDocumentTreeContent = (root: unknown) => {
+  walkDocumentTree(root, (node) => {
+    const revision = node.revision;
+    if (!revision || typeof revision !== 'object') return;
+
+    const record = revision as Record<string, unknown>;
+    if (record.content !== null && typeof record.content === 'object') {
+      record.content = JSON.stringify(record.content);
+    }
+  });
+};

--- a/apps/backend/src/utils/operations.ts
+++ b/apps/backend/src/utils/operations.ts
@@ -36,6 +36,16 @@ export const documentTreeDepth = (root: unknown): number => {
   return maxDepth;
 };
 
+export const documentTreeNodeCount = (root: unknown): number => {
+  let nodes = 0;
+
+  walkDocumentTree(root, () => {
+    nodes += 1;
+  });
+
+  return nodes;
+};
+
 export const normalizeDocumentTreeContent = (root: unknown) => {
   walkDocumentTree(root, (node) => {
     const revision = node.revision;

--- a/apps/backend/src/utils/strings.ts
+++ b/apps/backend/src/utils/strings.ts
@@ -5,6 +5,8 @@
 
 import { nanoid } from 'nanoid';
 
+const STORED_FILENAME_MAX_LENGTH = 200;
+
 export const slugify = (text: string) => {
   return text
     .replace(/([a-z])([A-Z])/g, '$1-$2')
@@ -20,4 +22,14 @@ export const safeFilename = (filename: string, extension: string) => {
   const timestamp = Date.now();
   const safeName = filename.replace(/[^a-zA-Z0-9-_]/g, '_');
   return `${safeName}_${timestamp}${extension}`;
+};
+
+export const sanitizeStoredFilename = (filename: string) => {
+  const leaf = filename.split(/[/\\]/).pop() ?? '';
+  const cleaned = leaf
+    .replace(/[^a-zA-Z0-9._-]/g, '_')
+    .replace(/^\.+/, '')
+    .slice(0, STORED_FILENAME_MAX_LENGTH);
+
+  return cleaned || `attachment_${nanoid(10)}`;
 };

--- a/apps/web/src/components/documents/useDocumentActions.ts
+++ b/apps/web/src/components/documents/useDocumentActions.ts
@@ -56,9 +56,12 @@ export function useDocumentActions(
 
   const loadedKey = docId ? `${docId}:${isEditTab ? 'edit' : 'view'}` : null;
 
+  const [hasUserEdit, setHasUserEdit] = useState(false);
+
   if (loadedKey && checksum && loadedFor !== loadedKey) {
     setLoadedFor(loadedKey);
     setLoadedChecksum(checksum);
+    setHasUserEdit(false);
   }
 
   const cloudRevision = useMemo(
@@ -134,6 +137,7 @@ export function useDocumentActions(
         setChecksum(cloudRevision.checksum);
         setLoadedChecksum(cloudRevision.checksum);
         setLoadedFor(loadedKey);
+        setHasUserEdit(false);
         if (isViewTab) {
           const revision = await queryClient.ensureQueryData(
             getRevisionByIdQueryOptions(cloudRevision.id, true),
@@ -163,6 +167,7 @@ export function useDocumentActions(
         setChecksum(newChecksum);
         setLoadedChecksum(newChecksum);
         setLoadedFor(loadedKey);
+        setHasUserEdit(false);
       }
       handleSaveSuccess();
     } catch {
@@ -191,6 +196,7 @@ export function useDocumentActions(
       setChecksum(newChecksum);
       setLoadedChecksum(newChecksum);
       setLoadedFor(loadedKey);
+      setHasUserEdit(false);
       handleSaveSuccess();
     } catch {
       setIsSaving(false);
@@ -218,6 +224,7 @@ export function useDocumentActions(
       setChecksum(newChecksum);
       setLoadedChecksum(newChecksum);
       setLoadedFor(loadedKey);
+      setHasUserEdit(false);
       handleSaveSuccess();
     } catch {
       setIsSaving(false);
@@ -225,6 +232,20 @@ export function useDocumentActions(
   };
 
   const handleUpdateRef = useRef(handleUpdate);
+
+  useEffect(() => {
+    const handleDocumentEdited = (event: Event) => {
+      const customEvent = event as CustomEvent<{ documentId: string; tabId?: string }>;
+      if (customEvent.detail.documentId === docId && customEvent.detail.tabId === tabId) {
+        setHasUserEdit(true);
+      }
+    };
+
+    window.addEventListener('document-edited', handleDocumentEdited);
+    return () => {
+      window.removeEventListener('document-edited', handleDocumentEdited);
+    };
+  }, [docId, tabId]);
 
   useEffect(() => {
     const handleChecksumChange = (event: Event) => {
@@ -264,16 +285,16 @@ export function useDocumentActions(
   useEffect(() => {
     if (isLoading) return;
     if (isDocumentTab) {
-      setTabDirty(tab.id, !isUpToDate);
+      setTabDirty(tab.id, hasUserEdit);
     }
-  }, [isDocumentTab, isLoading, isUpToDate, setTabDirty, tab?.id]);
+  }, [isDocumentTab, isLoading, hasUserEdit, setTabDirty, tab?.id]);
 
   const backgroundClassName = (() => {
     if (!handle) return undefined;
     if (isJustSaved) {
       return 'bg-green-100/80 dark:bg-green-900/40';
     }
-    if (!isLoading && !isUpToDate) {
+    if (!isLoading && hasUserEdit) {
       // Document has unsaved changes
       return 'bg-yellow-100/70 dark:bg-yellow-900/30';
     }

--- a/apps/web/src/components/documents/useDocumentActions.ts
+++ b/apps/web/src/components/documents/useDocumentActions.ts
@@ -45,17 +45,34 @@ export function useDocumentActions(
     enabled: !!docId,
   });
 
+  const tab = useSelector((state) => state.tabs.tabList.find((tab) => tab.id === tabId));
+  const isViewTab = tab && tab.pathname.startsWith('/view/');
+  const isEditTab = tab && tab.pathname.startsWith('/edit/');
+  const isDocumentTab = isEditTab || isViewTab;
+
   const [checksum, setChecksum] = useState<string | null>(null);
+  const [loadedChecksum, setLoadedChecksum] = useState<string | null>(null);
+  const [loadedFor, setLoadedFor] = useState<string | null>(null);
+
+  const loadedKey = docId ? `${docId}:${isEditTab ? 'edit' : 'view'}` : null;
+
+  if (loadedKey && checksum && loadedFor !== loadedKey) {
+    setLoadedFor(loadedKey);
+    setLoadedChecksum(checksum);
+  }
+
   const cloudRevision = useMemo(
     () => revisions?.find((r) => r.checksum === checksum),
     [revisions, checksum],
   );
 
   const isPreviouslySaved = !!cloudRevision;
+  const isUnchangedSinceLoad = !!loadedChecksum && loadedChecksum === checksum;
   const isUpToDate =
-    isPreviouslySaved &&
-    document?.currentRevisionId === cloudRevision.id &&
-    cloudRevision.checksum === checksum;
+    isUnchangedSinceLoad ||
+    (isPreviouslySaved &&
+      document?.currentRevisionId === cloudRevision.id &&
+      cloudRevision.checksum === checksum);
 
   const isLoading =
     !document ||
@@ -63,10 +80,6 @@ export function useDocumentActions(
     !revisions?.length ||
     (isPreviouslySaved && cloudRevision.documentId !== document.id);
 
-  const tab = useSelector((state) => state.tabs.tabList.find((tab) => tab.id === tabId));
-  const isViewTab = tab && tab.pathname.startsWith('/view/');
-  const isEditTab = tab && tab.pathname.startsWith('/edit/');
-  const isDocumentTab = isEditTab || isViewTab;
   const { setTabDirty, setTabSaving, setTabJustSaved } = useActions();
 
   const isSaving = !!tab?.isSaving;
@@ -119,6 +132,8 @@ export function useDocumentActions(
           head: cloudRevision.id,
         });
         setChecksum(cloudRevision.checksum);
+        setLoadedChecksum(cloudRevision.checksum);
+        setLoadedFor(loadedKey);
         if (isViewTab) {
           const revision = await queryClient.ensureQueryData(
             getRevisionByIdQueryOptions(cloudRevision.id, true),
@@ -146,6 +161,8 @@ export function useDocumentActions(
           isAutosave,
         });
         setChecksum(newChecksum);
+        setLoadedChecksum(newChecksum);
+        setLoadedFor(loadedKey);
       }
       handleSaveSuccess();
     } catch {
@@ -172,6 +189,8 @@ export function useDocumentActions(
         keepPreviousRevision: true,
       });
       setChecksum(newChecksum);
+      setLoadedChecksum(newChecksum);
+      setLoadedFor(loadedKey);
       handleSaveSuccess();
     } catch {
       setIsSaving(false);
@@ -197,6 +216,8 @@ export function useDocumentActions(
         keepPreviousRevision: false,
       });
       setChecksum(newChecksum);
+      setLoadedChecksum(newChecksum);
+      setLoadedFor(loadedKey);
       handleSaveSuccess();
     } catch {
       setIsSaving(false);

--- a/apps/web/src/providers/RealtimeProvider.tsx
+++ b/apps/web/src/providers/RealtimeProvider.tsx
@@ -10,7 +10,11 @@ import {
 } from '@/queries/caches/documents';
 import { addSpaceToCache, isSpaceCached, removeSpaceFromCache } from '@/queries/caches/spaces';
 import { getAllDocumentsQueryOptions, ListDocumentResult } from '@/queries/documents';
-import { DOCUMENTS_QUERY_KEYS, SPACES_QUERY_KEYS } from '@/queries/query-keys';
+import {
+  DOCUMENTS_QUERY_KEYS,
+  REVISIONS_QUERY_KEYS,
+  SPACES_QUERY_KEYS,
+} from '@/queries/query-keys';
 import { getAllSpacesQueryOptions, ListSpaceResult } from '@/queries/spaces';
 import { useAllQueriesInvalidate } from '@/queries/utils';
 import { useSelector } from '@/store';
@@ -229,6 +233,17 @@ export const RealtimeProvider = ({ children }: { children: React.ReactNode }) =>
           );
         }
       }
+      const cached = queryClient.getQueryData(
+        DOCUMENTS_QUERY_KEYS.DETAIL_BY_HANDLE(data.handle),
+      ) as { currentRevisionId?: string | null } | undefined;
+
+      if (cached && cached.currentRevisionId !== data.currentRevisionId) {
+        invalidate([
+          DOCUMENTS_QUERY_KEYS.DETAIL_BY_HANDLE(data.handle),
+          REVISIONS_QUERY_KEYS.BY_DOCUMENT_ID(data.id),
+        ]);
+      }
+
       invalidate([
         DOCUMENTS_QUERY_KEYS.HOME.BASE,
         DOCUMENTS_QUERY_KEYS.FAVORITES,

--- a/apps/web/src/queries/documents.ts
+++ b/apps/web/src/queries/documents.ts
@@ -52,6 +52,7 @@ import { getRevisionsByDocumentIdQueryOptions } from './revisions';
 import { addDocumentToCache, isDocumentCached, removeDocumentFromCache } from './caches/documents';
 import { createLocalDocument, deleteLocalDocument } from '@repo/editor/indexeddb';
 import { importDocumentSchema } from '@repo/backend/operations.ts';
+import { expandDocumentTreeContent } from '@/utils/exportedDocument';
 const listDocuments = async ({ spaceId }: { spaceId: string }) => {
   return await getUserDocuments({ spaceId, documentType: 'note' });
 };
@@ -1223,10 +1224,8 @@ export function useExportDocumentMutation(itemId: string, documentName?: string)
         throw error;
       }
       if (data) {
-        // Parse the content as JSON
-        (data as any).revision.content = JSON.parse((data as any).revision.content);
         // Stringify the data
-        const jsonString = JSON.stringify(data, null, 2);
+        const jsonString = JSON.stringify(expandDocumentTreeContent(data), null, 2);
 
         // Create a blob from the JSON string
         const blob = new Blob([jsonString], { type: 'application/json' });

--- a/apps/web/src/queries/revisions.ts
+++ b/apps/web/src/queries/revisions.ts
@@ -206,6 +206,7 @@ export function useSaveDocumentMutation({
       }
       const { error: updateError } = await updateDocument(document.id, {
         currentRevisionId: newRevision.id,
+        expectedCurrentRevisionId: document.currentRevisionId,
       });
       if (updateError) {
         throw new Error(updateError.message || 'Failed to update document head');

--- a/apps/web/src/queries/revisions.ts
+++ b/apps/web/src/queries/revisions.ts
@@ -209,7 +209,9 @@ export function useSaveDocumentMutation({
         expectedCurrentRevisionId: document.currentRevisionId,
       });
       if (updateError) {
-        throw new Error(updateError.message || 'Failed to update document head');
+        throw Object.assign(new Error(updateError.message || 'Failed to update document head'), {
+          conflict: updateError.response?.status === 409,
+        });
       }
       if (!keepPreviousRevision) {
         const { error: deleteError } = await deleteRevision(document.currentRevisionId!);
@@ -236,7 +238,8 @@ export function useSaveDocumentMutation({
       ]);
     },
     onError: (error, __, toastId) => {
-      if (toastId) {
+      const conflict = 'conflict' in error && error.conflict === true;
+      if (toastId || conflict) {
         toast.error(error.message || 'Failed to save document', {
           id: toastId,
         });

--- a/apps/web/src/queries/spaces.ts
+++ b/apps/web/src/queries/spaces.ts
@@ -42,6 +42,7 @@ import {
   removeDocumentFromFavorites,
 } from '@repo/sdk/favorites.ts';
 import { importDocumentSchema } from '@repo/backend/operations.ts';
+import { expandDocumentTreeContent } from '@/utils/exportedDocument';
 const listSpaces = async () => {
   return getUserDocuments({ documentType: 'space' });
 };
@@ -889,7 +890,7 @@ export function useExportSpaceMutation(itemId: string, spaceName?: string) {
       }
       if (data) {
         // Stringify the data
-        const jsonString = JSON.stringify(data, null, 2);
+        const jsonString = JSON.stringify(expandDocumentTreeContent(data), null, 2);
 
         // Create a blob from the JSON string
         const blob = new Blob([jsonString], { type: 'application/json' });

--- a/apps/web/src/utils/exportedDocument.ts
+++ b/apps/web/src/utils/exportedDocument.ts
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const CHILD_KEYS = ['children', 'spaceRootChildren'] as const;
+
+const asReadableContent = (content: string): unknown => {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return content;
+  }
+
+  return parsed !== null && typeof parsed === 'object' ? parsed : content;
+};
+
+export const expandDocumentTreeContent = (root: unknown) => {
+  const stack: unknown[] = [root];
+
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node || typeof node !== 'object') continue;
+
+    const record = node as Record<string, unknown>;
+    const revision = record.revision;
+
+    if (revision && typeof revision === 'object') {
+      const revisionRecord = revision as Record<string, unknown>;
+      if (typeof revisionRecord.content === 'string') {
+        revisionRecord.content = asReadableContent(revisionRecord.content);
+      }
+    }
+
+    for (const key of CHILD_KEYS) {
+      const children = record[key];
+      if (!Array.isArray(children)) continue;
+      for (const child of children) stack.push(child);
+    }
+  }
+
+  return root;
+};

--- a/packages/editor/src/Editor.tsx
+++ b/packages/editor/src/Editor.tsx
@@ -47,6 +47,7 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import ShortcutsPlugin from '@repo/editor/plugins/ShortcutsPlugin';
 import FloatingToolbarPlugin from '@repo/editor/plugins/FloatingToolbar';
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
+import { HISTORIC_TAG } from 'lexical';
 import { useActions, useSelector } from '@repo/editor/store';
 import { useCallback, useEffect } from 'react';
 import { computeChecksum } from '@repo/editor/utils/computeChecksum';
@@ -90,9 +91,12 @@ export const Editor: React.FC<{
       }
       const serializedEditorState = serializeEditorState(editorState);
       updateChecksum(serializedEditorState);
+      if (documentId && !tags.has(HISTORIC_TAG)) {
+        window.dispatchEvent(new CustomEvent('document-edited', { detail: { documentId, tabId } }));
+      }
       onChange?.(editorState, editor, tags);
     },
-    [onChange, updateChecksum],
+    [onChange, updateChecksum, documentId, tabId],
   );
 
   return (

--- a/packages/editor/src/plugins/AttachmentPlugin/index.tsx
+++ b/packages/editor/src/plugins/AttachmentPlugin/index.tsx
@@ -11,18 +11,23 @@
  *
  */
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
-import { $wrapNodeInElement, mergeRegister } from '@lexical/utils';
+import { $findMatchingParent, $wrapNodeInElement, mergeRegister } from '@lexical/utils';
 import {
+  $createParagraphNode,
   $getNodeByKey,
+  $getPreviousSelection,
+  $getRoot,
+  $getSelection,
+  $insertNodes,
+  $isElementNode,
+  $isRangeSelection,
+  $isRootOrShadowRoot,
   COMMAND_PRIORITY_EDITOR,
+  HISTORY_MERGE_TAG,
   HISTORIC_TAG,
   createCommand,
   LexicalCommand,
   MutationListener,
-  $isRootNode,
-  $createParagraphNode,
-  $insertNodes,
-  HISTORY_MERGE_TAG,
 } from 'lexical';
 import { useEffect } from 'react';
 
@@ -31,6 +36,7 @@ import {
   AttachmentNode,
   AttachmentPayload,
 } from '@repo/editor/nodes/AttachmentNode';
+import { $isPageNode, $isPageSetupNode } from '@repo/editor/nodes/PageNode';
 import { useActions } from '@repo/editor/store';
 import { ANNOUNCE_COMMAND } from '@repo/editor/commands';
 
@@ -39,6 +45,57 @@ export type InsertAttachmentPayload = Readonly<AttachmentPayload>;
 export const INSERT_ATTACHMENT_COMMAND: LexicalCommand<InsertAttachmentPayload> = createCommand();
 
 const processingNodeKeys = new Set<string>();
+
+function $ensureValidAttachmentInsertionSelection() {
+  // An async upload can leave the editor focused on a page structure node. Move only
+  // those unsafe selections to a concrete body block and preserve normal caret insertion.
+  const selection = $getSelection() || $getPreviousSelection();
+  let selectionNode;
+  if ($isRangeSelection(selection)) {
+    selectionNode = $getNodeByKey(selection.focus.key);
+  } else {
+    const selectedNodes = selection?.getNodes();
+    selectionNode = selectedNodes?.[selectedNodes.length - 1];
+  }
+
+  const needsDocumentBodyFallback =
+    !selectionNode ||
+    $isRootOrShadowRoot(selectionNode) ||
+    $isPageNode(selectionNode) ||
+    $isPageSetupNode(selectionNode);
+
+  if (!needsDocumentBodyFallback) return;
+
+  const selectedPage = selectionNode ? $findMatchingParent(selectionNode, $isPageNode) : null;
+  const pages = $getRoot().getChildren().filter($isPageNode);
+  const fallbackPage = selectedPage ?? pages[pages.length - 1];
+  const insertionContainer = fallbackPage?.getContentNode() ?? $getRoot();
+  const lastDescendant = insertionContainer.getLastDescendant();
+  const hasBlockInsertionPoint =
+    lastDescendant &&
+    $findMatchingParent(
+      lastDescendant,
+      (node) => $isElementNode(node) && !node.isInline() && !$isRootOrShadowRoot(node),
+    );
+
+  if (hasBlockInsertionPoint) {
+    insertionContainer.selectEnd();
+  } else {
+    const paragraph = $createParagraphNode();
+    insertionContainer.append(paragraph);
+    paragraph.selectEnd();
+  }
+}
+
+export function $insertAttachmentNode(payload: InsertAttachmentPayload): AttachmentNode {
+  $ensureValidAttachmentInsertionSelection();
+  const attachmentNode = $createAttachmentNode(payload);
+  $insertNodes([attachmentNode]);
+  if ($isRootOrShadowRoot(attachmentNode.getParentOrThrow())) {
+    $wrapNodeInElement(attachmentNode, $createParagraphNode);
+  }
+  return attachmentNode;
+}
 
 export default function AttachmentPlugin() {
   const [editor] = useLexicalComposerContext();
@@ -156,11 +213,7 @@ export default function AttachmentPlugin() {
       editor.registerCommand(
         INSERT_ATTACHMENT_COMMAND,
         (payload) => {
-          const attachmentNode = $createAttachmentNode(payload);
-          $insertNodes([attachmentNode]);
-          if ($isRootNode(attachmentNode.getParentOrThrow())) {
-            $wrapNodeInElement(attachmentNode, $createParagraphNode);
-          }
+          $insertAttachmentNode(payload);
           return true;
         },
         COMMAND_PRIORITY_EDITOR,

--- a/packages/embed-pdf/src/assets.d.ts
+++ b/packages/embed-pdf/src/assets.d.ts
@@ -15,3 +15,7 @@ declare module '*.wasm?url' {
   const src: string;
   export default src;
 }
+
+interface ImportMeta {
+  readonly env: { readonly DEV: boolean };
+}

--- a/packages/embed-pdf/src/viewer.tsx
+++ b/packages/embed-pdf/src/viewer.tsx
@@ -94,6 +94,7 @@ export function PDFViewer({ url }: PDFViewerProps) {
   const { engine, isLoading, error } = usePdfiumEngine({
     wasmUrl: pdfiumWasmUrl,
     fontFallback: pdfFontFallback,
+    worker: !import.meta.env.DEV,
   });
 
   // Memoize UIProvider props to prevent unnecessary remounts

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turborepo.com/schema.json",
-  "globalEnv": ["VITE_BACKEND_URL", "DB_FILE_NAME", "WEB_DIR", "TRUST_PROXY", "TRUST_HOST"],
+  "globalEnv": ["VITE_BACKEND_URL", "DEV", "DB_FILE_NAME", "WEB_DIR", "TRUST_PROXY", "TRUST_HOST"],
   "ui": "tui",
   "tasks": {
     "build": {


### PR DESCRIPTION
# Backend hardening: data loss, availability, and file handling

Closes a set of defects found during a full review of `apps/backend`. Each was reproduced against a running instance before the fix and re-verified after; the measurements below are observed, not estimated.

**11 commits · 36 files · 2 migrations**

---

## Data loss

**Deleting one revision deleted the document and its whole subtree.** `documents.current_revision_id` is a pointer but was declared `ON DELETE CASCADE`, so removing the pointed-at row removed its owner, then cascaded through `parent_id`/`space_id`. Reproduced: `DELETE /api/revisions/<head>` → `204`, workspace went from 3 documents to 0. The FK is now `SET NULL`, and the service refuses to delete a revision that is still a document's head (`409`).

**Deleted documents leaked their files forever.** `deleteDocument` issued a single-row delete and let SQLite cascade, so the application never learned which revisions vanished and never removed their content or attachment directories. Measured in a container: a space with three 5 MB attachments left **15 MB** behind on delete; now returns to baseline. `prune-orphans` is included for files stranded by earlier versions.

## Security

**Arbitrary file write via document import.** `attachments.ts` joined an unvalidated `filename` from the import payload onto the target directory — only the *parent* passed through the containment check. A payload naming `../../../local.db` returned `201` and replaced the SQLite database (184320 → 6 bytes). Filenames are now reduced to a single sanitised segment, the complete path is containment-checked, and the schema rejects separators outright.

**Path traversal in `/storage` reads any file under `storage/`.** Encoded `../` in the `filename`/`userId` params reached `local.db` itself — password hash and every session token. The `images`/`covers` routes had no ownership check at all. Params are now constrained, ownership is enforced, and the containment test uses `path.relative` instead of a bare `startsWith`.

**Internal detail no longer reaches clients.** Unexpected errors returned `error.message` verbatim, exposing absolute paths and full SQL statements. 4xx still explain themselves; 5xx return a generic message, with full detail logged server-side.

## Availability

**Any authenticated request could kill the process.** Three vectors, each reproduced: a wrong multipart field name (throw inside formidable's `fileBegin`), an over-deep import (throw in an un-awaited queue task — returned `201`, then died), and a non-string socket payload. Under `restart: unless-stopped` the container showed **3 restarts and 3 PIDs** in one test run; now `0`. Each is contained at its source, with process-level handlers as a backstop.

**A self-parented document hung the server permanently.** `PATCH` accepted a document as its own parent; the `spaceId` propagation then recursed forever — 88.6% CPU, RSS past 4 GB, `/api/health` timing out, with the single-writer queue pinned. Cycles are rejected, and propagation is now one bulk update over a `UNION` CTE that terminates on pre-existing bad data.

**A JSON body to any upload route hung forever.** `express.json` was mounted globally and drained the stream before formidable read it. Scoped to `/api`; those routes now answer `422` immediately.

## Editor ⚠️

**Inserting an attachment silently did nothing.** The file uploaded — `POST /storage/attachments/:documentId` returned `201` and the file landed on disk — but no node appeared in the document and no error was shown.

After the async upload completes the editor's selection can rest on the root or on a page-structure node (`page`, `page-setup`) rather than a body block, and `$insertNodes` cannot place the attachment there. The existing guard used `$isRootNode`, which does not match a page node, so the failure went undetected.

The caret is now moved to the enclosing page's content node before insertion — creating a paragraph if the page has no block to insert into — and the guard uses `$isRootOrShadowRoot`. This is the only change outside `apps/backend`.


## Performance

A filesystem write was held inside the write transaction, and the handle check ran on a second connection.

| | before | after |
|---|---|---|
| 8 concurrent saves | 8 × `500` `SQLITE_BUSY` | 8 × `201` |
| 16 concurrent saves | — | 16 × `201` |
| cascade delete, 10k docs | 14,878 ms | **78 ms** |
| handle lookup, 5k rows | 0.191 ms | **0.017 ms** |

WAL is enabled at boot and writes retry with full jitter (`busy_timeout` is not reachable through this driver). Migration `0004` adds 7 indexes — `documents` and `revisions` previously had none beyond their primary keys, so every list query and FK cascade was a full scan.

## Correctness

Search treats `%`/`_` as literals; `limit` is capped; a `toSQL()` debug log that printed bound params on every paginated request is removed; attachment insertion no longer fails when the caret rests on page-structure nodes.

---

## Migrations

- **`0003`** — rebuilds `documents` to change the FK. SQLite cannot alter a constraint in place, and `DROP TABLE` also drops the five FTS triggers, so the migration recreates them; `drizzle-kit` does not model them and its generated output would have left search silently broken.
- **`0004`** — adds indexes.

Verified against a populated database: rows preserved, 5/5 triggers restored, `integrity_check ok`, zero FK violations.

## Operational notes

- **`BETTER_AUTH_SECRET` is now required in production.** Better Auth refuses its default secret there, which previously surfaced as a `500` on every authenticated request; the server now stops at boot with an actionable message. Compose already sets it — this affects bare `docker run`.
- **Reclaiming leaked files:** `docker compose exec wordyme node src/scripts/prune-orphans.mjs` (add `--delete` after reviewing). Dry-run by default and refuses to run against an empty or wrong database.


## Verification

Every fix was reproduced and re-tested against a running instance, and the security and availability changes were additionally verified in a built Docker image with a real volume. No automated tests exist in the backend — adding them is the most valuable follow-up to this work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved document deletion, revision cleanup, attachment handling, hierarchy validation, and file security.
- Fixed special-character searches, upload errors, unauthorized file access, deep imports, and stale document data.
- Added conflict detection for simultaneous document edits and safer revision deletion.

## Performance & Reliability
- Improved database reliability, search synchronization, error handling, and query performance.
- Added streaming exports and safeguards for pagination, imports, and document sizes.
- Added a database readiness check.

## Editor
- Attachment insertion now recovers from invalid cursor positions.

## Maintenance
- Added orphaned-file cleanup tooling and SQLite backup guidance.

## Configuration
- Production authentication secrets must contain at least 32 characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->