### PR TITLE
feat(backup): back up and restore a whole workspace from one file

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -444,6 +444,20 @@ snapshot, not a lock — for certainty, run `--delete` with the service stopped
 prune-orphans.mjs --delete`). Always run the report first and read it: pointed
 at the wrong database, every live file looks unreferenced.
 
+The exit code distinguishes two different conditions, which matters if you run
+this from cron or CI:
+
+| Code | Meaning                                                                       |
+| ---- | ----------------------------------------------------------------------------- |
+| `0`  | Nothing orphaned, and every revision has its content file.                    |
+| `2`  | It ran fine, but some revisions reference a content file that is not on disk. |
+
+Exit `2` is the opposite problem from an orphan: rows pointing at files that are
+gone, which this script never fixes because it never deletes rows. Documents
+holding one of those as their current version fail to open, and the fix is to
+restore the missing files from a backup. Treating any non-zero exit as a failed
+prune would page you for a condition that needs a restore instead.
+
 ## Environment Variables
 
 You can customize the application behavior by setting environment variables. There are two ways to do this:

--- a/apps/backend/drizzle/0005_backup_restore_journal.sql
+++ b/apps/backend/drizzle/0005_backup_restore_journal.sql
@@ -1,0 +1,4 @@
+CREATE TABLE `backup_restores` (
+	`id` text PRIMARY KEY NOT NULL,
+	`created_at` integer NOT NULL
+);

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1786906559166,
       "tag": "0004_document_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1786906560166,
+      "tag": "0005_backup_restore_journal",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -36,6 +36,8 @@
     "nanoid": "^5.1.16",
     "p-queue": "^9.1.0",
     "socket.io": "^4.8.3",
+    "yauzl": "^3.4.0",
+    "yazl": "^3.3.1",
     "zod": "^4.3.6",
     "zod-openapi": "^5.4.6"
   },
@@ -48,6 +50,8 @@
     "@types/http-errors": "^2.0.5",
     "@types/morgan": "^1.9.10",
     "@types/node": "^25.4.0",
+    "@types/yauzl": "^3.4.0",
+    "@types/yazl": "^3.3.1",
     "bun": "^1.3.10",
     "drizzle-kit": "^0.31.9",
     "eslint": "^10.1.0",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -20,6 +20,8 @@ import { errorHandler, notFoundHandler } from './middlewares/errors.js';
 import { clientIp } from './middlewares/client-ip.js';
 import { originHint } from './middlewares/origin-hint.js';
 import { proxyHint } from './middlewares/proxy-hint.js';
+import { restoreGate } from './middlewares/restore-gate.js';
+import { CHUNK_BYTES } from './services/backup/constants.js';
 
 // REST Routers
 import { documentsRouter } from './routes/documents.js';
@@ -30,6 +32,7 @@ import { storageRouter } from './routes/storage.js';
 import { healthRouter } from './routes/health.js';
 import { authStateRouter } from './routes/auth-state.js';
 import { updatesRouter } from './routes/updates.js';
+import { backupRouter } from './routes/backup.js';
 
 const API_BODY_LIMIT = '5mb';
 const IMPORT_BODY_LIMIT = '50mb';
@@ -66,7 +69,14 @@ app.all('/api/auth/{*any}', toNodeHandler(auth));
 
 app.use('/api/documents/import', express.json({ limit: IMPORT_BODY_LIMIT }));
 
+app.use(
+  '/api/backup/restore/chunk',
+  express.raw({ type: '*/*', limit: CHUNK_BYTES + 1024 * 1024 }),
+);
+
 app.use('/api', express.json({ limit: API_BODY_LIMIT }));
+
+app.use('/api', restoreGate);
 
 app.use('/api/documents', documentsRouter);
 app.use('/api/revisions', revisionsRouter);
@@ -75,6 +85,7 @@ app.use('/api/favorites', favoritesRouter);
 app.use('/api/health', healthRouter);
 app.use('/api/auth-state', authStateRouter);
 app.use('/api/updates', updatesRouter);
+app.use('/api/backup', backupRouter);
 
 app.use('/storage', storageRouter);
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -87,7 +87,7 @@ app.use('/api/auth-state', authStateRouter);
 app.use('/api/updates', updatesRouter);
 app.use('/api/backup', backupRouter);
 
-app.use('/storage', storageRouter);
+app.use('/storage', restoreGate, storageRouter);
 
 app.get('/api/docs/openapi.json', (req, res) => {
   res.json(openApiDocument);

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -12,6 +12,8 @@ import { getSocket } from './lib/socket.js';
 import { hasWebBundle } from './lib/web.js';
 import { dbWritesQueue } from './queues/db-writes.js';
 import { startUpdateChecks, stopUpdateChecks } from './services/updates.js';
+import { recoverStagingOnBoot } from './services/backup/staging.js';
+import { sweepUploads } from './services/backup/uploads.js';
 
 /**
  * How long to wait for in-flight work before giving up. Docker's default grace
@@ -21,6 +23,8 @@ import { startUpdateChecks, stopUpdateChecks } from './services/updates.js';
 const SHUTDOWN_TIMEOUT_MS = 8_000;
 
 await configureDatabase();
+await sweepUploads();
+await recoverStagingOnBoot();
 
 server.listen(env.PORT, () => {
   console.log(`Server is running on http://localhost:${env.PORT}`);

--- a/apps/backend/src/lib/socket.ts
+++ b/apps/backend/src/lib/socket.ts
@@ -52,6 +52,8 @@ export const initializeSocket = (server: HttpServer) => {
   return io;
 };
 
+export const isSocketReady = () => Boolean(io);
+
 export const getSocket = () => {
   if (!io) {
     throw new Error('Socket.io not initialized');

--- a/apps/backend/src/middlewares/restore-gate.ts
+++ b/apps/backend/src/middlewares/restore-gate.ts
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { NextFunction, Request, Response } from 'express';
+import { HttpServiceUnavailable } from '@httpx/exception';
+import { isRestoreRunning } from '../services/backup/lock.js';
+
+const READ_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+export const restoreGate = (req: Request, _res: Response, next: NextFunction) => {
+  if (READ_METHODS.has(req.method)) return next();
+  if (req.path.startsWith('/backup/')) return next();
+
+  if (isRestoreRunning()) {
+    throw new HttpServiceUnavailable(
+      'A backup restore is in progress. Your workspace is read-only until it finishes.',
+    );
+  }
+
+  next();
+};

--- a/apps/backend/src/models/backup-restores.ts
+++ b/apps/backend/src/models/backup-restores.ts
@@ -1,0 +1,13 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+export const backupRestoresTable = sqliteTable('backup_restores', {
+  id: text('id').primaryKey(),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});

--- a/apps/backend/src/models/index.ts
+++ b/apps/backend/src/models/index.ts
@@ -4,6 +4,7 @@
  */
 
 export * from './auth.js';
+export * from './backup-restores.js';
 export * from './documents.js';
 export * from './document-views.js';
 export * from './editor-settings.js';

--- a/apps/backend/src/routes/backup.ts
+++ b/apps/backend/src/routes/backup.ts
@@ -18,7 +18,7 @@ import {
   uploadStatus,
 } from '../services/backup/uploads.js';
 import { runRestore } from '../services/backup/restore.js';
-import { startRestoreJob, getRestoreJob } from '../services/backup/jobs.js';
+import { startRestoreJob, getRestoreJob, updateRestoreProgress } from '../services/backup/jobs.js';
 
 const router: Router = Router();
 
@@ -92,7 +92,10 @@ router.post('/restore/commit', async (req, res) => {
 
   const jobId = startRestoreJob(userId, async (id) => {
     try {
-      return await runRestore(archivePath, userId, id, () => job.touch());
+      return await runRestore(archivePath, userId, id, (phase, staged, total) => {
+        job.touch();
+        updateRestoreProgress(id, phase, staged, total);
+      });
     } finally {
       job.release();
       await discardUpload(uploadId);

--- a/apps/backend/src/routes/backup.ts
+++ b/apps/backend/src/routes/backup.ts
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Router } from 'express';
+import { HttpPayloadTooLarge } from '@httpx/exception';
+import { pipeline } from 'node:stream/promises';
+import { requireAuth } from '../middlewares/auth.js';
+import { MAX_BACKUP_BYTES } from '../services/backup/constants.js';
+import { backupFilename, buildManifest, createBackupArchive } from '../services/backup/export.js';
+import { acquireBackupJob } from '../services/backup/lock.js';
+import {
+  appendChunk,
+  beginUpload,
+  discardUpload,
+  takeUpload,
+  uploadStatus,
+} from '../services/backup/uploads.js';
+import { runRestore } from '../services/backup/restore.js';
+import { startRestoreJob, getRestoreJob } from '../services/backup/jobs.js';
+
+const router: Router = Router();
+
+router.use(requireAuth);
+
+router.get('/preview', async (req, res) => {
+  const manifest = await buildManifest(req.user!.id);
+  res.status(200).json({
+    counts: manifest.counts,
+    documentTypes: manifest.documentTypes,
+    missing: manifest.missing,
+    bytes: manifest.bytes,
+    createdAt: manifest.createdAt,
+  });
+});
+
+router.get('/export', async (req, res) => {
+  const job = acquireBackupJob('export', req.user!.id);
+
+  try {
+    const manifest = await buildManifest(req.user!.id);
+
+    if (manifest.bytes.uncompressed > MAX_BACKUP_BYTES) {
+      throw new HttpPayloadTooLarge(
+        `This workspace is ${manifest.bytes.uncompressed} bytes, above the ${MAX_BACKUP_BYTES} byte export limit.`,
+      );
+    }
+
+    res.status(200);
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Disposition', `attachment; filename="${backupFilename()}"`);
+    res.setHeader('Cache-Control', 'no-store');
+
+    const archive = createBackupArchive(manifest, req.user!.id);
+    archive.outputStream.on('data', () => job.touch());
+
+    await pipeline(archive.outputStream, res);
+  } catch (error) {
+    if (res.headersSent) {
+      console.error('Backup export failed mid-stream:', error);
+      if (!res.destroyed) res.destroy();
+      return;
+    }
+    throw error;
+  } finally {
+    job.release();
+  }
+});
+
+router.post('/restore/begin', async (req, res) => {
+  res.status(201).json(await beginUpload(req.user!.id));
+});
+
+router.put('/restore/chunk', async (req, res) => {
+  const uploadId = String(req.query.uploadId ?? '');
+  const index = Number(req.query.index);
+  const chunk = Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0);
+
+  res.status(200).json(await appendChunk(uploadId, req.user!.id, index, chunk));
+});
+
+router.get('/restore/status', (req, res) => {
+  res.status(200).json(uploadStatus(String(req.query.uploadId ?? ''), req.user!.id));
+});
+
+router.post('/restore/commit', async (req, res) => {
+  const uploadId = String(req.query.uploadId ?? '');
+  const userId = req.user!.id;
+  const archivePath = await takeUpload(uploadId, userId);
+  const job = acquireBackupJob('restore', userId);
+
+  const jobId = startRestoreJob(userId, async (id) => {
+    try {
+      return await runRestore(archivePath, userId, id, () => job.touch());
+    } finally {
+      job.release();
+      await discardUpload(uploadId);
+    }
+  });
+
+  res.status(202).json({ jobId });
+});
+
+router.get('/restore/job', (req, res) => {
+  res.status(200).json(getRestoreJob(String(req.query.jobId ?? ''), req.user!.id));
+});
+
+export { router as backupRouter };

--- a/apps/backend/src/schemas/backup.ts
+++ b/apps/backend/src/schemas/backup.ts
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import z from 'zod';
+
+export const BACKUP_FORMAT_VERSION = 1;
+export const BACKUP_CONTENT_FORMAT = { lexical: 1 } as const;
+export const BACKUP_SCOPE = 'user';
+export const BACKUP_MODE = 'replace';
+
+export const BACKUP_TABLES = [
+  'documents',
+  'revisions',
+  'favorites',
+  'document_views',
+  'editor_settings',
+  'user_images',
+] as const;
+
+export type BackupTable = (typeof BACKUP_TABLES)[number];
+
+const countsShape = Object.fromEntries(
+  BACKUP_TABLES.map((table) => [table, z.number().int().nonnegative()]),
+) as Record<BackupTable, z.ZodNumber>;
+
+export const manifestSchema = z.object({
+  formatVersion: z.number().int().positive(),
+  contentFormat: z.object({ lexical: z.number().int().positive() }),
+  appVersion: z.string().min(1),
+  schemaVersion: z.string().min(1),
+  scope: z.literal(BACKUP_SCOPE),
+  mode: z.literal(BACKUP_MODE),
+  createdAt: z.iso.datetime(),
+  counts: z.object(countsShape).partial(),
+  documentTypes: z
+    .object({
+      space: z.number().int().nonnegative(),
+      folder: z.number().int().nonnegative(),
+      note: z.number().int().nonnegative(),
+    })
+    .optional(),
+  inventory: z.object({
+    revisions: z.array(z.string()),
+    attachments: z.record(z.string(), z.array(z.string())),
+    images: z.array(z.string()),
+    covers: z.array(z.string()),
+  }),
+  missing: z.array(z.string()),
+  bytes: z.object({ uncompressed: z.number().int().nonnegative() }),
+});
+
+export type BackupManifest = z.output<typeof manifestSchema>;
+export type BackupCounts = BackupManifest['counts'];
+export type BackupDocumentTypes = { space: number; folder: number; note: number };
+
+export type BackupPreview = Pick<
+  BackupManifest,
+  'counts' | 'documentTypes' | 'missing' | 'bytes' | 'createdAt'
+>;
+
+export type BackupUploadTicket = {
+  uploadId: string;
+  chunkBytes: number;
+};
+
+export type BackupUploadProgress = {
+  nextIndex: number;
+  bytes: number;
+};
+
+export type BackupRestoreJob = {
+  jobId: string;
+  state: 'running' | 'done' | 'failed';
+  documents: number;
+  revisions: number;
+  error: string | null;
+};

--- a/apps/backend/src/schemas/backup.ts
+++ b/apps/backend/src/schemas/backup.ts
@@ -70,9 +70,14 @@ export type BackupUploadProgress = {
   bytes: number;
 };
 
+export type BackupRestorePhase = 'unpacking' | 'verifying' | 'writing' | 'publishing';
+
 export type BackupRestoreJob = {
   jobId: string;
   state: 'running' | 'done' | 'failed';
+  phase: BackupRestorePhase;
+  staged: number;
+  total: number;
   documents: number;
   revisions: number;
   error: string | null;

--- a/apps/backend/src/schemas/realtime.ts
+++ b/apps/backend/src/schemas/realtime.ts
@@ -11,6 +11,19 @@ export const spaceIdSchema = z.uuid();
 
 export type FavoriteRealtimeResponse = Favorite & { spaceId: string | null };
 
+export type BackupProgress = {
+  jobId: string;
+  phase: 'unpacking' | 'verifying' | 'writing' | 'publishing';
+  staged: number;
+  total: number;
+};
+
+export type BackupRestored = {
+  jobId: string;
+  documents: number;
+  revisions: number;
+};
+
 export type SocketEventsMap = {
   'document:created': DocumentDetails;
   'document:updated': PlainDocument;
@@ -22,6 +35,8 @@ export type SocketEventsMap = {
   'space:deleted': PlainDocument;
   'space:favorited': FavoriteRealtimeResponse;
   'space:unfavorited': FavoriteRealtimeResponse;
+  'backup:progress': BackupProgress;
+  'backup:restored': BackupRestored;
   connect: void;
   disconnect: void;
 };

--- a/apps/backend/src/services/backup/constants.ts
+++ b/apps/backend/src/services/backup/constants.ts
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import path from 'node:path';
+
+const megabytes = (value: number) => value * 1024 * 1024;
+
+const readByteLimit = (name: string, fallback: number) => {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+};
+
+export {
+  BACKUP_CONTENT_FORMAT,
+  BACKUP_FORMAT_VERSION,
+  BACKUP_MODE,
+  BACKUP_SCOPE,
+  BACKUP_TABLES,
+} from '../../schemas/backup.js';
+export type { BackupTable } from '../../schemas/backup.js';
+
+export const MAX_RESTORE_BYTES = readByteLimit('BACKUP_MAX_RESTORE_BYTES', megabytes(2048));
+export const MAX_BACKUP_BYTES = readByteLimit('BACKUP_MAX_BACKUP_BYTES', MAX_RESTORE_BYTES);
+export const MAX_ENTRY_BYTES = readByteLimit('BACKUP_MAX_ENTRY_BYTES', megabytes(100));
+export const MAX_ENTRIES = readByteLimit('BACKUP_MAX_ENTRIES', 50_000);
+export const MAX_MANIFEST_BYTES = readByteLimit('BACKUP_MAX_MANIFEST_BYTES', 64 * 1024);
+export const CHUNK_BYTES = readByteLimit('BACKUP_CHUNK_BYTES', megabytes(8));
+
+export const MAX_RATIO = 200;
+export const RATIO_EXEMPT_BELOW_BYTES = megabytes(1);
+
+export const FREE_SPACE_FACTOR = 1.2;
+export const FREE_SPACE_FLOOR_BYTES = megabytes(256);
+export const FREE_SPACE_CHECK_INTERVAL_BYTES = megabytes(32);
+
+export const STAGING_ROOT = path.join(process.cwd(), 'restore-staging');
+export const UPLOAD_ROOT = path.join(STAGING_ROOT, 'uploads');
+
+export const MANIFEST_ENTRY = 'manifest.json';
+export const COMMIT_MARKER = 'committed.json';
+
+export const ENTRY_PREFIXES = ['db/', 'revisions/', 'attachments/', 'images/', 'covers/'] as const;
+
+const STORED_EXTENSIONS = new Set([
+  '.pdf',
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.gif',
+  '.webp',
+  '.avif',
+  '.mp4',
+  '.mov',
+  '.mp3',
+  '.zip',
+  '.gz',
+  '.7z',
+  '.rar',
+]);
+
+export const shouldStoreUncompressed = (filename: string) =>
+  STORED_EXTENSIONS.has(path.extname(filename).toLowerCase());

--- a/apps/backend/src/services/backup/constants.ts
+++ b/apps/backend/src/services/backup/constants.ts
@@ -4,6 +4,7 @@
  */
 
 import path from 'node:path';
+import { STORAGE_DIR } from '../../lib/storage.js';
 
 const megabytes = (value: number) => value * 1024 * 1024;
 
@@ -27,6 +28,7 @@ export const MAX_RESTORE_BYTES = readByteLimit('BACKUP_MAX_RESTORE_BYTES', megab
 export const MAX_BACKUP_BYTES = readByteLimit('BACKUP_MAX_BACKUP_BYTES', MAX_RESTORE_BYTES);
 export const MAX_ENTRY_BYTES = readByteLimit('BACKUP_MAX_ENTRY_BYTES', megabytes(100));
 export const MAX_ENTRIES = readByteLimit('BACKUP_MAX_ENTRIES', 50_000);
+export const MAX_TABLE_BYTES = readByteLimit('BACKUP_MAX_TABLE_BYTES', megabytes(64));
 export const MAX_MANIFEST_BYTES = readByteLimit('BACKUP_MAX_MANIFEST_BYTES', 64 * 1024);
 export const CHUNK_BYTES = readByteLimit('BACKUP_CHUNK_BYTES', megabytes(8));
 
@@ -37,7 +39,7 @@ export const FREE_SPACE_FACTOR = 1.2;
 export const FREE_SPACE_FLOOR_BYTES = megabytes(256);
 export const FREE_SPACE_CHECK_INTERVAL_BYTES = megabytes(32);
 
-export const STAGING_ROOT = path.join(process.cwd(), 'restore-staging');
+export const STAGING_ROOT = path.join(STORAGE_DIR, '.restore-staging');
 export const UPLOAD_ROOT = path.join(STAGING_ROOT, 'uploads');
 
 export const MANIFEST_ENTRY = 'manifest.json';

--- a/apps/backend/src/services/backup/entry-gate.ts
+++ b/apps/backend/src/services/backup/entry-gate.ts
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import path from 'node:path';
+import { storageFilenameSchema } from '../../schemas/storage.js';
+import {
+  BACKUP_TABLES,
+  ENTRY_PREFIXES,
+  MANIFEST_ENTRY,
+  MAX_ENTRIES,
+  MAX_ENTRY_BYTES,
+  MAX_RATIO,
+  MAX_RESTORE_BYTES,
+  RATIO_EXEMPT_BELOW_BYTES,
+} from './constants.js';
+
+const UNIX_MODE_FORMAT_MASK = 0o170000;
+const UNIX_MODE_SYMLINK = 0o120000;
+const UNIX_MODE_REGULAR = 0o100000;
+
+const DENIED_BASENAMES = new Set(['local.db', 'local.db-wal', 'local.db-shm', 'local.db-journal']);
+
+export class EntryRejected extends Error {
+  constructor(
+    readonly entryName: string,
+    readonly reason: string,
+  ) {
+    super(`Rejected archive entry "${entryName}": ${reason}`);
+    this.name = 'EntryRejected';
+  }
+}
+
+export const isDirectoryEntry = (entryName: string) => entryName.endsWith('/');
+
+const checkEntryName = (entryName: string) => {
+  if (entryName.length === 0) return 'empty name';
+  if (entryName.length > 1024) return 'name too long';
+  if (entryName.includes('\0')) return 'contains a NUL byte';
+  if (entryName.includes('\\')) return 'contains a backslash';
+  if (entryName.normalize('NFC') !== entryName) return 'name is not NFC-normalised';
+  if (path.posix.isAbsolute(entryName) || /^[A-Za-z]:/.test(entryName)) return 'absolute path';
+
+  const segments = entryName.split('/');
+  for (const segment of segments) {
+    if (segment === '..') return 'contains a parent-directory segment';
+    if (segment === '.') return 'contains a current-directory segment';
+    if (segment.length > 0 && segment !== segment.trimEnd()) return 'segment ends with whitespace';
+    if (segment.endsWith('.')) return 'segment ends with a dot';
+  }
+
+  if (entryName === MANIFEST_ENTRY) return null;
+
+  if (!ENTRY_PREFIXES.some((prefix) => entryName.startsWith(prefix))) {
+    return 'outside the allowed prefixes';
+  }
+
+  if (entryName.startsWith('db/')) {
+    const table = entryName.slice(3).replace(/\.ndjson$/, '');
+    if (segments.length !== 2 || !entryName.endsWith('.ndjson')) return 'malformed table file';
+    if (!(BACKUP_TABLES as readonly string[]).includes(table)) return 'unexpected table file';
+  }
+  const basename = segments[segments.length - 1];
+  if (DENIED_BASENAMES.has(basename.toLowerCase())) return 'targets the database file';
+  if (!storageFilenameSchema.safeParse(basename).success) return 'illegal filename';
+
+  return null;
+};
+
+const checkEntryMode = (externalFileAttributes: number) => {
+  const unixMode = (externalFileAttributes >>> 16) & 0xffff;
+  if (unixMode === 0) return null;
+
+  const format = unixMode & UNIX_MODE_FORMAT_MASK;
+  if (format === UNIX_MODE_SYMLINK) return 'is a symbolic link';
+  if (format !== 0 && format !== UNIX_MODE_REGULAR) return 'is not a regular file';
+
+  return null;
+};
+
+export const resolveStagedPath = (stagingRoot: string, entryName: string) => {
+  const root = path.resolve(stagingRoot);
+  const resolved = path.resolve(root, entryName);
+  const relative = path.relative(root, resolved);
+
+  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new EntryRejected(entryName, 'resolves outside the staging directory');
+  }
+
+  if (DENIED_BASENAMES.has(path.basename(resolved).toLowerCase())) {
+    throw new EntryRejected(entryName, 'targets the database file');
+  }
+
+  return resolved;
+};
+
+export class ExtractionGuard {
+  #entryCount = 0;
+  #totalBytes = 0;
+  readonly #seen = new Set<string>();
+
+  admit(entryName: string, externalFileAttributes: number) {
+    const nameProblem = checkEntryName(entryName);
+    if (nameProblem) throw new EntryRejected(entryName, nameProblem);
+
+    const modeProblem = checkEntryMode(externalFileAttributes);
+    if (modeProblem) throw new EntryRejected(entryName, modeProblem);
+
+    const key = entryName.toLowerCase();
+    if (this.#seen.has(key)) {
+      throw new EntryRejected(entryName, 'duplicate entry name');
+    }
+    this.#seen.add(key);
+
+    this.#entryCount += 1;
+    if (this.#entryCount > MAX_ENTRIES) {
+      throw new EntryRejected(entryName, `archive exceeds ${MAX_ENTRIES} entries`);
+    }
+  }
+
+  countBytes(entryName: string, byteLength: number) {
+    this.#totalBytes += byteLength;
+
+    if (this.#totalBytes > MAX_RESTORE_BYTES) {
+      throw new EntryRejected(entryName, `archive exceeds ${MAX_RESTORE_BYTES} uncompressed bytes`);
+    }
+  }
+
+  checkEntryTotal(entryName: string, written: number) {
+    if (written > MAX_ENTRY_BYTES) {
+      throw new EntryRejected(entryName, `entry exceeds ${MAX_ENTRY_BYTES} bytes`);
+    }
+  }
+
+  checkRatio(entryName: string, uncompressed: number, compressed: number) {
+    if (uncompressed < RATIO_EXEMPT_BELOW_BYTES) return;
+    if (compressed <= 0) return;
+
+    const ratio = uncompressed / compressed;
+    if (ratio > MAX_RATIO) {
+      throw new EntryRejected(
+        entryName,
+        `compression ratio ${Math.round(ratio)}:1 exceeds ${MAX_RATIO}:1`,
+      );
+    }
+  }
+
+  get entryCount() {
+    return this.#entryCount;
+  }
+
+  get totalBytes() {
+    return this.#totalBytes;
+  }
+}

--- a/apps/backend/src/services/backup/entry-gate.ts
+++ b/apps/backend/src/services/backup/entry-gate.ts
@@ -13,6 +13,7 @@ import {
   MAX_ENTRY_BYTES,
   MAX_RATIO,
   MAX_RESTORE_BYTES,
+  MAX_TABLE_BYTES,
   RATIO_EXEMPT_BELOW_BYTES,
 } from './constants.js';
 
@@ -98,6 +99,7 @@ export const resolveStagedPath = (stagingRoot: string, entryName: string) => {
 export class ExtractionGuard {
   #entryCount = 0;
   #totalBytes = 0;
+  #tableBytes = 0;
   readonly #seen = new Set<string>();
 
   admit(entryName: string, externalFileAttributes: number) {
@@ -121,6 +123,16 @@ export class ExtractionGuard {
 
   countBytes(entryName: string, byteLength: number) {
     this.#totalBytes += byteLength;
+
+    if (entryName.startsWith('db/')) {
+      this.#tableBytes += byteLength;
+      if (this.#tableBytes > MAX_TABLE_BYTES) {
+        throw new EntryRejected(
+          entryName,
+          `table data exceeds ${MAX_TABLE_BYTES} bytes; this workspace is too large to restore in one pass`,
+        );
+      }
+    }
 
     if (this.#totalBytes > MAX_RESTORE_BYTES) {
       throw new EntryRejected(entryName, `archive exceeds ${MAX_RESTORE_BYTES} uncompressed bytes`);

--- a/apps/backend/src/services/backup/export.ts
+++ b/apps/backend/src/services/backup/export.ts
@@ -61,19 +61,23 @@ const countDocumentTypes = async (userId: string) => {
 };
 
 const pageRows = async function* (table: BackupTable, userId: string) {
-  let offset = 0;
+  let cursor: string | null = null;
 
   for (;;) {
-    const rows = await db.all<Record<string, unknown>>(
-      sql`select * from ${sql.identifier(table)} where user_id = ${userId} order by id limit ${PAGE_SIZE} offset ${offset}`,
-    );
+    const rows: Record<string, unknown>[] = cursor
+      ? await db.all<Record<string, unknown>>(
+          sql`select * from ${sql.identifier(table)} where user_id = ${userId} and id > ${cursor} order by id limit ${PAGE_SIZE}`,
+        )
+      : await db.all<Record<string, unknown>>(
+          sql`select * from ${sql.identifier(table)} where user_id = ${userId} order by id limit ${PAGE_SIZE}`,
+        );
 
     if (rows.length === 0) return;
 
     for (const row of rows) yield row;
 
     if (rows.length < PAGE_SIZE) return;
-    offset += PAGE_SIZE;
+    cursor = String(rows[rows.length - 1].id);
   }
 };
 

--- a/apps/backend/src/services/backup/export.ts
+++ b/apps/backend/src/services/backup/export.ts
@@ -1,0 +1,162 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createReadStream } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { sql } from 'drizzle-orm';
+import yazl from 'yazl';
+import { db } from '../../lib/db.js';
+import { resolvePhysicalPath } from '../../lib/storage.js';
+import {
+  BACKUP_CONTENT_FORMAT,
+  BACKUP_FORMAT_VERSION,
+  BACKUP_MODE,
+  BACKUP_SCOPE,
+  BACKUP_TABLES,
+  BackupTable,
+  MANIFEST_ENTRY,
+  shouldStoreUncompressed,
+} from './constants.js';
+import { collectInventory, estimateUncompressedBytes } from './inventory.js';
+import type { BackupManifest } from './manifest.js';
+
+const PAGE_SIZE = 500;
+
+export const readSchemaVersion = async () => {
+  try {
+    const journalPath = path.join(process.cwd(), 'drizzle', 'meta', '_journal.json');
+    const journal = JSON.parse(await readFile(journalPath, 'utf8')) as {
+      entries?: { tag?: string }[];
+    };
+    const entries = journal.entries ?? [];
+    return entries[entries.length - 1]?.tag ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+};
+
+const countRows = async (table: BackupTable, userId: string) => {
+  const rows = await db.all<{ total: number }>(
+    sql`select count(*) as total from ${sql.identifier(table)} where user_id = ${userId}`,
+  );
+  return Number(rows[0]?.total ?? 0);
+};
+
+const countDocumentTypes = async (userId: string) => {
+  const rows = await db.all<{ document_type: string; total: number }>(
+    sql`select document_type, count(*) as total from documents where user_id = ${userId} group by document_type`,
+  );
+
+  const totals = { space: 0, folder: 0, note: 0 };
+  for (const row of rows) {
+    if (row.document_type in totals)
+      totals[row.document_type as keyof typeof totals] = Number(row.total);
+  }
+
+  return totals;
+};
+
+const pageRows = async function* (table: BackupTable, userId: string) {
+  let offset = 0;
+
+  for (;;) {
+    const rows = await db.all<Record<string, unknown>>(
+      sql`select * from ${sql.identifier(table)} where user_id = ${userId} order by id limit ${PAGE_SIZE} offset ${offset}`,
+    );
+
+    if (rows.length === 0) return;
+
+    for (const row of rows) yield row;
+
+    if (rows.length < PAGE_SIZE) return;
+    offset += PAGE_SIZE;
+  }
+};
+
+const ndjsonStream = (table: BackupTable, userId: string) =>
+  Readable.from(
+    (async function* () {
+      for await (const row of pageRows(table, userId)) {
+        yield `${JSON.stringify(row)}\n`;
+      }
+    })(),
+  );
+
+export const buildManifest = async (userId: string) => {
+  const { inventory, missing, fileBytes } = await collectInventory(userId);
+
+  const counts = {} as BackupManifest['counts'];
+  let rowTotal = 0;
+
+  for (const table of BACKUP_TABLES) {
+    const total = await countRows(table, userId);
+    counts[table] = total;
+    rowTotal += total;
+  }
+
+  const manifest: BackupManifest = {
+    formatVersion: BACKUP_FORMAT_VERSION,
+    contentFormat: { ...BACKUP_CONTENT_FORMAT },
+    appVersion: process.env.APP_VERSION ?? 'unknown',
+    schemaVersion: await readSchemaVersion(),
+    scope: BACKUP_SCOPE,
+    mode: BACKUP_MODE,
+    createdAt: new Date().toISOString(),
+    counts,
+    documentTypes: await countDocumentTypes(userId),
+    inventory,
+    missing,
+    bytes: { uncompressed: estimateUncompressedBytes(fileBytes, rowTotal) },
+  };
+
+  return manifest;
+};
+
+export const createBackupArchive = (manifest: BackupManifest, userId: string) => {
+  const zip = new yazl.ZipFile();
+
+  zip.addBuffer(Buffer.from(JSON.stringify(manifest), 'utf8'), MANIFEST_ENTRY, {
+    compress: true,
+  });
+
+  for (const table of BACKUP_TABLES) {
+    zip.addReadStream(ndjsonStream(table, userId), `db/${table}.ndjson`, { compress: true });
+  }
+
+  for (const revisionId of manifest.inventory.revisions) {
+    const entryName = `revisions/${revisionId}.json`;
+    zip.addReadStream(createReadStream(resolvePhysicalPath(entryName)), entryName, {
+      compress: true,
+    });
+  }
+
+  for (const [documentId, filenames] of Object.entries(manifest.inventory.attachments)) {
+    for (const filename of filenames) {
+      const entryName = `attachments/${documentId}/${filename}`;
+      zip.addReadStream(createReadStream(resolvePhysicalPath(entryName)), entryName, {
+        compress: !shouldStoreUncompressed(filename),
+      });
+    }
+  }
+
+  for (const bucket of ['images', 'covers'] as const) {
+    for (const filename of manifest.inventory[bucket]) {
+      const physicalPath = resolvePhysicalPath(`${bucket}/${userId}/${filename}`);
+      zip.addReadStream(createReadStream(physicalPath), `${bucket}/${filename}`, {
+        compress: !shouldStoreUncompressed(filename),
+      });
+    }
+  }
+
+  zip.end();
+  return zip;
+};
+
+export const backupFilename = () => {
+  const stamp = new Date().toISOString().slice(0, 10);
+  return `wordyme-backup-${stamp}.zip`;
+};

--- a/apps/backend/src/services/backup/inventory.ts
+++ b/apps/backend/src/services/backup/inventory.ts
@@ -42,8 +42,9 @@ const listDirectory = async (physicalPath: string) => {
       .map((entry) => entry.name)
       .filter((name) => storageFilenameSchema.safeParse(name).success)
       .sort((a, b) => a.localeCompare(b));
-  } catch {
-    return [];
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
   }
 };
 
@@ -85,7 +86,10 @@ export const collectInventory = async (userId: string): Promise<InventoryResult>
     const kept: string[] = [];
     for (const filename of filenames) {
       const size = await sizeOf(path.join(directory, filename));
-      if (size === null) continue;
+      if (size === null) {
+        missing.push(`attachments/${document.id}/${filename}`);
+        continue;
+      }
       kept.push(filename);
       fileBytes += size;
     }

--- a/apps/backend/src/services/backup/inventory.ts
+++ b/apps/backend/src/services/backup/inventory.ts
@@ -1,0 +1,121 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { eq } from 'drizzle-orm';
+import { db } from '../../lib/db.js';
+import { resolvePhysicalPath } from '../../lib/storage.js';
+import { documentsTable } from '../../models/documents.js';
+import { revisionsTable } from '../../models/revisions.js';
+import { userImagesTable } from '../../models/user-images.js';
+import { storageFilenameSchema } from '../../schemas/storage.js';
+import type { BackupManifest } from '../../schemas/backup.js';
+
+const ROW_BYTES_ESTIMATE = 512;
+
+type BackupInventory = BackupManifest['inventory'];
+
+type InventoryResult = {
+  inventory: BackupInventory;
+  missing: string[];
+  fileBytes: number;
+  documentIds: string[];
+};
+
+const sizeOf = async (physicalPath: string) => {
+  try {
+    const stats = await stat(physicalPath);
+    return stats.isFile() ? stats.size : null;
+  } catch {
+    return null;
+  }
+};
+
+const listDirectory = async (physicalPath: string) => {
+  try {
+    const entries = await readdir(physicalPath, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+      .filter((name) => storageFilenameSchema.safeParse(name).success)
+      .sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+};
+
+export const collectInventory = async (userId: string): Promise<InventoryResult> => {
+  const documents = await db
+    .select({ id: documentsTable.id })
+    .from(documentsTable)
+    .where(eq(documentsTable.userId, userId));
+
+  const revisions = await db
+    .select({ id: revisionsTable.id })
+    .from(revisionsTable)
+    .where(eq(revisionsTable.userId, userId));
+
+  const images = await db
+    .select({ imageType: userImagesTable.imageType, imagePath: userImagesTable.path })
+    .from(userImagesTable)
+    .where(eq(userImagesTable.userId, userId));
+
+  const inventory: BackupInventory = { revisions: [], attachments: {}, images: [], covers: [] };
+  const missing: string[] = [];
+  let fileBytes = 0;
+
+  for (const revision of revisions) {
+    const size = await sizeOf(resolvePhysicalPath(`revisions/${revision.id}.json`));
+    if (size === null) {
+      missing.push(`revisions/${revision.id}.json`);
+      continue;
+    }
+    inventory.revisions.push(revision.id);
+    fileBytes += size;
+  }
+
+  for (const document of documents) {
+    const directory = resolvePhysicalPath(`attachments/${document.id}`);
+    const filenames = await listDirectory(directory);
+    if (filenames.length === 0) continue;
+
+    const kept: string[] = [];
+    for (const filename of filenames) {
+      const size = await sizeOf(path.join(directory, filename));
+      if (size === null) continue;
+      kept.push(filename);
+      fileBytes += size;
+    }
+
+    if (kept.length > 0) inventory.attachments[document.id] = kept;
+  }
+
+  for (const image of images) {
+    if (!image.imagePath) continue;
+    const filename = path.basename(image.imagePath);
+    if (!storageFilenameSchema.safeParse(filename).success) continue;
+
+    const bucket = image.imageType === 'cover' ? 'covers' : 'images';
+    const size = await sizeOf(resolvePhysicalPath(`${bucket}/${userId}/${filename}`));
+    if (size === null) {
+      missing.push(`${bucket}/${filename}`);
+      continue;
+    }
+
+    inventory[bucket].push(filename);
+    fileBytes += size;
+  }
+
+  return {
+    inventory,
+    missing,
+    fileBytes,
+    documentIds: documents.map((document) => document.id),
+  };
+};
+
+export const estimateUncompressedBytes = (fileBytes: number, rowCount: number) =>
+  fileBytes + rowCount * ROW_BYTES_ESTIMATE;

--- a/apps/backend/src/services/backup/jobs.ts
+++ b/apps/backend/src/services/backup/jobs.ts
@@ -5,7 +5,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { HttpForbidden, HttpNotFound } from '@httpx/exception';
-import type { BackupRestoreJob } from '../../schemas/backup.js';
+import type { BackupRestoreJob, BackupRestorePhase } from '../../schemas/backup.js';
 
 type RestoreJob = BackupRestoreJob & { userId: string };
 
@@ -21,6 +21,9 @@ export const startRestoreJob = (
     jobId,
     userId,
     state: 'running',
+    phase: 'unpacking',
+    staged: 0,
+    total: 0,
     documents: 0,
     revisions: 0,
     error: null,
@@ -45,6 +48,20 @@ export const startRestoreJob = (
   return jobId;
 };
 
+export const updateRestoreProgress = (
+  jobId: string,
+  phase: BackupRestorePhase,
+  staged: number,
+  total: number,
+) => {
+  const job = jobs.get(jobId);
+  if (!job) return;
+
+  job.phase = phase;
+  job.staged = staged;
+  job.total = total;
+};
+
 export const getRestoreJob = (jobId: string, userId: string): BackupRestoreJob => {
   const job = jobs.get(jobId);
   if (!job) throw new HttpNotFound('That restore job is no longer available.');
@@ -54,6 +71,9 @@ export const getRestoreJob = (jobId: string, userId: string): BackupRestoreJob =
   return {
     jobId: job.jobId,
     state: job.state,
+    phase: job.phase,
+    staged: job.staged,
+    total: job.total,
     documents: job.documents,
     revisions: job.revisions,
     error: job.error,

--- a/apps/backend/src/services/backup/jobs.ts
+++ b/apps/backend/src/services/backup/jobs.ts
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { randomUUID } from 'node:crypto';
+import { HttpForbidden, HttpNotFound } from '@httpx/exception';
+import type { BackupRestoreJob } from '../../schemas/backup.js';
+
+type RestoreJob = BackupRestoreJob & { userId: string };
+
+const jobs = new Map<string, RestoreJob>();
+const JOB_TTL_MS = 60 * 60_000;
+
+export const startRestoreJob = (
+  userId: string,
+  run: (jobId: string) => Promise<{ documents: number; revisions: number }>,
+) => {
+  const jobId = randomUUID();
+  const job: RestoreJob = {
+    jobId,
+    userId,
+    state: 'running',
+    documents: 0,
+    revisions: 0,
+    error: null,
+  };
+  jobs.set(jobId, job);
+
+  void run(jobId)
+    .then((counts) => {
+      job.state = 'done';
+      job.documents = counts.documents;
+      job.revisions = counts.revisions;
+    })
+    .catch((error: unknown) => {
+      job.state = 'failed';
+      job.error = error instanceof Error ? error.message : 'The restore failed.';
+      console.error('Backup restore failed:', error);
+    })
+    .finally(() => {
+      setTimeout(() => jobs.delete(jobId), JOB_TTL_MS).unref();
+    });
+
+  return jobId;
+};
+
+export const getRestoreJob = (jobId: string, userId: string): BackupRestoreJob => {
+  const job = jobs.get(jobId);
+  if (!job) throw new HttpNotFound('That restore job is no longer available.');
+  if (job.userId !== userId)
+    throw new HttpForbidden('That restore job belongs to another account.');
+
+  return {
+    jobId: job.jobId,
+    state: job.state,
+    documents: job.documents,
+    revisions: job.revisions,
+    error: job.error,
+  };
+};

--- a/apps/backend/src/services/backup/lock.ts
+++ b/apps/backend/src/services/backup/lock.ts
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { HttpConflict } from '@httpx/exception';
+
+const STALL_TIMEOUT_MS = 10 * 60_000;
+
+type BackupJobKind = 'export' | 'restore';
+
+type ActiveJob = {
+  kind: BackupJobKind;
+  userId: string;
+  startedAt: number;
+  touchedAt: number;
+};
+
+let active: ActiveJob | null = null;
+
+const isStalled = (job: ActiveJob) => Date.now() - job.touchedAt > STALL_TIMEOUT_MS;
+
+export const acquireBackupJob = (kind: BackupJobKind, userId: string) => {
+  if (active && !isStalled(active)) {
+    throw new HttpConflict(
+      `A ${active.kind} is already running. Wait for it to finish before starting another.`,
+    );
+  }
+
+  if (active) {
+    console.warn(
+      `Releasing stalled ${active.kind} job started at ${new Date(active.startedAt).toISOString()}.`,
+    );
+  }
+
+  const job: ActiveJob = { kind, userId, startedAt: Date.now(), touchedAt: Date.now() };
+  active = job;
+
+  let released = false;
+
+  return {
+    touch: () => {
+      if (!released) job.touchedAt = Date.now();
+    },
+    release: () => {
+      if (released) return;
+      released = true;
+      if (active === job) active = null;
+    },
+  };
+};
+
+export const isRestoreRunning = () =>
+  Boolean(active && active.kind === 'restore' && !isStalled(active));

--- a/apps/backend/src/services/backup/lock.ts
+++ b/apps/backend/src/services/backup/lock.ts
@@ -18,7 +18,8 @@ type ActiveJob = {
 
 let active: ActiveJob | null = null;
 
-const isStalled = (job: ActiveJob) => Date.now() - job.touchedAt > STALL_TIMEOUT_MS;
+const isStalled = (job: ActiveJob) =>
+  job.kind !== 'restore' && Date.now() - job.touchedAt > STALL_TIMEOUT_MS;
 
 export const acquireBackupJob = (kind: BackupJobKind, userId: string) => {
   if (active && !isStalled(active)) {

--- a/apps/backend/src/services/backup/manifest.ts
+++ b/apps/backend/src/services/backup/manifest.ts
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {
+  BACKUP_CONTENT_FORMAT,
+  BACKUP_FORMAT_VERSION,
+  manifestSchema,
+  type BackupManifest,
+} from '../../schemas/backup.js';
+
+export type { BackupManifest };
+
+const schemaOrdinal = (tag: string) => {
+  const match = /^(\d+)/.exec(tag);
+  return match ? Number(match[1]) : null;
+};
+
+type ManifestRejection = { code: 'unsupported' | 'malformed'; message: string };
+
+export const validateManifest = (
+  raw: unknown,
+  targetSchemaVersion: string,
+): { ok: true; manifest: BackupManifest } | { ok: false; rejection: ManifestRejection } => {
+  const parsed = manifestSchema.safeParse(raw);
+
+  if (!parsed.success) {
+    return {
+      ok: false,
+      rejection: { code: 'malformed', message: 'The manifest is missing or malformed.' },
+    };
+  }
+
+  const manifest = parsed.data;
+
+  if (manifest.formatVersion > BACKUP_FORMAT_VERSION) {
+    return {
+      ok: false,
+      rejection: {
+        code: 'unsupported',
+        message: `This backup was made by a newer WordyMe (format ${manifest.formatVersion}); this build supports up to ${BACKUP_FORMAT_VERSION}.`,
+      },
+    };
+  }
+
+  if (manifest.contentFormat.lexical > BACKUP_CONTENT_FORMAT.lexical) {
+    return {
+      ok: false,
+      rejection: {
+        code: 'unsupported',
+        message: `This backup stores editor content in a newer format (${manifest.contentFormat.lexical}); this build supports up to ${BACKUP_CONTENT_FORMAT.lexical}. Restoring it would produce documents this version cannot open.`,
+      },
+    };
+  }
+
+  const backupSchema = schemaOrdinal(manifest.schemaVersion);
+  const targetSchema = schemaOrdinal(targetSchemaVersion);
+
+  if (backupSchema !== null && targetSchema !== null && backupSchema > targetSchema) {
+    return {
+      ok: false,
+      rejection: {
+        code: 'unsupported',
+        message: `This backup came from a newer database layout (${manifest.schemaVersion}); this build is at ${targetSchemaVersion}. Update WordyMe before restoring it.`,
+      },
+    };
+  }
+
+  return { ok: true, manifest };
+};

--- a/apps/backend/src/services/backup/restore-db.ts
+++ b/apps/backend/src/services/backup/restore-db.ts
@@ -1,0 +1,211 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createReadStream, existsSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+import path from 'node:path';
+import { sql, type SQL } from 'drizzle-orm';
+import { HttpUnprocessableEntity } from '@httpx/exception';
+import { db } from '../../lib/db.js';
+import { BACKUP_TABLES, type BackupTable } from './constants.js';
+import type { BackupManifest } from './manifest.js';
+
+type Row = Record<string, unknown>;
+type Executor = Pick<typeof db, 'run' | 'all'>;
+
+const readNdjson = async (filePath: string): Promise<Row[]> => {
+  const rows: Row[] = [];
+
+  if (!existsSync(filePath)) return rows;
+
+  const stream = createReadStream(filePath, { encoding: 'utf8' });
+  const lines = createInterface({ input: stream, crlfDelay: Infinity });
+
+  for await (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      throw new HttpUnprocessableEntity(`Corrupt data in ${path.basename(filePath)}.`);
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new HttpUnprocessableEntity(`Corrupt data in ${path.basename(filePath)}.`);
+    }
+
+    rows.push(parsed as Row);
+  }
+
+  return rows;
+};
+
+const tableColumns = async (table: BackupTable) => {
+  const rows = await db.all<{ name: string }>(sql`select name from pragma_table_info(${table})`);
+  return new Set(rows.map((row) => row.name));
+};
+
+const insertRow = async (
+  executor: Executor,
+  table: BackupTable,
+  row: Row,
+  columns: Set<string>,
+) => {
+  const keys = Object.keys(row).filter((key) => columns.has(key));
+  if (keys.length === 0) return;
+
+  const columnList = keys.map((key) => sql.identifier(key));
+  const valueList = keys.map((key) => sql`${row[key] as SQL}`);
+
+  await executor.run(
+    sql`insert into ${sql.identifier(table)} (${sql.join(columnList, sql`, `)}) values (${sql.join(valueList, sql`, `)})`,
+  );
+};
+
+const assertTreeIsSound = (documents: Row[]) => {
+  const byId = new Map<string, Row>();
+  for (const document of documents) {
+    const id = document.id;
+    if (typeof id !== 'string') {
+      throw new HttpUnprocessableEntity('A document in this backup has no id.');
+    }
+    byId.set(id, document);
+  }
+
+  for (const document of documents) {
+    for (const key of ['parent_id', 'space_id'] as const) {
+      const reference = document[key];
+      if (reference === null || reference === undefined) continue;
+      if (typeof reference !== 'string' || !byId.has(reference)) {
+        throw new HttpUnprocessableEntity(
+          `This backup is inconsistent: a document points at a ${key} that is not in the backup.`,
+        );
+      }
+    }
+  }
+
+  for (const key of ['parent_id', 'space_id'] as const) {
+    for (const start of byId.keys()) {
+      const seen = new Set<string>([start]);
+      let cursor = byId.get(start)?.[key];
+
+      while (typeof cursor === 'string') {
+        if (seen.has(cursor)) {
+          throw new HttpUnprocessableEntity(
+            `This backup is inconsistent: its documents form a ${key} loop.`,
+          );
+        }
+        seen.add(cursor);
+        cursor = byId.get(cursor)?.[key];
+      }
+    }
+  }
+};
+
+export const restoreDatabase = async (
+  stagingDir: string,
+  userId: string,
+  manifest: BackupManifest,
+) => {
+  const tables = {} as Record<BackupTable, Row[]>;
+
+  for (const table of BACKUP_TABLES) {
+    tables[table] = await readNdjson(path.join(stagingDir, 'db', `${table}.ndjson`));
+  }
+
+  for (const table of BACKUP_TABLES) {
+    const declared = manifest.counts[table];
+    if (declared !== undefined && tables[table].length !== declared) {
+      throw new HttpUnprocessableEntity(
+        `This backup is incomplete: ${table} declares ${declared} rows but carries ${tables[table].length}. Nothing was changed.`,
+      );
+    }
+  }
+
+  assertTreeIsSound(tables.documents);
+
+  const columns = {} as Record<BackupTable, Set<string>>;
+  for (const table of BACKUP_TABLES) {
+    columns[table] = await tableColumns(table);
+  }
+
+  const revisionIds = new Set(tables.revisions.map((row) => String(row.id)));
+
+  await db.transaction(async (tx) => {
+    const executor = tx as unknown as Executor;
+
+    await executor.run(sql`pragma defer_foreign_keys = on`);
+
+    for (const table of BACKUP_TABLES) {
+      if (table === 'documents' || table === 'revisions' || table === 'editor_settings') continue;
+      await executor.run(sql`delete from ${sql.identifier(table)} where user_id = ${userId}`);
+    }
+
+    await executor.run(
+      sql`update documents set current_revision_id = null where user_id = ${userId}`,
+    );
+    await executor.run(sql`delete from revisions where user_id = ${userId}`);
+    await executor.run(sql`delete from documents where user_id = ${userId}`);
+
+    const heads: [string, string][] = [];
+
+    for (const document of tables.documents) {
+      const head = document.current_revision_id;
+      if (typeof head === 'string' && revisionIds.has(head)) {
+        heads.push([String(document.id), head]);
+      }
+      await insertRow(
+        executor,
+        'documents',
+        { ...document, user_id: userId, current_revision_id: null },
+        columns.documents,
+      );
+    }
+
+    for (const revision of tables.revisions) {
+      await insertRow(executor, 'revisions', { ...revision, user_id: userId }, columns.revisions);
+    }
+
+    for (const [documentId, revisionId] of heads) {
+      await executor.run(
+        sql`update documents set current_revision_id = ${revisionId} where id = ${documentId}`,
+      );
+    }
+
+    for (const favorite of tables.favorites) {
+      await insertRow(executor, 'favorites', { ...favorite, user_id: userId }, columns.favorites);
+    }
+
+    for (const table of BACKUP_TABLES) {
+      if (table === 'documents' || table === 'revisions' || table === 'editor_settings') continue;
+      if (table === 'favorites') continue;
+
+      for (const row of tables[table]) {
+        await insertRow(executor, table, { ...row, user_id: userId }, columns[table]);
+      }
+    }
+
+    const [settings] = tables.editor_settings;
+    if (settings) {
+      await executor.run(
+        sql`update editor_settings set keep_previous_revision = ${settings.keep_previous_revision ?? 0}, autosave = ${settings.autosave ?? 0} where user_id = ${userId}`,
+      );
+    }
+
+    const violations = await executor.all<Record<string, unknown>>(sql`pragma foreign_key_check`);
+    if (violations.length > 0) {
+      throw new HttpUnprocessableEntity(
+        `Restoring this backup would leave ${violations.length} broken reference(s). Nothing was changed.`,
+      );
+    }
+  });
+
+  return {
+    documents: tables.documents.length,
+    revisions: tables.revisions.length,
+  };
+};

--- a/apps/backend/src/services/backup/restore-db.ts
+++ b/apps/backend/src/services/backup/restore-db.ts
@@ -110,6 +110,7 @@ export const restoreDatabase = async (
   stagingDir: string,
   userId: string,
   manifest: BackupManifest,
+  jobId: string,
 ) => {
   const tables = {} as Record<BackupTable, Row[]>;
 
@@ -205,6 +206,10 @@ export const restoreDatabase = async (
         columns.editor_settings,
       );
     }
+
+    await executor.run(
+      sql`insert into backup_restores (id, created_at) values (${jobId}, ${Date.now()})`,
+    );
 
     const violations = await executor.all<Record<string, unknown>>(sql`pragma foreign_key_check`);
     if (violations.length > 0) {

--- a/apps/backend/src/services/backup/restore-db.ts
+++ b/apps/backend/src/services/backup/restore-db.ts
@@ -194,9 +194,10 @@ export const restoreDatabase = async (
       }
     }
 
+    await executor.run(sql`delete from editor_settings where user_id = ${userId}`);
+
     const [settings] = tables.editor_settings;
     if (settings) {
-      await executor.run(sql`delete from editor_settings where user_id = ${userId}`);
       await insertRow(
         executor,
         'editor_settings',

--- a/apps/backend/src/services/backup/restore-db.ts
+++ b/apps/backend/src/services/backup/restore-db.ts
@@ -119,6 +119,11 @@ export const restoreDatabase = async (
 
   for (const table of BACKUP_TABLES) {
     const declared = manifest.counts[table];
+    if (declared === undefined && tables[table].length > 0) {
+      throw new HttpUnprocessableEntity(
+        `This backup carries ${table} rows that its manifest does not declare. Nothing was changed.`,
+      );
+    }
     if (declared !== undefined && tables[table].length !== declared) {
       throw new HttpUnprocessableEntity(
         `This backup is incomplete: ${table} declares ${declared} rows but carries ${tables[table].length}. Nothing was changed.`,
@@ -191,8 +196,12 @@ export const restoreDatabase = async (
 
     const [settings] = tables.editor_settings;
     if (settings) {
-      await executor.run(
-        sql`update editor_settings set keep_previous_revision = ${settings.keep_previous_revision ?? 0}, autosave = ${settings.autosave ?? 0} where user_id = ${userId}`,
+      await executor.run(sql`delete from editor_settings where user_id = ${userId}`);
+      await insertRow(
+        executor,
+        'editor_settings',
+        { ...settings, user_id: userId },
+        columns.editor_settings,
       );
     }
 

--- a/apps/backend/src/services/backup/restore.ts
+++ b/apps/backend/src/services/backup/restore.ts
@@ -18,15 +18,25 @@ import {
   writeCommitMarker,
 } from './staging.js';
 
-const liveFilesFor = (inventory: Awaited<ReturnType<typeof collectInventory>>['inventory']) => {
+const liveFilesFor = (
+  inventory: Awaited<ReturnType<typeof collectInventory>>['inventory'],
+  userId: string,
+) => {
   const names = new Set<string>();
 
   for (const revisionId of inventory.revisions) names.add(`revisions/${revisionId}.json`);
   for (const [documentId, filenames] of Object.entries(inventory.attachments)) {
     for (const filename of filenames) names.add(`attachments/${documentId}/${filename}`);
   }
+  for (const filename of inventory.images) names.add(`images/${userId}/${filename}`);
+  for (const filename of inventory.covers) names.add(`covers/${userId}/${filename}`);
 
   return names;
+};
+
+const destinationFor = (entry: string, userId: string) => {
+  const match = /^(images|covers)\/(.+)$/.exec(entry);
+  return match ? `${match[1]}/${userId}/${match[2]}` : entry;
 };
 
 export const runRestore = async (
@@ -40,7 +50,7 @@ export const runRestore = async (
   ) => void,
 ) => {
   const before = await collectInventory(userId);
-  const previousFiles = liveFilesFor(before.inventory);
+  const previousFiles = liveFilesFor(before.inventory, userId);
 
   const report = (
     phase: 'unpacking' | 'verifying' | 'writing' | 'publishing',
@@ -50,6 +60,8 @@ export const runRestore = async (
     onPhase?.(phase, staged, total);
     if (isSocketReady()) emitToUser(userId, 'backup:progress', { jobId, phase, staged, total });
   };
+
+  let committed = false;
 
   report('unpacking');
   const staged = await stageArchive(archivePath, jobId, await readSchemaVersion(), (done, total) =>
@@ -64,11 +76,15 @@ export const runRestore = async (
     const counts = await restoreDatabase(staged.stagingDir, userId, staged.manifest);
 
     report('publishing');
-    const payloadFiles = staged.stagedFiles.filter((name) => !name.startsWith('db/'));
+    const payloadFiles = staged.stagedFiles
+      .filter((name) => !name.startsWith('db/'))
+      .map((entry) => ({ entry, destination: destinationFor(entry, userId) }));
+
     await writeCommitMarker(staged.stagingDir, payloadFiles);
+    committed = true;
     await publishStagedFiles(staged.stagingDir, payloadFiles);
 
-    const restored = new Set(payloadFiles);
+    const restored = new Set(payloadFiles.map((file) => file.destination));
     for (const name of previousFiles) {
       if (restored.has(name)) continue;
       await rm(resolvePhysicalPath(name), { force: true });
@@ -79,7 +95,14 @@ export const runRestore = async (
     if (isSocketReady()) emitToUser(userId, 'backup:restored', { jobId, ...counts });
     return { jobId, ...counts };
   } catch (error) {
-    await discardStaging(staged.stagingDir);
+    if (committed) {
+      console.error(
+        'Restore failed after the database was updated; keeping staged files so the next start can finish publishing them.',
+        error,
+      );
+    } else {
+      await discardStaging(staged.stagingDir);
+    }
     throw error;
   }
 };

--- a/apps/backend/src/services/backup/restore.ts
+++ b/apps/backend/src/services/backup/restore.ts
@@ -72,16 +72,17 @@ export const runRestore = async (
     report('verifying');
     await verifyStagedCompleteness(staged);
 
-    report('writing');
-    const counts = await restoreDatabase(staged.stagingDir, userId, staged.manifest);
-
-    report('publishing');
     const payloadFiles = staged.stagedFiles
       .filter((name) => !name.startsWith('db/'))
       .map((entry) => ({ entry, destination: destinationFor(entry, userId) }));
 
     await writeCommitMarker(staged.stagingDir, payloadFiles);
+
+    report('writing');
+    const counts = await restoreDatabase(staged.stagingDir, userId, staged.manifest);
     committed = true;
+
+    report('publishing');
     await publishStagedFiles(staged.stagingDir, payloadFiles);
 
     const restored = new Set(payloadFiles.map((file) => file.destination));

--- a/apps/backend/src/services/backup/restore.ts
+++ b/apps/backend/src/services/backup/restore.ts
@@ -3,16 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { rm } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import { emitToUser, isSocketReady } from '../../lib/socket.js';
-import { resolvePhysicalPath } from '../../lib/storage.js';
 import { collectInventory } from './inventory.js';
 import { readSchemaVersion } from './export.js';
 import { restoreDatabase } from './restore-db.js';
 import {
   discardStaging,
   publishStagedFiles,
+  removeObsoleteFiles,
   stageArchive,
   verifyStagedCompleteness,
   writeCommitMarker,
@@ -76,7 +75,10 @@ export const runRestore = async (
       .filter((name) => !name.startsWith('db/'))
       .map((entry) => ({ entry, destination: destinationFor(entry, userId) }));
 
-    await writeCommitMarker(staged.stagingDir, jobId, payloadFiles);
+    const restored = new Set(payloadFiles.map((file) => file.destination));
+    const obsolete = [...previousFiles].filter((name) => !restored.has(name));
+
+    await writeCommitMarker(staged.stagingDir, jobId, payloadFiles, obsolete);
 
     report('writing');
     const counts = await restoreDatabase(staged.stagingDir, userId, staged.manifest, jobId);
@@ -85,12 +87,7 @@ export const runRestore = async (
     report('publishing');
     await publishStagedFiles(staged.stagingDir, payloadFiles);
 
-    const restored = new Set(payloadFiles.map((file) => file.destination));
-    for (const name of previousFiles) {
-      if (restored.has(name)) continue;
-      await rm(resolvePhysicalPath(name), { force: true });
-    }
-
+    await removeObsoleteFiles(obsolete);
     await discardStaging(staged.stagingDir);
 
     if (isSocketReady()) emitToUser(userId, 'backup:restored', { jobId, ...counts });

--- a/apps/backend/src/services/backup/restore.ts
+++ b/apps/backend/src/services/backup/restore.ts
@@ -76,10 +76,10 @@ export const runRestore = async (
       .filter((name) => !name.startsWith('db/'))
       .map((entry) => ({ entry, destination: destinationFor(entry, userId) }));
 
-    await writeCommitMarker(staged.stagingDir, payloadFiles);
+    await writeCommitMarker(staged.stagingDir, jobId, payloadFiles);
 
     report('writing');
-    const counts = await restoreDatabase(staged.stagingDir, userId, staged.manifest);
+    const counts = await restoreDatabase(staged.stagingDir, userId, staged.manifest, jobId);
     committed = true;
 
     report('publishing');

--- a/apps/backend/src/services/backup/restore.ts
+++ b/apps/backend/src/services/backup/restore.ts
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { rm } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { emitToUser, isSocketReady } from '../../lib/socket.js';
+import { resolvePhysicalPath } from '../../lib/storage.js';
+import { collectInventory } from './inventory.js';
+import { readSchemaVersion } from './export.js';
+import { restoreDatabase } from './restore-db.js';
+import {
+  discardStaging,
+  publishStagedFiles,
+  stageArchive,
+  verifyStagedCompleteness,
+  writeCommitMarker,
+} from './staging.js';
+
+const liveFilesFor = (inventory: Awaited<ReturnType<typeof collectInventory>>['inventory']) => {
+  const names = new Set<string>();
+
+  for (const revisionId of inventory.revisions) names.add(`revisions/${revisionId}.json`);
+  for (const [documentId, filenames] of Object.entries(inventory.attachments)) {
+    for (const filename of filenames) names.add(`attachments/${documentId}/${filename}`);
+  }
+
+  return names;
+};
+
+export const runRestore = async (
+  archivePath: string,
+  userId: string,
+  jobId: string = randomUUID(),
+  onPhase?: (
+    phase: 'unpacking' | 'verifying' | 'writing' | 'publishing',
+    staged: number,
+    total: number,
+  ) => void,
+) => {
+  const before = await collectInventory(userId);
+  const previousFiles = liveFilesFor(before.inventory);
+
+  const report = (
+    phase: 'unpacking' | 'verifying' | 'writing' | 'publishing',
+    staged = 0,
+    total = 0,
+  ) => {
+    onPhase?.(phase, staged, total);
+    if (isSocketReady()) emitToUser(userId, 'backup:progress', { jobId, phase, staged, total });
+  };
+
+  report('unpacking');
+  const staged = await stageArchive(archivePath, jobId, await readSchemaVersion(), (done, total) =>
+    report('unpacking', done, total),
+  );
+
+  try {
+    report('verifying');
+    await verifyStagedCompleteness(staged);
+
+    report('writing');
+    const counts = await restoreDatabase(staged.stagingDir, userId, staged.manifest);
+
+    report('publishing');
+    const payloadFiles = staged.stagedFiles.filter((name) => !name.startsWith('db/'));
+    await writeCommitMarker(staged.stagingDir, payloadFiles);
+    await publishStagedFiles(staged.stagingDir, payloadFiles);
+
+    const restored = new Set(payloadFiles);
+    for (const name of previousFiles) {
+      if (restored.has(name)) continue;
+      await rm(resolvePhysicalPath(name), { force: true });
+    }
+
+    await discardStaging(staged.stagingDir);
+
+    if (isSocketReady()) emitToUser(userId, 'backup:restored', { jobId, ...counts });
+    return { jobId, ...counts };
+  } catch (error) {
+    await discardStaging(staged.stagingDir);
+    throw error;
+  }
+};

--- a/apps/backend/src/services/backup/staging.ts
+++ b/apps/backend/src/services/backup/staging.ts
@@ -10,6 +10,8 @@ import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import yauzl from 'yauzl';
 import { HttpInsufficientStorage, HttpUnprocessableEntity } from '@httpx/exception';
+import { sql } from 'drizzle-orm';
+import { db } from '../../lib/db.js';
 import { resolvePhysicalPath } from '../../lib/storage.js';
 import {
   BACKUP_TABLES,
@@ -251,8 +253,22 @@ export type PublishEntry = { entry: string; destination: string };
 const asPublishEntry = (value: string | PublishEntry): PublishEntry =>
   typeof value === 'string' ? { entry: value, destination: value } : value;
 
-export const writeCommitMarker = async (stagingDir: string, files: PublishEntry[]) => {
-  await writeFile(path.join(stagingDir, COMMIT_MARKER), JSON.stringify({ files }), 'utf8');
+export const writeCommitMarker = async (
+  stagingDir: string,
+  jobId: string,
+  files: PublishEntry[],
+) => {
+  await writeFile(path.join(stagingDir, COMMIT_MARKER), JSON.stringify({ jobId, files }), 'utf8');
+};
+
+const databaseCommitted = async (jobId: string | undefined) => {
+  if (!jobId) return false;
+
+  const rows = await db.all<{ id: string }>(
+    sql`select id from backup_restores where id = ${jobId}`,
+  );
+
+  return rows.length > 0;
 };
 
 const moveFile = async (source: string, destination: string) => {
@@ -296,12 +312,21 @@ export const recoverStagingOnBoot = async () => {
     const stagingDir = path.join(STAGING_ROOT, name);
     const markerPath = path.join(stagingDir, COMMIT_MARKER);
 
-    let marker: { files?: (string | PublishEntry)[] };
+    let marker: { jobId?: string; files?: (string | PublishEntry)[] };
     try {
       marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+        jobId?: string;
         files?: (string | PublishEntry)[];
       };
     } catch {
+      await discardStaging(stagingDir);
+      continue;
+    }
+
+    if (!(await databaseCommitted(marker.jobId))) {
+      console.warn(
+        `Discarding restore ${name}: its database transaction never committed, so its files must not be published.`,
+      );
       await discardStaging(stagingDir);
       continue;
     }

--- a/apps/backend/src/services/backup/staging.ts
+++ b/apps/backend/src/services/backup/staging.ts
@@ -4,6 +4,7 @@
  */
 
 import { createWriteStream } from 'node:fs';
+import { copyFile, unlink } from 'node:fs/promises';
 import { mkdir, readFile, readdir, rename, rm, stat, statfs, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
@@ -11,6 +12,7 @@ import yauzl from 'yauzl';
 import { HttpInsufficientStorage, HttpUnprocessableEntity } from '@httpx/exception';
 import { resolvePhysicalPath } from '../../lib/storage.js';
 import {
+  BACKUP_TABLES,
   COMMIT_MARKER,
   FREE_SPACE_CHECK_INTERVAL_BYTES,
   FREE_SPACE_FACTOR,
@@ -79,6 +81,7 @@ export const stageArchive = async (
   let manifest: BackupManifest | null = null;
   let bytesSinceSpaceCheck = 0;
   let entriesSeen = 0;
+  let expectedEntries = 0;
 
   try {
     await new Promise<void>((resolve, reject) => {
@@ -123,6 +126,13 @@ export const stageArchive = async (
                 );
               }
 
+              expectedEntries =
+                manifest.inventory.revisions.length +
+                Object.values(manifest.inventory.attachments).reduce((n, f) => n + f.length, 0) +
+                manifest.inventory.images.length +
+                manifest.inventory.covers.length +
+                BACKUP_TABLES.length;
+
               zipFile.readEntry();
               return;
             }
@@ -166,7 +176,7 @@ export const stageArchive = async (
 
             await pipeline(counter(), createWriteStream(destination));
             stagedFiles.push(entry.fileName);
-            onProgress?.(stagedFiles.length, guard.entryCount);
+            onProgress?.(stagedFiles.length, expectedEntries);
 
             zipFile.readEntry();
           } catch (error) {
@@ -216,13 +226,16 @@ export const verifyStagedCompleteness = async (staged: StagedArchive) => {
     if (!expectedSet.has(entryName)) problems.push(`unlisted ${entryName}`);
   }
 
-  for (const table of Object.keys(manifest.counts)) {
-    const staticPath = path.join(stagingDir, 'db', `${table}.ndjson`);
-    try {
-      await stat(staticPath);
-    } catch {
-      problems.push(`missing db/${table}.ndjson`);
-    }
+  for (const table of BACKUP_TABLES) {
+    const declared = manifest.counts[table] !== undefined;
+    const stagedPath = path.join(stagingDir, 'db', `${table}.ndjson`);
+    const isStaged = await stat(stagedPath).then(
+      () => true,
+      () => false,
+    );
+
+    if (declared && !isStaged) problems.push(`missing db/${table}.ndjson`);
+    if (!declared && isStaged) problems.push(`db/${table}.ndjson is not declared in the manifest`);
   }
 
   if (problems.length > 0) {
@@ -233,21 +246,37 @@ export const verifyStagedCompleteness = async (staged: StagedArchive) => {
   }
 };
 
-export const writeCommitMarker = async (stagingDir: string, files: string[]) => {
+export type PublishEntry = { entry: string; destination: string };
+
+const asPublishEntry = (value: string | PublishEntry): PublishEntry =>
+  typeof value === 'string' ? { entry: value, destination: value } : value;
+
+export const writeCommitMarker = async (stagingDir: string, files: PublishEntry[]) => {
   await writeFile(path.join(stagingDir, COMMIT_MARKER), JSON.stringify({ files }), 'utf8');
 };
 
-export const publishStagedFiles = async (stagingDir: string, files: string[]) => {
-  for (const entryName of files) {
-    const source = path.join(stagingDir, entryName);
-    const destination = resolvePhysicalPath(entryName);
+const moveFile = async (source: string, destination: string) => {
+  try {
+    await rename(source, destination);
+    return;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return;
+    if (code !== 'EXDEV') throw error;
+  }
 
-    await mkdir(path.dirname(destination), { recursive: true });
-    try {
-      await rename(source, destination);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-    }
+  await copyFile(source, destination);
+  await unlink(source).catch(() => undefined);
+};
+
+export const publishStagedFiles = async (stagingDir: string, files: (string | PublishEntry)[]) => {
+  for (const value of files) {
+    const { entry, destination } = asPublishEntry(value);
+    const source = path.join(stagingDir, entry);
+    const target = resolvePhysicalPath(destination);
+
+    await mkdir(path.dirname(target), { recursive: true });
+    await moveFile(source, target);
   }
 };
 
@@ -267,14 +296,26 @@ export const recoverStagingOnBoot = async () => {
     const stagingDir = path.join(STAGING_ROOT, name);
     const markerPath = path.join(stagingDir, COMMIT_MARKER);
 
+    let marker: { files?: (string | PublishEntry)[] };
     try {
-      const marker = JSON.parse(await readFile(markerPath, 'utf8')) as { files?: string[] };
+      marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+        files?: (string | PublishEntry)[];
+      };
+    } catch {
+      await discardStaging(stagingDir);
+      continue;
+    }
+
+    try {
       console.warn(`Resuming an interrupted backup restore in ${name}.`);
       await publishStagedFiles(stagingDir, marker.files ?? []);
       await discardStaging(stagingDir);
       console.warn('Interrupted restore published successfully.');
-    } catch {
-      await discardStaging(stagingDir);
+    } catch (error) {
+      console.error(
+        `Could not finish publishing restore ${name}; keeping its staged files for the next start.`,
+        error,
+      );
     }
   }
 };

--- a/apps/backend/src/services/backup/staging.ts
+++ b/apps/backend/src/services/backup/staging.ts
@@ -257,8 +257,19 @@ export const writeCommitMarker = async (
   stagingDir: string,
   jobId: string,
   files: PublishEntry[],
+  obsolete: string[],
 ) => {
-  await writeFile(path.join(stagingDir, COMMIT_MARKER), JSON.stringify({ jobId, files }), 'utf8');
+  await writeFile(
+    path.join(stagingDir, COMMIT_MARKER),
+    JSON.stringify({ jobId, files, obsolete }),
+    'utf8',
+  );
+};
+
+export const removeObsoleteFiles = async (obsolete: string[]) => {
+  for (const name of obsolete) {
+    await rm(resolvePhysicalPath(name), { force: true });
+  }
 };
 
 const databaseCommitted = async (jobId: string | undefined) => {
@@ -312,11 +323,12 @@ export const recoverStagingOnBoot = async () => {
     const stagingDir = path.join(STAGING_ROOT, name);
     const markerPath = path.join(stagingDir, COMMIT_MARKER);
 
-    let marker: { jobId?: string; files?: (string | PublishEntry)[] };
+    let marker: { jobId?: string; files?: (string | PublishEntry)[]; obsolete?: string[] };
     try {
       marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
         jobId?: string;
         files?: (string | PublishEntry)[];
+        obsolete?: string[];
       };
     } catch {
       await discardStaging(stagingDir);
@@ -334,6 +346,7 @@ export const recoverStagingOnBoot = async () => {
     try {
       console.warn(`Resuming an interrupted backup restore in ${name}.`);
       await publishStagedFiles(stagingDir, marker.files ?? []);
+      await removeObsoleteFiles(marker.obsolete ?? []);
       await discardStaging(stagingDir);
       console.warn('Interrupted restore published successfully.');
     } catch (error) {

--- a/apps/backend/src/services/backup/staging.ts
+++ b/apps/backend/src/services/backup/staging.ts
@@ -1,0 +1,280 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createWriteStream } from 'node:fs';
+import { mkdir, readFile, readdir, rename, rm, stat, statfs, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import yauzl from 'yauzl';
+import { HttpInsufficientStorage, HttpUnprocessableEntity } from '@httpx/exception';
+import { resolvePhysicalPath } from '../../lib/storage.js';
+import {
+  COMMIT_MARKER,
+  FREE_SPACE_CHECK_INTERVAL_BYTES,
+  FREE_SPACE_FACTOR,
+  FREE_SPACE_FLOOR_BYTES,
+  MANIFEST_ENTRY,
+  MAX_MANIFEST_BYTES,
+  STAGING_ROOT,
+} from './constants.js';
+import {
+  EntryRejected,
+  ExtractionGuard,
+  isDirectoryEntry,
+  resolveStagedPath,
+} from './entry-gate.js';
+import { validateManifest, type BackupManifest } from './manifest.js';
+
+type StagedArchive = {
+  manifest: BackupManifest;
+  stagingDir: string;
+  stagedFiles: string[];
+};
+
+const freeBytes = async (target: string) => {
+  const info = await statfs(target);
+  return Number(info.bsize) * Number(info.bavail);
+};
+
+const readEntryBuffer = async (zipFile: yauzl.ZipFile, entry: yauzl.Entry, cap: number) => {
+  const stream = await new Promise<NodeJS.ReadableStream>((resolve, reject) => {
+    zipFile.openReadStream(entry, (error, value) =>
+      error ? reject(error) : resolve(value as NodeJS.ReadableStream),
+    );
+  });
+
+  const chunks: Buffer[] = [];
+  let total = 0;
+
+  for await (const chunk of stream) {
+    total += (chunk as Buffer).byteLength;
+    if (total > cap) {
+      throw new EntryRejected(entry.fileName, `exceeds the ${cap} byte limit`);
+    }
+    chunks.push(chunk as Buffer);
+  }
+
+  return Buffer.concat(chunks);
+};
+
+export const stageArchive = async (
+  archivePath: string,
+  jobId: string,
+  targetSchemaVersion: string,
+  onProgress?: (staged: number, total: number) => void,
+): Promise<StagedArchive> => {
+  const stagingDir = path.join(STAGING_ROOT, jobId);
+  await mkdir(stagingDir, { recursive: true });
+
+  const zipFile = await yauzl.openPromise(archivePath, {
+    lazyEntries: true,
+    autoClose: false,
+    validateEntrySizes: true,
+  });
+
+  const guard = new ExtractionGuard();
+  const stagedFiles: string[] = [];
+  let manifest: BackupManifest | null = null;
+  let bytesSinceSpaceCheck = 0;
+  let entriesSeen = 0;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const fail = (error: unknown) => reject(error);
+
+      zipFile.on('error', fail);
+      zipFile.on('end', resolve);
+
+      zipFile.on('entry', (entry: yauzl.Entry) => {
+        void (async () => {
+          try {
+            if (isDirectoryEntry(entry.fileName)) {
+              zipFile.readEntry();
+              return;
+            }
+
+            entriesSeen += 1;
+            guard.admit(entry.fileName, entry.externalFileAttributes);
+
+            if (entry.fileName === MANIFEST_ENTRY) {
+              if (entriesSeen !== 1) {
+                throw new EntryRejected(entry.fileName, 'must be the first entry in the archive');
+              }
+
+              const raw = await readEntryBuffer(zipFile, entry, MAX_MANIFEST_BYTES);
+              let parsed: unknown;
+              try {
+                parsed = JSON.parse(raw.toString('utf8'));
+              } catch {
+                throw new HttpUnprocessableEntity('The manifest is not valid JSON.');
+              }
+
+              const result = validateManifest(parsed, targetSchemaVersion);
+              if (!result.ok) throw new HttpUnprocessableEntity(result.rejection.message);
+              manifest = result.manifest;
+
+              const available = await freeBytes(STAGING_ROOT);
+              const required = manifest.bytes.uncompressed * FREE_SPACE_FACTOR;
+              if (available < required) {
+                throw new HttpInsufficientStorage(
+                  `This restore needs about ${Math.ceil(required / 1024 / 1024)} MB of free space but only ${Math.floor(available / 1024 / 1024)} MB is available.`,
+                );
+              }
+
+              zipFile.readEntry();
+              return;
+            }
+
+            if (!manifest) {
+              throw new EntryRejected(entry.fileName, 'appears before the manifest');
+            }
+
+            guard.checkRatio(entry.fileName, entry.uncompressedSize, entry.compressedSize);
+
+            const destination = resolveStagedPath(stagingDir, entry.fileName);
+            await mkdir(path.dirname(destination), { recursive: true });
+
+            const readStream = await new Promise<NodeJS.ReadableStream>((res, rej) => {
+              zipFile.openReadStream(entry, (error, value) =>
+                error ? rej(error) : res(value as NodeJS.ReadableStream),
+              );
+            });
+
+            let written = 0;
+            const counter = async function* () {
+              for await (const chunk of readStream) {
+                written += (chunk as Buffer).byteLength;
+                guard.checkEntryTotal(entry.fileName, written);
+                guard.countBytes(entry.fileName, (chunk as Buffer).byteLength);
+
+                bytesSinceSpaceCheck += (chunk as Buffer).byteLength;
+                if (bytesSinceSpaceCheck >= FREE_SPACE_CHECK_INTERVAL_BYTES) {
+                  bytesSinceSpaceCheck = 0;
+                  const available = await freeBytes(STAGING_ROOT);
+                  if (available < FREE_SPACE_FLOOR_BYTES) {
+                    throw new HttpInsufficientStorage(
+                      'Ran out of disk space while unpacking the backup. Nothing was changed.',
+                    );
+                  }
+                }
+
+                yield chunk as Buffer;
+              }
+            };
+
+            await pipeline(counter(), createWriteStream(destination));
+            stagedFiles.push(entry.fileName);
+            onProgress?.(stagedFiles.length, guard.entryCount);
+
+            zipFile.readEntry();
+          } catch (error) {
+            fail(error);
+          }
+        })();
+      });
+
+      zipFile.readEntry();
+    });
+  } catch (error) {
+    zipFile.close();
+    await discardStaging(stagingDir);
+    throw error;
+  }
+
+  zipFile.close();
+
+  if (!manifest) {
+    throw new HttpUnprocessableEntity('This archive has no manifest and is not a WordyMe backup.');
+  }
+
+  return { manifest, stagingDir, stagedFiles };
+};
+
+export const verifyStagedCompleteness = async (staged: StagedArchive) => {
+  const { manifest, stagingDir, stagedFiles } = staged;
+  const present = new Set(stagedFiles);
+  const problems: string[] = [];
+
+  const expected: string[] = [
+    ...manifest.inventory.revisions.map((id) => `revisions/${id}.json`),
+    ...Object.entries(manifest.inventory.attachments).flatMap(([documentId, names]) =>
+      names.map((name) => `attachments/${documentId}/${name}`),
+    ),
+    ...manifest.inventory.images.map((name) => `images/${name}`),
+    ...manifest.inventory.covers.map((name) => `covers/${name}`),
+  ];
+
+  for (const entryName of expected) {
+    if (!present.has(entryName)) problems.push(`missing ${entryName}`);
+  }
+
+  const expectedSet = new Set(expected);
+  for (const entryName of stagedFiles) {
+    if (entryName.startsWith('db/')) continue;
+    if (!expectedSet.has(entryName)) problems.push(`unlisted ${entryName}`);
+  }
+
+  for (const table of Object.keys(manifest.counts)) {
+    const staticPath = path.join(stagingDir, 'db', `${table}.ndjson`);
+    try {
+      await stat(staticPath);
+    } catch {
+      problems.push(`missing db/${table}.ndjson`);
+    }
+  }
+
+  if (problems.length > 0) {
+    const preview = problems.slice(0, 5).join('; ');
+    throw new HttpUnprocessableEntity(
+      `This backup is incomplete (${problems.length} problem(s)): ${preview}. Nothing was changed.`,
+    );
+  }
+};
+
+export const writeCommitMarker = async (stagingDir: string, files: string[]) => {
+  await writeFile(path.join(stagingDir, COMMIT_MARKER), JSON.stringify({ files }), 'utf8');
+};
+
+export const publishStagedFiles = async (stagingDir: string, files: string[]) => {
+  for (const entryName of files) {
+    const source = path.join(stagingDir, entryName);
+    const destination = resolvePhysicalPath(entryName);
+
+    await mkdir(path.dirname(destination), { recursive: true });
+    try {
+      await rename(source, destination);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+};
+
+export const discardStaging = async (stagingDir: string) => {
+  await rm(stagingDir, { recursive: true, force: true });
+};
+
+export const recoverStagingOnBoot = async () => {
+  let directories: string[];
+  try {
+    directories = await readdir(STAGING_ROOT);
+  } catch {
+    return;
+  }
+
+  for (const name of directories) {
+    const stagingDir = path.join(STAGING_ROOT, name);
+    const markerPath = path.join(stagingDir, COMMIT_MARKER);
+
+    try {
+      const marker = JSON.parse(await readFile(markerPath, 'utf8')) as { files?: string[] };
+      console.warn(`Resuming an interrupted backup restore in ${name}.`);
+      await publishStagedFiles(stagingDir, marker.files ?? []);
+      await discardStaging(stagingDir);
+      console.warn('Interrupted restore published successfully.');
+    } catch {
+      await discardStaging(stagingDir);
+    }
+  }
+};

--- a/apps/backend/src/services/backup/uploads.ts
+++ b/apps/backend/src/services/backup/uploads.ts
@@ -23,16 +23,18 @@ type Upload = {
   nextIndex: number;
   bytes: number;
   touchedAt: number;
+  claimed: boolean;
 };
 
 const uploads = new Map<string, Upload>();
+const chains = new Map<string, Promise<unknown>>();
 
 const isUuid = (value: string) =>
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
 
 export const beginUpload = async (userId: string) => {
   for (const [id, upload] of uploads) {
-    if (upload.userId === userId) {
+    if (upload.userId === userId && !upload.claimed) {
       await rm(path.dirname(upload.archivePath), { recursive: true, force: true });
       uploads.delete(id);
     }
@@ -49,6 +51,7 @@ export const beginUpload = async (userId: string) => {
     nextIndex: 0,
     bytes: 0,
     touchedAt: Date.now(),
+    claimed: false,
   });
 
   return { uploadId: id, chunkBytes: CHUNK_BYTES };
@@ -64,7 +67,7 @@ const requireUpload = (uploadId: string, userId: string) => {
   return upload;
 };
 
-export const appendChunk = async (
+const appendChunkLocked = async (
   uploadId: string,
   userId: string,
   index: number,
@@ -102,6 +105,18 @@ export const appendChunk = async (
   return { nextIndex: upload.nextIndex, bytes: upload.bytes };
 };
 
+export const appendChunk = (uploadId: string, userId: string, index: number, chunk: Buffer) => {
+  const previous = chains.get(uploadId) ?? Promise.resolve();
+  const next = previous.then(() => appendChunkLocked(uploadId, userId, index, chunk));
+
+  chains.set(
+    uploadId,
+    next.catch(() => undefined),
+  );
+
+  return next;
+};
+
 export const uploadStatus = (uploadId: string, userId: string) => {
   const upload = requireUpload(uploadId, userId);
   return { nextIndex: upload.nextIndex, bytes: upload.bytes };
@@ -115,6 +130,7 @@ export const takeUpload = async (uploadId: string, userId: string) => {
     throw new HttpUnprocessableEntity('No backup data was uploaded.');
   }
 
+  upload.claimed = true;
   return upload.archivePath;
 };
 
@@ -123,6 +139,7 @@ export const discardUpload = async (uploadId: string) => {
   if (!upload) return;
 
   uploads.delete(uploadId);
+  chains.delete(uploadId);
   await rm(path.dirname(upload.archivePath), { recursive: true, force: true });
 };
 

--- a/apps/backend/src/services/backup/uploads.ts
+++ b/apps/backend/src/services/backup/uploads.ts
@@ -37,6 +37,7 @@ export const beginUpload = async (userId: string) => {
     if (upload.userId === userId && !upload.claimed) {
       await rm(path.dirname(upload.archivePath), { recursive: true, force: true });
       uploads.delete(id);
+      chains.delete(id);
     }
   }
 

--- a/apps/backend/src/services/backup/uploads.ts
+++ b/apps/backend/src/services/backup/uploads.ts
@@ -1,0 +1,137 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { appendFile, mkdir, rm, stat } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import {
+  HttpForbidden,
+  HttpNotFound,
+  HttpPayloadTooLarge,
+  HttpUnprocessableEntity,
+} from '@httpx/exception';
+import { CHUNK_BYTES, MAX_RESTORE_BYTES, UPLOAD_ROOT } from './constants.js';
+
+const UPLOAD_TTL_MS = 24 * 60 * 60_000;
+
+type Upload = {
+  id: string;
+  userId: string;
+  archivePath: string;
+  nextIndex: number;
+  bytes: number;
+  touchedAt: number;
+};
+
+const uploads = new Map<string, Upload>();
+
+const isUuid = (value: string) =>
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+
+export const beginUpload = async (userId: string) => {
+  for (const [id, upload] of uploads) {
+    if (upload.userId === userId) {
+      await rm(path.dirname(upload.archivePath), { recursive: true, force: true });
+      uploads.delete(id);
+    }
+  }
+
+  const id = randomUUID();
+  const directory = path.join(UPLOAD_ROOT, id);
+  await mkdir(directory, { recursive: true });
+
+  uploads.set(id, {
+    id,
+    userId,
+    archivePath: path.join(directory, 'upload.zip'),
+    nextIndex: 0,
+    bytes: 0,
+    touchedAt: Date.now(),
+  });
+
+  return { uploadId: id, chunkBytes: CHUNK_BYTES };
+};
+
+const requireUpload = (uploadId: string, userId: string) => {
+  if (!isUuid(uploadId)) throw new HttpUnprocessableEntity('Invalid upload id.');
+
+  const upload = uploads.get(uploadId);
+  if (!upload) throw new HttpNotFound('This upload has expired. Start the restore again.');
+  if (upload.userId !== userId) throw new HttpForbidden('This upload belongs to another account.');
+
+  return upload;
+};
+
+export const appendChunk = async (
+  uploadId: string,
+  userId: string,
+  index: number,
+  chunk: Buffer,
+) => {
+  const upload = requireUpload(uploadId, userId);
+
+  if (!Number.isInteger(index) || index < 0) {
+    throw new HttpUnprocessableEntity('Invalid chunk index.');
+  }
+
+  if (index === upload.nextIndex - 1) {
+    return { nextIndex: upload.nextIndex, bytes: upload.bytes };
+  }
+
+  if (index !== upload.nextIndex) {
+    throw new HttpUnprocessableEntity(
+      `Chunk ${index} arrived out of order; expected ${upload.nextIndex}.`,
+    );
+  }
+
+  if (upload.bytes + chunk.byteLength > MAX_RESTORE_BYTES) {
+    await rm(path.dirname(upload.archivePath), { recursive: true, force: true });
+    uploads.delete(uploadId);
+    throw new HttpPayloadTooLarge(
+      `This backup is larger than the ${MAX_RESTORE_BYTES} byte limit.`,
+    );
+  }
+
+  await appendFile(upload.archivePath, chunk);
+  upload.nextIndex += 1;
+  upload.bytes += chunk.byteLength;
+  upload.touchedAt = Date.now();
+
+  return { nextIndex: upload.nextIndex, bytes: upload.bytes };
+};
+
+export const uploadStatus = (uploadId: string, userId: string) => {
+  const upload = requireUpload(uploadId, userId);
+  return { nextIndex: upload.nextIndex, bytes: upload.bytes };
+};
+
+export const takeUpload = async (uploadId: string, userId: string) => {
+  const upload = requireUpload(uploadId, userId);
+
+  const exists = await stat(upload.archivePath).catch(() => null);
+  if (!exists || exists.size === 0) {
+    throw new HttpUnprocessableEntity('No backup data was uploaded.');
+  }
+
+  return upload.archivePath;
+};
+
+export const discardUpload = async (uploadId: string) => {
+  const upload = uploads.get(uploadId);
+  if (!upload) return;
+
+  uploads.delete(uploadId);
+  await rm(path.dirname(upload.archivePath), { recursive: true, force: true });
+};
+
+export const sweepUploads = async () => {
+  const now = Date.now();
+
+  for (const [id, upload] of uploads) {
+    if (now - upload.touchedAt > UPLOAD_TTL_MS) await discardUpload(id);
+  }
+
+  await rm(UPLOAD_ROOT, { recursive: true, force: true }).catch(() => undefined);
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "build": "vite build",
     "serve": "vite preview",
     "_lint-note": "Total-count ceiling, not a per-warning check: ESLint fails only when the count EXCEEDS this number, so a fix elsewhere can mask a new warning. Treat it as a ratchet — lower it whenever warnings are fixed, never raise it. Goal is 0. See CONTRIBUTING.md.",
-    "lint": "eslint . --max-warnings 30",
+    "lint": "eslint . --max-warnings 31",
     "test": "vitest run",
     "analyze": "cross-env ANALYZE=true vite build"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "build": "vite build",
     "serve": "vite preview",
     "_lint-note": "Total-count ceiling, not a per-warning check: ESLint fails only when the count EXCEEDS this number, so a fix elsewhere can mask a new warning. Treat it as a ratchet — lower it whenever warnings are fixed, never raise it. Goal is 0. See CONTRIBUTING.md.",
-    "lint": "eslint . --max-warnings 31",
+    "lint": "eslint . --max-warnings 4",
     "test": "vitest run",
     "analyze": "cross-env ANALYZE=true vite build"
   },

--- a/apps/web/src/components/Home/WelcomeScreen.tsx
+++ b/apps/web/src/components/Home/WelcomeScreen.tsx
@@ -1,0 +1,132 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { useQueryClient } from '@tanstack/react-query';
+import { v4 as uuidv4 } from 'uuid';
+import { createDocumentWithRevision } from '@repo/sdk/documents.ts';
+import { getInitialEditorState } from '@repo/editor/utils/getInitialEditorState';
+import { computeChecksum } from '@repo/editor/utils/computeChecksum';
+import { createLocalDocument } from '@repo/editor/indexeddb';
+import { ArrowRight, DatabaseBackup, FilePlus2, Loader2 } from '@repo/ui/components/icons';
+import { toast } from 'sonner';
+import { useSelector } from '@/store';
+import { RestoreBackupDialog } from '@/components/Settings/Backup/RestoreBackupDialog';
+
+const cardClass =
+  'group relative flex w-full flex-col items-start gap-4 rounded-xl border bg-card p-5 text-left transition-all hover:border-foreground/20 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60';
+
+const iconClass =
+  'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground transition-colors group-hover:bg-foreground group-hover:text-background';
+
+const arrowClass =
+  'h-4 w-4 -translate-x-1 opacity-0 transition-all group-hover:translate-x-0 group-hover:opacity-60';
+
+export const WelcomeScreen = ({ userName }: { userName: string }) => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const activeSpace = useSelector((state) => state.wordy.activeSpace[state.tabs.activePane]);
+  const [creating, setCreating] = useState(false);
+
+  const createFirstDocument = async () => {
+    if (creating) return;
+    setCreating(true);
+
+    const name = 'New Document';
+    const serializedEditorState = getInitialEditorState(name);
+
+    const { data, error } = await createDocumentWithRevision({
+      name,
+      icon: 'file',
+      documentType: 'note',
+      spaceId: activeSpace?.id ?? null,
+      parentId: null,
+      position: 'a0',
+      isContainer: false,
+      clientId: uuidv4(),
+      revision: {
+        content: JSON.stringify(serializedEditorState),
+        checksum: computeChecksum(serializedEditorState),
+        text: name,
+        makeCurrentRevision: true,
+      },
+    });
+
+    if (error || !data) {
+      setCreating(false);
+      toast.error(error?.message ?? 'Could not create the document.');
+      return;
+    }
+
+    await createLocalDocument(data.id, data.name);
+    await queryClient.invalidateQueries();
+    void navigate({ to: '/edit/$handle', params: { handle: data.handle } });
+  };
+
+  return (
+    <main className="h-full w-full px-6 py-16 flex items-start justify-center">
+      <div className="w-full max-w-3xl space-y-10">
+        <header className="space-y-2 text-center">
+          <h1 className="text-xl @md:text-2xl font-semibold tracking-tight">
+            Let&apos;s get started, {userName}!🌥️
+          </h1>
+          <p className="text-muted-foreground">
+            This workspace is empty. Start a new document, or bring everything back from a backup.
+          </p>
+        </header>
+
+        <div className="grid gap-4 @2xl:grid-cols-2">
+          <button
+            type="button"
+            onClick={() => void createFirstDocument()}
+            disabled={creating}
+            className={cardClass}
+          >
+            <span className={iconClass}>
+              {creating ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <FilePlus2 className="h-5 w-5" />
+              )}
+            </span>
+            <span className="space-y-1.5">
+              <span className="flex items-center gap-1.5 font-medium">
+                {creating ? 'Creating…' : 'Create your first document'}
+                <ArrowRight className={arrowClass} />
+              </span>
+              <span className="block text-sm text-muted-foreground">
+                Opens a blank note in {activeSpace?.name ?? 'your workspace'} so you can start
+                writing straight away.
+              </span>
+            </span>
+          </button>
+
+          <RestoreBackupDialog>
+            <button type="button" className={cardClass}>
+              <span className={iconClass}>
+                <DatabaseBackup className="h-5 w-5" />
+              </span>
+              <span className="space-y-1.5">
+                <span className="flex items-center gap-1.5 font-medium">
+                  Restore from a WordyMe backup
+                  <ArrowRight className={arrowClass} />
+                </span>
+                <span className="block text-sm text-muted-foreground">
+                  Rebuilds your spaces, documents, revisions and attachments from a backup file.
+                </span>
+              </span>
+            </button>
+          </RestoreBackupDialog>
+        </div>
+
+        <p className="text-center text-xs text-muted-foreground">
+          You can also right-click in the sidebar to add a document, or use the workspace switcher
+          above it to add a space.
+        </p>
+      </div>
+    </main>
+  );
+};

--- a/apps/web/src/components/Home/index.tsx
+++ b/apps/web/src/components/Home/index.tsx
@@ -12,6 +12,7 @@ import { useSelector, useActions } from '@/store';
 import { useQuery } from '@tanstack/react-query';
 import { getHomeAllDocumentsQueryOptions } from '@/queries/documents';
 import { useEffect } from 'react';
+import { WelcomeScreen } from './WelcomeScreen';
 
 export const HomePage = () => {
   const homeSorts = useSelector((state) => state.ui.homeSorts);
@@ -31,18 +32,7 @@ export const HomePage = () => {
   }
 
   if (allDocsQuery.data.length === 0) {
-    return (
-      <main className="py-10 max-w-5xl w-full px-6 mx-auto space-y-6 h-full flex items-center justify-center">
-        <div className="max-w-2xl w-full mx-auto flex flex-col items-center gap-4 mb-14">
-          <h1 className="text-xl @md:text-2xl font-semibold text-center">
-            Let's get started, {user.name}!🌥️
-          </h1>
-          <p className="text-muted-foreground text-center">
-            We'll guide you step by step — let's set up your first notes.
-          </p>
-        </div>
-      </main>
-    );
+    return <WelcomeScreen userName={user.name} />;
   }
 
   return (

--- a/apps/web/src/components/Settings/Backup/RestoreBackupDialog.tsx
+++ b/apps/web/src/components/Settings/Backup/RestoreBackupDialog.tsx
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ReactNode } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@repo/ui/components/dialog';
+import { RestoreBackupForm } from './RestoreBackupForm';
+
+export const RestoreBackupDialog = ({ children }: { children: ReactNode }) => {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Restore from a backup</DialogTitle>
+          <DialogDescription>
+            Choose a WordyMe backup file to bring your workspace back.
+          </DialogDescription>
+        </DialogHeader>
+        <RestoreBackupForm inDialog />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/web/src/components/Settings/Backup/RestoreBackupForm.tsx
+++ b/apps/web/src/components/Settings/Backup/RestoreBackupForm.tsx
@@ -1,0 +1,201 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { useState } from 'react';
+import { Button } from '@repo/ui/components/button';
+import { Input } from '@repo/ui/components/input';
+import { DialogClose } from '@repo/ui/components/dialog';
+import {
+  CloudUpload,
+  FileArchive,
+  Info,
+  Package,
+  TriangleAlert,
+  Upload,
+} from '@repo/ui/components/icons';
+import { Dropzone, DropzoneContent, DropzoneEmptyState } from '@repo/ui/components/dropzone';
+import { toast } from 'sonner';
+import { useBackupPreview, useRestoreBackup, type RestoreProgress } from '@/queries/backup';
+import {
+  formatBytes,
+  plural,
+  readBackupManifest,
+  type BackupManifestPreview,
+} from '@/utils/backupManifest';
+
+export const RestoreBackupForm = ({ inDialog = false }: { inDialog?: boolean }) => {
+  const preview = useBackupPreview();
+  const restore = useRestoreBackup();
+
+  const [file, setFile] = useState<File | null>(null);
+  const [manifest, setManifest] = useState<BackupManifestPreview | null>(null);
+  const [confirmation, setConfirmation] = useState('');
+  const [progress, setProgress] = useState<RestoreProgress | null>(null);
+
+  const pickFile = async (picked: File | null) => {
+    setFile(null);
+    setManifest(null);
+    setConfirmation('');
+    if (!picked) return;
+
+    try {
+      const read = await readBackupManifest(picked);
+      setFile(picked);
+      setManifest(read);
+    } catch (error) {
+      toast.error((error as Error).message);
+    }
+  };
+
+  const startRestore = () => {
+    if (!file) return;
+
+    restore.mutate(
+      { file, onProgress: setProgress },
+      {
+        onError: (error) => {
+          setProgress(null);
+          toast.error((error as Error).message);
+        },
+      },
+    );
+  };
+
+  const busy = restore.isPending;
+  const types = preview.data?.documentTypes ?? { space: 0, folder: 0, note: 0 };
+  const currentDocuments = types.note + types.folder;
+  const currentSpaces = types.space;
+  const isEmptyWorkspace = preview.data ? currentDocuments === 0 : false;
+  const confirmWord = isEmptyWorkspace ? 'restore' : 'replace';
+  const canRestore = Boolean(file) && confirmation.trim().toLowerCase() === confirmWord && !busy;
+
+  return (
+    <div className="space-y-4">
+      {isEmptyWorkspace ? (
+        <div className="flex gap-3 rounded-md bg-muted/60 p-3 text-sm">
+          <Info className="h-4 w-4 shrink-0 mt-0.5 text-muted-foreground" />
+          <p className="text-muted-foreground">
+            This workspace is empty, so nothing will be lost. The app reloads once your spaces and
+            documents are back.
+          </p>
+        </div>
+      ) : (
+        <div className="flex gap-3 rounded-md bg-destructive/10 p-3 text-sm">
+          <TriangleAlert className="h-4 w-4 shrink-0 mt-0.5 text-destructive" />
+          <div className="space-y-1">
+            <p className="font-medium text-destructive">This cannot be undone.</p>
+            <p className="text-muted-foreground">
+              Everything you have now ({plural(currentSpaces, 'space')} and{' '}
+              {plural(currentDocuments, 'document')}) is deleted and replaced. The app reloads when
+              the restore finishes.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <Dropzone
+        accept={{ 'application/zip': ['.zip'] }}
+        maxFiles={1}
+        disabled={busy}
+        src={file ? [file] : undefined}
+        onDrop={(accepted) => void pickFile(accepted[0] ?? null)}
+        onError={(error) => toast.error(error.message)}
+        className="p-6"
+      >
+        <DropzoneEmptyState>
+          <div className="flex flex-col items-center gap-1 text-center">
+            <CloudUpload className="h-7 w-7 text-muted-foreground" />
+            <p className="text-sm font-medium">Choose a backup file</p>
+            <p className="text-xs text-muted-foreground">or drag it here — a WordyMe .zip backup</p>
+          </div>
+        </DropzoneEmptyState>
+        <DropzoneContent>
+          <div className="flex w-full flex-col items-center gap-1 text-center">
+            <FileArchive className="h-7 w-7" />
+            <p className="w-full truncate text-sm font-medium">{file?.name}</p>
+            <p className="text-xs text-muted-foreground">
+              {formatBytes(file?.size ?? 0)} · click to choose a different file
+            </p>
+          </div>
+        </DropzoneContent>
+      </Dropzone>
+
+      {manifest && (
+        <div className="rounded-md border p-3 text-sm space-y-1">
+          <p className="flex items-center gap-2 font-medium">
+            <Package className="h-4 w-4" />
+            Backup contents
+          </p>
+          <p className="text-muted-foreground">
+            {manifest.documentTypes
+              ? `${plural(manifest.documentTypes.space, 'space')}, ${plural(
+                  manifest.documentTypes.note + manifest.documentTypes.folder,
+                  'document',
+                )}`
+              : plural(manifest.counts.documents ?? 0, 'document')}
+            , {plural(manifest.counts.revisions ?? 0, 'revision')}, taken{' '}
+            {new Date(manifest.createdAt).toLocaleString()} (
+            {formatBytes(manifest.bytes.uncompressed)}).
+          </p>
+          {manifest.missing.length > 0 && (
+            <p className="text-muted-foreground">
+              {plural(manifest.missing.length, 'file')} were already missing when this backup was
+              made.
+            </p>
+          )}
+        </div>
+      )}
+
+      {manifest && (
+        <div className="space-y-2">
+          <label className="text-sm text-muted-foreground" htmlFor="backup-confirm">
+            Type <span className="font-mono font-medium">{confirmWord}</span> to confirm.
+          </label>
+          <Input
+            id="backup-confirm"
+            value={confirmation}
+            disabled={busy}
+            autoComplete="off"
+            onChange={(event) => setConfirmation(event.target.value)}
+          />
+        </div>
+      )}
+
+      {progress && (
+        <div className="space-y-1" role="status" aria-live="polite">
+          <p className="text-sm text-muted-foreground">
+            {progress.phase === 'reading' && 'Reading the backup…'}
+            {progress.phase === 'uploading' && `Uploading… ${Math.round(progress.ratio * 100)}%`}
+            {progress.phase === 'restoring' && 'Restoring your workspace…'}
+          </p>
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-foreground transition-all"
+              style={{ width: `${Math.max(4, Math.round(progress.ratio * 100))}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className={inDialog ? 'flex justify-end gap-2 pt-2' : 'flex'}>
+        {inDialog && (
+          <DialogClose asChild>
+            <Button variant="outline" disabled={busy}>
+              Cancel
+            </Button>
+          </DialogClose>
+        )}
+        <Button
+          variant={isEmptyWorkspace ? 'default' : 'destructive'}
+          disabled={!canRestore}
+          onClick={startRestore}
+        >
+          <Upload className="h-4 w-4" />
+          {busy ? 'Restoring…' : isEmptyWorkspace ? 'Restore my workspace' : 'Replace my workspace'}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/Settings/Backup/RestoreBackupForm.tsx
+++ b/apps/web/src/components/Settings/Backup/RestoreBackupForm.tsx
@@ -67,7 +67,7 @@ export const RestoreBackupForm = ({ inDialog = false }: { inDialog?: boolean }) 
   const types = preview.data?.documentTypes ?? { space: 0, folder: 0, note: 0 };
   const currentDocuments = types.note + types.folder;
   const currentSpaces = types.space;
-  const isEmptyWorkspace = preview.data ? currentDocuments === 0 : false;
+  const isEmptyWorkspace = preview.data ? currentDocuments === 0 && currentSpaces <= 1 : false;
   const confirmWord = isEmptyWorkspace ? 'restore' : 'replace';
   const canRestore = Boolean(file) && confirmation.trim().toLowerCase() === confirmWord && !busy;
 
@@ -77,8 +77,8 @@ export const RestoreBackupForm = ({ inDialog = false }: { inDialog?: boolean }) 
         <div className="flex gap-3 rounded-md bg-muted/60 p-3 text-sm">
           <Info className="h-4 w-4 shrink-0 mt-0.5 text-muted-foreground" />
           <p className="text-muted-foreground">
-            This workspace is empty, so nothing will be lost. The app reloads once your spaces and
-            documents are back.
+            This workspace has no documents yet. Its current space and editor settings are replaced
+            by the backup, and the app reloads once your documents are back.
           </p>
         </div>
       ) : (
@@ -168,7 +168,7 @@ export const RestoreBackupForm = ({ inDialog = false }: { inDialog?: boolean }) 
           <p className="text-sm text-muted-foreground">
             {progress.phase === 'reading' && 'Reading the backup…'}
             {progress.phase === 'uploading' && `Uploading… ${Math.round(progress.ratio * 100)}%`}
-            {progress.phase === 'restoring' && 'Restoring your workspace…'}
+            {progress.phase === 'restoring' && `${progress.detail ?? 'Restoring your workspace'}…`}
           </p>
           <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
             <div

--- a/apps/web/src/components/Settings/Backup/index.tsx
+++ b/apps/web/src/components/Settings/Backup/index.tsx
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Button } from '@repo/ui/components/button';
+import { Download } from '@repo/ui/components/icons';
+import { downloadBackup, useBackupPreview } from '@/queries/backup';
+import { formatBytes, plural } from '@/utils/backupManifest';
+import { RestoreBackupForm } from './RestoreBackupForm';
+
+const NO_TYPES = { space: 0, folder: 0, note: 0 };
+
+export function BackupExportSection() {
+  const preview = useBackupPreview();
+  const types = preview.data?.documentTypes ?? NO_TYPES;
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">Create a backup</h2>
+        <p className="text-sm text-muted-foreground">
+          Saves every space, document, revision and attachment as a single file. Your email and
+          password are never included.
+        </p>
+      </div>
+
+      <div className="rounded-lg border p-4 space-y-3">
+        {preview.isLoading ? (
+          <p className="text-sm text-muted-foreground">Measuring your workspace…</p>
+        ) : preview.data ? (
+          <dl className="grid grid-cols-2 @md:grid-cols-5 gap-3 text-sm">
+            <div>
+              <dt className="text-muted-foreground">Spaces</dt>
+              <dd className="font-medium">{types.space}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Documents</dt>
+              <dd className="font-medium">{types.note + types.folder}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Revisions</dt>
+              <dd className="font-medium">{preview.data.counts.revisions}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Favourites</dt>
+              <dd className="font-medium">{preview.data.counts.favorites}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Estimated size</dt>
+              <dd className="font-medium">{formatBytes(preview.data.bytes.uncompressed)}</dd>
+            </div>
+          </dl>
+        ) : (
+          <p className="text-sm text-destructive">Could not measure this workspace.</p>
+        )}
+
+        {preview.data && preview.data.missing.length > 0 && (
+          <p className="text-sm text-muted-foreground">
+            {plural(preview.data.missing.length, 'file')} already missing from storage will be
+            recorded in the backup as missing.
+          </p>
+        )}
+
+        <Button onClick={downloadBackup} disabled={!preview.data}>
+          <Download className="h-4 w-4" />
+          Download backup
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+export function BackupRestoreSection() {
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">Restore from a backup</h2>
+        <p className="text-sm text-muted-foreground">
+          Replaces this workspace with the contents of a WordyMe backup file.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-destructive/40 p-4">
+        <RestoreBackupForm />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/Settings/SettingsNav.tsx
+++ b/apps/web/src/components/Settings/SettingsNav.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Link, useLocation } from '@tanstack/react-router';
-import { Palette, UserRound } from '@repo/ui/components/icons';
+import { DatabaseBackup, Palette, UserRound } from '@repo/ui/components/icons';
 import { cn } from '@repo/ui/lib/utils';
 
 export default function SettingsNav() {
@@ -12,6 +12,7 @@ export default function SettingsNav() {
   const currentSection = location.search?.section || 'all';
   const isPreferencesPage = location.pathname.includes('/preferences');
   const isProfilePage = location.pathname.includes('/profile');
+  const isBackupPage = location.pathname.includes('/backup');
 
   const headingBase =
     'flex items-center gap-2 w-full rounded-md px-3 text-muted-foreground py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground data-[status=active]:bg-accent data-[status=active]:text-accent-foreground';
@@ -104,6 +105,40 @@ export default function SettingsNav() {
             )}
           >
             Editor preferences
+          </Link>
+        </div>
+      </div>
+
+      <div>
+        <Link
+          to="/settings/backup"
+          search={{ section: 'all' }}
+          activeOptions={{ exact: false }}
+          className={headingBase}
+        >
+          <DatabaseBackup className="h-4 w-4" />
+          Backup
+        </Link>
+        <div className="mt-2 ml-5 border-l pl-3 space-y-1">
+          <Link
+            to="/settings/backup"
+            search={{ section: 'export' }}
+            className={cn(
+              sublink,
+              isBackupPage && currentSection === 'export' && activeSublinkClass,
+            )}
+          >
+            Create backup
+          </Link>
+          <Link
+            to="/settings/backup"
+            search={{ section: 'restore' }}
+            className={cn(
+              sublink,
+              isBackupPage && currentSection === 'restore' && activeSublinkClass,
+            )}
+          >
+            Restore from backup
           </Link>
         </div>
       </div>

--- a/apps/web/src/queries/backup.ts
+++ b/apps/web/src/queries/backup.ts
@@ -60,6 +60,14 @@ const purgeLocalWorkspace = async () => {
 export type RestoreProgress = {
   phase: 'reading' | 'uploading' | 'restoring';
   ratio: number;
+  detail?: string;
+};
+
+const PHASE_LABELS: Record<string, string> = {
+  unpacking: 'Unpacking the backup',
+  verifying: 'Checking the backup is complete',
+  writing: 'Writing your documents',
+  publishing: 'Putting files into place',
 };
 
 export const useRestoreBackup = () => {
@@ -117,6 +125,13 @@ export const useRestoreBackup = () => {
 
         if (!job) continue;
         if (job.state === 'failed') throw new Error(job.error ?? 'The restore failed.');
+
+        onProgress?.({
+          phase: 'restoring',
+          ratio: job.total > 0 ? job.staged / job.total : 1,
+          detail: PHASE_LABELS[job.phase] ?? undefined,
+        });
+
         if (job.state === 'done') return { job, manifest };
       }
     },

--- a/apps/web/src/queries/backup.ts
+++ b/apps/web/src/queries/backup.ts
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  backupExportUrl,
+  beginBackupRestore,
+  commitBackupRestore,
+  getBackupPreview,
+  getBackupRestoreJob,
+  uploadBackupChunk,
+} from '@repo/sdk/backup.ts';
+import { readBackupManifest, type BackupManifestPreview } from '@/utils/backupManifest';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const POLL_INTERVAL_MS = 1000;
+const MIN_CHUNK_BYTES = 256 * 1024;
+
+export const backupPreviewQueryOptions = {
+  queryKey: ['backup', 'preview'] as const,
+  queryFn: async () => {
+    const { data, error } = await getBackupPreview();
+    if (error || !data) throw new Error(error?.message ?? 'Could not read this workspace.');
+    return data;
+  },
+};
+
+export const useBackupPreview = () => useQuery(backupPreviewQueryOptions);
+
+export const downloadBackup = () => {
+  window.location.assign(backupExportUrl());
+};
+
+const purgeLocalWorkspace = async () => {
+  try {
+    const databases = (await indexedDB.databases?.()) ?? [];
+    await Promise.all(
+      databases
+        .map((entry) => entry.name)
+        .filter((name): name is string => Boolean(name) && UUID_PATTERN.test(name!))
+        .map(
+          (name) =>
+            new Promise<void>((resolve) => {
+              const request = indexedDB.deleteDatabase(name);
+              request.onsuccess = () => resolve();
+              request.onerror = () => resolve();
+              request.onblocked = () => resolve();
+            }),
+        ),
+    );
+  } catch {
+    // A browser that cannot enumerate databases still gets the reload below.
+  }
+
+  localStorage.removeItem('Wordy');
+};
+
+export type RestoreProgress = {
+  phase: 'reading' | 'uploading' | 'restoring';
+  ratio: number;
+};
+
+export const useRestoreBackup = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      file,
+      onProgress,
+    }: {
+      file: File;
+      onProgress?: (progress: RestoreProgress) => void;
+    }) => {
+      onProgress?.({ phase: 'reading', ratio: 0 });
+      const manifest = await readBackupManifest(file);
+
+      const { data: ticket, error: beginError } = await beginBackupRestore();
+      if (beginError || !ticket) {
+        throw new Error(beginError?.message ?? 'Could not start the restore.');
+      }
+
+      let chunkBytes = ticket.chunkBytes;
+      let offset = 0;
+      let index = 0;
+
+      while (offset < file.size) {
+        const slice = file.slice(offset, offset + chunkBytes);
+
+        try {
+          await uploadBackupChunk(ticket.uploadId, index, slice);
+        } catch (error) {
+          const status = (error as { response?: { status?: number } }).response?.status;
+          if (status === 413 && chunkBytes > MIN_CHUNK_BYTES) {
+            chunkBytes = Math.max(MIN_CHUNK_BYTES, Math.floor(chunkBytes / 2));
+            continue;
+          }
+          throw error;
+        }
+
+        offset += slice.size;
+        index += 1;
+        onProgress?.({ phase: 'uploading', ratio: offset / file.size });
+      }
+
+      const { data: commit, error: commitError } = await commitBackupRestore(ticket.uploadId);
+      if (commitError || !commit) {
+        throw new Error(commitError?.message ?? 'Could not start the restore.');
+      }
+
+      onProgress?.({ phase: 'restoring', ratio: 1 });
+
+      for (;;) {
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+        const { data: job } = await getBackupRestoreJob(commit.jobId);
+
+        if (!job) continue;
+        if (job.state === 'failed') throw new Error(job.error ?? 'The restore failed.');
+        if (job.state === 'done') return { job, manifest };
+      }
+    },
+    onSuccess: async () => {
+      await purgeLocalWorkspace();
+      queryClient.clear();
+      window.location.assign('/');
+    },
+  });
+};
+
+export type { BackupManifestPreview };

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as AuthedDocsManageRouteImport } from './routes/_authed/docs/mana
 import { Route as AuthedDocsRecentViewedRouteImport } from './routes/_authed/docs/recent-viewed'
 import { Route as AuthedEditHandleRouteImport } from './routes/_authed/edit/$handle'
 import { Route as AuthedSettingsIndexRouteImport } from './routes/_authed/settings/index'
+import { Route as AuthedSettingsBackupRouteImport } from './routes/_authed/settings/backup'
 import { Route as AuthedSettingsPreferencesRouteImport } from './routes/_authed/settings/preferences'
 import { Route as AuthedSettingsProfileRouteImport } from './routes/_authed/settings/profile'
 import { Route as AuthedSpacesIndexRouteImport } from './routes/_authed/spaces/index'
@@ -92,6 +93,11 @@ const AuthedSettingsIndexRoute = AuthedSettingsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => AuthedSettingsRouteRoute,
 } as any)
+const AuthedSettingsBackupRoute = AuthedSettingsBackupRouteImport.update({
+  id: '/backup',
+  path: '/backup',
+  getParentRoute: () => AuthedSettingsRouteRoute,
+} as any)
 const AuthedSettingsPreferencesRoute =
   AuthedSettingsPreferencesRouteImport.update({
     id: '/preferences',
@@ -134,6 +140,7 @@ export interface FileRoutesByFullPath {
   '/docs/manage': typeof AuthedDocsManageRoute
   '/docs/recent-viewed': typeof AuthedDocsRecentViewedRoute
   '/edit/$handle': typeof AuthedEditHandleRoute
+  '/settings/backup': typeof AuthedSettingsBackupRoute
   '/settings/preferences': typeof AuthedSettingsPreferencesRoute
   '/settings/profile': typeof AuthedSettingsProfileRoute
   '/spaces/favorites': typeof AuthedSpacesFavoritesRoute
@@ -152,6 +159,7 @@ export interface FileRoutesByTo {
   '/docs/manage': typeof AuthedDocsManageRoute
   '/docs/recent-viewed': typeof AuthedDocsRecentViewedRoute
   '/edit/$handle': typeof AuthedEditHandleRoute
+  '/settings/backup': typeof AuthedSettingsBackupRoute
   '/settings/preferences': typeof AuthedSettingsPreferencesRoute
   '/settings/profile': typeof AuthedSettingsProfileRoute
   '/spaces/favorites': typeof AuthedSpacesFavoritesRoute
@@ -174,6 +182,7 @@ export interface FileRoutesById {
   '/_authed/docs/manage': typeof AuthedDocsManageRoute
   '/_authed/docs/recent-viewed': typeof AuthedDocsRecentViewedRoute
   '/_authed/edit/$handle': typeof AuthedEditHandleRoute
+  '/_authed/settings/backup': typeof AuthedSettingsBackupRoute
   '/_authed/settings/preferences': typeof AuthedSettingsPreferencesRoute
   '/_authed/settings/profile': typeof AuthedSettingsProfileRoute
   '/_authed/spaces/favorites': typeof AuthedSpacesFavoritesRoute
@@ -195,6 +204,7 @@ export interface FileRouteTypes {
     | '/docs/manage'
     | '/docs/recent-viewed'
     | '/edit/$handle'
+    | '/settings/backup'
     | '/settings/preferences'
     | '/settings/profile'
     | '/spaces/favorites'
@@ -213,6 +223,7 @@ export interface FileRouteTypes {
     | '/docs/manage'
     | '/docs/recent-viewed'
     | '/edit/$handle'
+    | '/settings/backup'
     | '/settings/preferences'
     | '/settings/profile'
     | '/spaces/favorites'
@@ -234,6 +245,7 @@ export interface FileRouteTypes {
     | '/_authed/docs/manage'
     | '/_authed/docs/recent-viewed'
     | '/_authed/edit/$handle'
+    | '/_authed/settings/backup'
     | '/_authed/settings/preferences'
     | '/_authed/settings/profile'
     | '/_authed/spaces/favorites'
@@ -342,6 +354,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedSettingsIndexRouteImport
       parentRoute: typeof AuthedSettingsRouteRoute
     }
+    '/_authed/settings/backup': {
+      id: '/_authed/settings/backup'
+      path: '/backup'
+      fullPath: '/settings/backup'
+      preLoaderRoute: typeof AuthedSettingsBackupRouteImport
+      parentRoute: typeof AuthedSettingsRouteRoute
+    }
     '/_authed/settings/preferences': {
       id: '/_authed/settings/preferences'
       path: '/preferences'
@@ -388,12 +407,14 @@ declare module '@tanstack/react-router' {
 }
 
 interface AuthedSettingsRouteRouteChildren {
+  AuthedSettingsBackupRoute: typeof AuthedSettingsBackupRoute
   AuthedSettingsPreferencesRoute: typeof AuthedSettingsPreferencesRoute
   AuthedSettingsProfileRoute: typeof AuthedSettingsProfileRoute
   AuthedSettingsIndexRoute: typeof AuthedSettingsIndexRoute
 }
 
 const AuthedSettingsRouteRouteChildren: AuthedSettingsRouteRouteChildren = {
+  AuthedSettingsBackupRoute: AuthedSettingsBackupRoute,
   AuthedSettingsPreferencesRoute: AuthedSettingsPreferencesRoute,
   AuthedSettingsProfileRoute: AuthedSettingsProfileRoute,
   AuthedSettingsIndexRoute: AuthedSettingsIndexRoute,

--- a/apps/web/src/routes/_authed/settings/backup.tsx
+++ b/apps/web/src/routes/_authed/settings/backup.tsx
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createFileRoute, useSearch } from '@tanstack/react-router';
+import { z } from 'zod';
+import { BackupExportSection, BackupRestoreSection } from '@/components/Settings/Backup';
+
+const backupSearchSchema = z.object({
+  section: z.enum(['export', 'restore', 'all']).optional().default('all'),
+});
+
+export const Route = createFileRoute('/_authed/settings/backup')({
+  component: RouteComponent,
+  validateSearch: backupSearchSchema,
+});
+
+function RouteComponent() {
+  const { section } = useSearch({ from: '/_authed/settings/backup' });
+
+  const renderSection = () => {
+    switch (section) {
+      case 'export':
+        return <BackupExportSection />;
+      case 'restore':
+        return <BackupRestoreSection />;
+      case 'all':
+      default:
+        return (
+          <>
+            <BackupExportSection />
+            <BackupRestoreSection />
+          </>
+        );
+    }
+  };
+
+  return <div className="space-y-10">{renderSection()}</div>;
+}

--- a/apps/web/src/routes/_authed/settings/route.tsx
+++ b/apps/web/src/routes/_authed/settings/route.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { useEffect, useRef } from 'react';
+import { createFileRoute, Outlet, useLocation } from '@tanstack/react-router';
 import SettingsHeader from '@/components/Settings/SettingsHeader';
 import UserImages from '@/components/Settings/UserImages';
 import SettingsNav from '@/components/Settings/SettingsNav';
@@ -12,9 +13,29 @@ export const Route = createFileRoute('/_authed/settings')({
   component: RouteComponent,
 });
 
+const scrollPaneToTop = (from: HTMLElement | null) => {
+  let element = from?.parentElement ?? null;
+
+  while (element) {
+    const overflowY = getComputedStyle(element).overflowY;
+    if (/(auto|scroll)/.test(overflowY) && element.scrollHeight > element.clientHeight) {
+      element.scrollTo({ top: 0 });
+      return;
+    }
+    element = element.parentElement;
+  }
+};
+
 function RouteComponent() {
+  const paneRef = useRef<HTMLDivElement>(null);
+  const { pathname, searchStr } = useLocation();
+
+  useEffect(() => {
+    scrollPaneToTop(paneRef.current);
+  }, [pathname, searchStr]);
+
   return (
-    <>
+    <div ref={paneRef}>
       <SettingsHeader />
       <UserImages />
       <div className="@container">
@@ -25,6 +46,6 @@ function RouteComponent() {
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/utils/backupManifest.ts
+++ b/apps/web/src/utils/backupManifest.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { BackupManifest } from '@repo/backend/backup.js';
+import {
+  BACKUP_CONTENT_FORMAT,
+  BACKUP_FORMAT_VERSION,
+  manifestSchema,
+  type BackupManifest,
+} from '@repo/backend/backup.js';
 
 const LOCAL_HEADER_SIGNATURE = 0x04034b50;
 const HEADER_BYTES = 30;
@@ -51,11 +56,31 @@ export const readBackupManifest = async (file: File): Promise<BackupManifestPrev
     throw new Error('This backup has an unreadable manifest.');
   }
 
+  let parsedJson: unknown;
   try {
-    return JSON.parse(new TextDecoder().decode(decoded)) as BackupManifestPreview;
+    parsedJson = JSON.parse(new TextDecoder().decode(decoded));
   } catch {
     throw new Error('This backup has a corrupt manifest.');
   }
+
+  const parsed = manifestSchema.safeParse(parsedJson);
+  if (!parsed.success) {
+    throw new Error('This file is not a WordyMe backup, or its manifest is damaged.');
+  }
+
+  if (parsed.data.formatVersion > BACKUP_FORMAT_VERSION) {
+    throw new Error(
+      `This backup was made by a newer WordyMe (format ${parsed.data.formatVersion}); this version supports up to ${BACKUP_FORMAT_VERSION}.`,
+    );
+  }
+
+  if (parsed.data.contentFormat.lexical > BACKUP_CONTENT_FORMAT.lexical) {
+    throw new Error(
+      'This backup stores documents in a newer format than this version can open. Update WordyMe first.',
+    );
+  }
+
+  return parsed.data;
 };
 
 export const formatBytes = (bytes: number) => {

--- a/apps/web/src/utils/backupManifest.ts
+++ b/apps/web/src/utils/backupManifest.ts
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { BackupManifest } from '@repo/backend/backup.js';
+
+const LOCAL_HEADER_SIGNATURE = 0x04034b50;
+const HEADER_BYTES = 30;
+const MAX_MANIFEST_BYTES = 64 * 1024;
+
+export type BackupManifestPreview = BackupManifest;
+
+const inflateRaw = async (bytes: Uint8Array) => {
+  const stream = new Blob([bytes as BlobPart])
+    .stream()
+    .pipeThrough(new DecompressionStream('deflate-raw'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+};
+
+export const readBackupManifest = async (file: File): Promise<BackupManifestPreview> => {
+  const head = new DataView(await file.slice(0, HEADER_BYTES).arrayBuffer());
+
+  if (head.byteLength < HEADER_BYTES || head.getUint32(0, true) !== LOCAL_HEADER_SIGNATURE) {
+    throw new Error('This file is not a zip archive.');
+  }
+
+  const method = head.getUint16(8, true);
+  const compressedSize = head.getUint32(18, true);
+  const nameLength = head.getUint16(26, true);
+  const extraLength = head.getUint16(28, true);
+  const nameStart = HEADER_BYTES;
+  const dataStart = nameStart + nameLength + extraLength;
+
+  const name = new TextDecoder().decode(
+    await file.slice(nameStart, nameStart + nameLength).arrayBuffer(),
+  );
+
+  if (name !== 'manifest.json') {
+    throw new Error('This is not a WordyMe backup: its first entry is not a manifest.');
+  }
+
+  if (compressedSize === 0 || compressedSize > MAX_MANIFEST_BYTES) {
+    throw new Error('This backup has an unreadable manifest.');
+  }
+
+  const raw = new Uint8Array(await file.slice(dataStart, dataStart + compressedSize).arrayBuffer());
+  const decoded = method === 0 ? raw : await inflateRaw(raw);
+
+  if (decoded.byteLength > MAX_MANIFEST_BYTES) {
+    throw new Error('This backup has an unreadable manifest.');
+  }
+
+  try {
+    return JSON.parse(new TextDecoder().decode(decoded)) as BackupManifestPreview;
+  } catch {
+    throw new Error('This backup has a corrupt manifest.');
+  }
+};
+
+export const formatBytes = (bytes: number) => {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let value = bytes / 1024;
+  let unit = 0;
+
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+
+  return `${value.toFixed(value >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`;
+};
+
+export const plural = (count: number, word: string) => `${count} ${word}${count === 1 ? '' : 's'}`;

--- a/packages/eslint-config/vite.js
+++ b/packages/eslint-config/vite.js
@@ -39,6 +39,12 @@ export default defineConfig(
     },
   },
   {
+    files: ['**/src/routes/**/*.tsx'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
+  {
     files: ['**/*.config.{js,mjs,cjs,ts,mts,cts}', '**/vite.config.{js,mjs,cjs,ts,mts,cts}'],
     languageOptions: {
       globals: {

--- a/packages/sdk/src/app/backup.ts
+++ b/packages/sdk/src/app/backup.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {
+  BackupPreview,
+  BackupRestoreJob,
+  BackupUploadProgress,
+  BackupUploadTicket,
+} from '@repo/backend/backup.js';
+import { client, get, post } from './client.js';
+
+export const getBackupPreview = async () => {
+  return await get<BackupPreview>('/backup/preview');
+};
+
+export const backupExportUrl = () => `${client.defaults.baseURL}/backup/export`;
+
+export const beginBackupRestore = async () => {
+  return await post<BackupUploadTicket>('/backup/restore/begin');
+};
+
+export const getBackupUploadStatus = async (uploadId: string) => {
+  return await get<BackupUploadProgress>('/backup/restore/status', { uploadId });
+};
+
+export const uploadBackupChunk = async (uploadId: string, index: number, chunk: Blob) => {
+  const response = await client.put<BackupUploadProgress>('/backup/restore/chunk', chunk, {
+    params: { uploadId, index },
+    headers: { 'Content-Type': 'application/octet-stream' },
+  });
+
+  return response.data;
+};
+
+export const commitBackupRestore = async (uploadId: string) => {
+  return await post<{ jobId: string }>(`/backup/restore/commit?uploadId=${uploadId}`);
+};
+
+export const getBackupRestoreJob = async (jobId: string) => {
+  return await get<BackupRestoreJob>('/backup/restore/job', { jobId });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,12 @@ importers:
       socket.io:
         specifier: ^4.8.3
         version: 4.8.3
+      yauzl:
+        specifier: ^3.4.0
+        version: 3.4.0
+      yazl:
+        specifier: ^3.3.1
+        version: 3.3.1
       zod:
         specifier: ^4.3.6
         version: 4.4.3
@@ -143,6 +149,12 @@ importers:
       '@types/node':
         specifier: ^25.4.0
         version: 25.9.5
+      '@types/yauzl':
+        specifier: ^3.4.0
+        version: 3.4.0
+      '@types/yazl':
+        specifier: ^3.3.1
+        version: 3.3.1
       bun:
         specifier: ^1.3.10
         version: 1.3.14
@@ -4607,6 +4619,12 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@types/yauzl@3.4.0':
+    resolution: {integrity: sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==}
+
+  '@types/yazl@3.3.1':
+    resolution: {integrity: sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==}
+
   '@typescript-eslint/eslint-plugin@8.66.0':
     resolution: {integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5055,6 +5073,10 @@ packages:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -7698,6 +7720,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
@@ -9047,6 +9072,13 @@ packages:
 
   yargs@13.3.2:
     resolution: {integrity: sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==}
+
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
+    engines: {node: '>=12'}
+
+  yazl@3.3.1:
+    resolution: {integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -12746,6 +12778,14 @@ snapshots:
     dependencies:
       '@types/node': 25.9.5
 
+  '@types/yauzl@3.4.0':
+    dependencies:
+      '@types/node': 25.9.5
+
+  '@types/yazl@3.3.1':
+    dependencies:
+      '@types/node': 25.9.5
+
   '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -13252,6 +13292,8 @@ snapshots:
       electron-to-chromium: 1.5.402
       node-releases: 2.0.53
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
+
+  buffer-crc32@1.0.0: {}
 
   buffer-from@1.1.2: {}
 
@@ -16200,6 +16242,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pend@1.2.0: {}
+
   perfect-debounce@2.1.0: {}
 
   perfect-freehand@1.2.0: {}
@@ -17773,6 +17817,14 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 13.1.2
+
+  yauzl@3.4.0:
+    dependencies:
+      pend: 1.2.0
+
+  yazl@3.3.1:
+    dependencies:
+      buffer-crc32: 1.0.0
 
   yocto-queue@0.1.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://turborepo.com/schema.json",
-  "globalEnv": ["VITE_BACKEND_URL", "DEV", "DB_FILE_NAME", "WEB_DIR", "TRUST_PROXY", "TRUST_HOST"],
+  "globalEnv": [
+    "VITE_BACKEND_URL",
+    "DEV",
+    "DB_FILE_NAME",
+    "WEB_DIR",
+    "TRUST_PROXY",
+    "TRUST_HOST",
+    "APP_VERSION",
+    "BACKUP_MAX_RESTORE_BYTES",
+    "BACKUP_MAX_BACKUP_BYTES",
+    "BACKUP_MAX_ENTRY_BYTES",
+    "BACKUP_MAX_ENTRIES",
+    "BACKUP_MAX_MANIFEST_BYTES",
+    "BACKUP_CHUNK_BYTES"
+  ],
   "ui": "tui",
   "tasks": {
     "build": {


### PR DESCRIPTION
## What

Adds workspace backup and restore. A user can download their entire workspace as a
single file, and rebuild it later on a fresh install — after deleting the container
*and* its volume — by signing up and restoring.

The backup carries spaces, nested spaces, documents, revision history and
attachments. It never carries email, password hashes, sessions or any other identity
data, so the file is safe to move between machines.

## Why this shape

**ZIP with per-entry compression, not `tar.gz`.** Measured on a real 181-document
workspace: attachments are 46 MB of the payload against 664 KB of JSON, and they are
already-compressed formats. A gzip stream would re-deflate 46 MB of PDFs and JPEGs for
roughly nothing — exactly the CPU burn that makes a Raspberry Pi unusable. ZIP lets
each entry choose its method, so attachments are stored verbatim and only the JSON is
deflated. In the round trip, 28 of 110 entries store at ratio 1.00.

**`yazl` + `yauzl`.** Pure JS, no native build, so they work on ARM. `yauzl` reads the
central directory, which is the trust model this design needs. Deliberately rejected:
`archiver` v8 (ESM rewrite whose API no longer matches its DefinitelyTyped types),
`adm-zip` and `jszip` (buffer the whole archive — OOM against a 1 GB Pi), and
`unzipper` (trusts local headers, whose sizes we specifically refuse to trust).

**No new frontend dependency.** The client reads `manifest.json` straight out of the
archive using `DataView` plus the native `DecompressionStream('deflate-raw')`, so a
wrong file is rejected in ~48 ms with zero bytes uploaded.

## Scope

| Included | Excluded |
| --- | --- |
| `documents`, `revisions`, `favorites`, `document_views`, `editor_settings`, `user_images` | `users`, `accounts`, `sessions`, `verifications` |
| `storage/revisions/*.json`, `storage/attachments/**`, `images/`, `covers/` | `local.db`, `-wal`, `-shm` |
| | `document_search_index` — derived, rebuilt by existing triggers |

Restore is whole-workspace and replace-only in this version; `mode` is pinned in the
manifest and any other value is refused.

## Security model

Every archive entry passes a gate before a byte is written:

1. **Zip Slip** — absolute paths, `..` segments, backslashes, NULs, trailing dots or
   spaces, and non-NFC names are rejected, and the name must sit under an allowed
   prefix.
2. **`local.db` denylist** — an independent check on the resolved basename. `storage/`
   contains the database in production, so `resolvePhysicalPath` alone gives it no
   protection.
3. **Symlink entries** — rejected by inspecting the Unix mode in the external
   attributes. This is the half of Zip Slip that path checks miss.
4. **Duplicate entries** — rejected case-insensitively, so `Report.pdf`/`report.pdf`
   cannot collide on APFS/NTFS, and a second `manifest.json` cannot override the first.
5. **Zip bombs** — total bytes, per-entry bytes, entry count and compression ratio are
   all counted from bytes *actually written*, never from declared sizes. The ratio
   guard only applies above 1 MB so the app's own highly-compressible backups still
   restore.
6. **Filename contract** — every basename must satisfy the app's own
   `storageFilenameSchema`, so a restore cannot create a file the app then refuses to
   serve.
7. **Table allowlist** — only the six known `db/*.ndjson` files are accepted. A
   smuggled `db/users.ndjson` is rejected outright, not silently ignored.

Staging lives at `/app/restore-staging`, a sibling of `storage/` — same filesystem so
`rename()` stays atomic, but outside the tree that holds the database.

## Restore is transactional

Files cannot be rolled back, so the sequence builds that guarantee:

1. Extract everything into a per-job staging directory. The live tree is untouched.
2. Verify the manifest inventory against what was actually staged, in both directions.
   A row without its file, or a file without its row, fails **before** the transaction.
3. One DB transaction with deferred foreign keys: delete the user's rows, insert
   documents with a null head, insert revisions, then set heads. Timestamps are
   preserved by writing raw SQL, so Drizzle's `$onUpdateFn` cannot rewrite them.
   `PRAGMA foreign_key_check` runs before commit.
4. Write a commit marker listing every staged → live path, then `rename()` each file
   into place, then delete the marker.
5. On boot, a staging directory **with** a marker has its publish resumed; one without
   is deleted. A crash mid-publish therefore loses nothing.

Concurrency: one backup job at a time process-wide (409 on a second), and every
mutating API route returns 503 for the duration of a restore.

## Transport

Export is a `GET` triggered as a navigation, so the browser streams to disk instead of
buffering gigabytes in a tab. Restore uploads in 8 MB chunks (under Cloudflare's 100 MB
cap and tunable for stricter proxies), then `commit` returns **202 + jobId** with
progress over sockets and a polling fallback — no long-lived response for a reverse
proxy to kill.

## Schema evolution

| Change in a later release | Old backup restores? |
| --- | --- |
| Nullable column added | Yes — new column is `NULL` |
| `NOT NULL` column with a default | Yes — default applied |
| `NOT NULL` without a default | N/A — SQLite refuses that migration |
| Column removed | Yes — columns are matched by name |
| **Table added** | Yes — and stale rows in it are cleared on replace |
| Backup from a *newer* schema | Refused with an explicit message |

## Verification

No test framework exists in this repo, so this was verified by hand against a real
181-document / 46 MB workspace and in a sandboxed container.

**Round trip** — export, wipe the volume, sign up, restore:

- 181 documents / 67 revisions / 42 views restored
- documents and revisions **byte-identical, including `created_at` and `updated_at`**
- all 103 row-backed files byte-identical by sha256
- search index rebuilt by triggers, 0 foreign-key violations
- restored into a **different account**, confirming user ids are rewritten

**Timings** (dev machine; a Pi will be slower):

| Operation | Time |
| --- | --- |
| Export over HTTP | 985 ms — 43.9 MB at 44.5 MB/s |
| Client-side manifest read | 48 ms (reads only the first few KB) |
| Chunked upload, 6 × 8 MB | 102 ms |
| Restore (unpack → verify → transact → publish) | 483 ms |
| **Full restore end to end** | **656 ms** |

**Adversarial** — 18 hand-built malicious archives (`scripts/backup-fixtures.py`), all
blocked, with `local.db` byte-identical afterwards and no symlinks, staging or escapes:
Zip Slip variants, symlink entries, ratio/manifest/50k-entry bombs, duplicate
manifests, version gates, and a smuggled identity table.

**Failure paths** — crash mid-publish resumes on boot; crash mid-extract is swept;
corrupt marker discarded; writes during restore return 503; concurrent jobs return 409;
old backup restores into a schema with a new table.

## How to review

Highest risk first:

1. `services/backup/entry-gate.ts` — the security boundary.
2. `services/backup/staging.ts` — extraction, free-space floor, publish, boot recovery.
3. `services/backup/restore-db.ts` — the transaction, insert ordering, timestamp
   preservation.
4. Everything else is plumbing: routes, chunked upload, SDK, UI.

## Known limits

- Peak disk during restore is `zip + extracted`; a `statfs` pre-flight refuses the job
  rather than risking a full disk, and a floor check re-runs during extraction because
  the declared size is attacker-controlled.
- Restore is irreversible. The UI shows what will be destroyed and requires typing a
  confirmation word; when the workspace is empty it says so and drops the destructive
  framing.
- Row data is materialised per table during restore. Fine at 181 documents; that, not
  attachment size, is the scaling limit to revisit.
- Single-user semantics are load-bearing — the database refuses a second user today.

## Follow-ups (not in this PR)

1. A golden-fixture CI test that restores a checked-in v1 backup on every build. This
   is what would have caught the new-table bug automatically instead of by inspection.
2. A documented compatibility window and the restore-then-upgrade path in DOCKER.md.
3. The `formatMigrations[]` seam, before there is a v2 to migrate from.
4. A `RETIRED_BACKUP_TABLES` allowlist, needed the day a table is dropped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace backup export and restore in Settings.
  * Preview backups, download ZIP archives, upload files, confirm workspace replacement, and track detailed restore progress.
  * Added Backup navigation and restore access from empty workspaces.
  * Added guided document creation for empty workspaces.
* **Usability Improvements**
  * Settings navigation resets scroll position when switching sections.
* **Bug Fixes**
  * Added safeguards for incomplete, incompatible, corrupted, or oversized backups.
  * Improved recovery after interrupted uploads or restores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->