### PR TITLE
feat(auth): add a CLI password reset for self-hosters

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -418,6 +418,39 @@ the damage only shows when a document fails to open.
 > `chown` inside the container is not an option here: `cap_drop: ALL` removes
 > `CAP_CHOWN` and `CAP_DAC_OVERRIDE`, so not even root can do it.
 
+### Resetting a Forgotten Password
+
+This app has no mail transport, so there is no "forgot password" email, and
+sign-up is closed once the first account exists. If you lock yourself out, reset
+the password from the host instead.
+
+Set a new password, generated for you and printed once:
+
+```bash
+docker compose exec wordyme node reset-password.mjs
+```
+
+Or choose it yourself:
+
+```bash
+docker compose exec wordyme node reset-password.mjs --password 'a long passphrase'
+```
+
+Sign-up closes after the first account, so there is only ever one to reset and
+the email can be left out. Pass it explicitly if you prefer, and use `--list` if
+you have forgotten which address you signed up with:
+
+```bash
+docker compose exec wordyme node reset-password.mjs --list
+```
+
+The hash is produced by Better Auth itself, so the new password works exactly
+like one set through the UI. Every existing session is signed out, on the view
+that a reset which leaves old sessions alive is not a reset. Anyone who can run
+`docker compose exec` already has the database, so this grants no access they
+did not have — but it does mean the command belongs to the host operator, not to
+end users.
+
 ### Reclaiming Orphaned Files
 
 Deleting a document removes its rows and its files together. Deletions made by

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -430,11 +430,15 @@ Set a new password, generated for you and printed once:
 docker compose exec wordyme node reset-password.mjs
 ```
 
-Or choose it yourself:
+Or choose it yourself, piping it in so it never becomes a command argument:
 
 ```bash
-docker compose exec wordyme node reset-password.mjs --password 'a long passphrase'
+printf '%s' 'a long passphrase' | docker compose exec -T wordyme node reset-password.mjs --password-stdin
 ```
+
+Passing a password as an argument is refused. Arguments are visible to `ps` for
+every user on the host and are written to shell history, which is the same
+reason `docker login` takes `--password-stdin`.
 
 Sign-up closes after the first account, so there is only ever one to reset and
 the email can be left out. Pass it explicitly if you prefer, and use `--list` if

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,7 @@ COPY --from=builder /app/apps/backend/dist ./dist
 COPY --from=builder /app/apps/backend/drizzle ./drizzle
 COPY --from=builder /app/apps/backend/src/scripts/run-migrations.mjs ./run-migrations.mjs
 COPY --from=builder /app/apps/backend/src/scripts/prune-orphans.mjs ./prune-orphans.mjs
+COPY --from=builder /app/apps/backend/src/scripts/reset-password.mjs ./reset-password.mjs
 
 # Served by Express from the same origin as the API. Resolved relative to
 # ./dist, not the working directory — see apps/backend/src/lib/web.ts.
@@ -120,7 +121,7 @@ COPY --from=builder /app/apps/web/dist ./web
 # 0744 produces an image where the non-root user cannot traverse it, and
 # migrations fail with a confusing "Can't find meta/_journal.json". Normalise
 # to read-for-all, execute only where it already applies.
-RUN chmod -R a+rX ./dist ./drizzle ./web ./run-migrations.mjs ./prune-orphans.mjs
+RUN chmod -R a+rX ./dist ./drizzle ./web ./run-migrations.mjs ./prune-orphans.mjs ./reset-password.mjs
 
 RUN mkdir -p storage && chown -R nodejs:nodejs storage
 

--- a/apps/backend/src/scripts/reset-password.mjs
+++ b/apps/backend/src/scripts/reset-password.mjs
@@ -28,12 +28,14 @@ const usage = () => {
 Set a new password for an account.
 
   node reset-password.mjs
-  node reset-password.mjs --password '<new password>'
   node reset-password.mjs <email>
   node reset-password.mjs --list
+  printf '%s' 'a long passphrase' | node reset-password.mjs --password-stdin
 
 This instance holds a single account, so the email may be omitted. Without
---password a strong one is generated and printed once.
+--password-stdin a strong password is generated and printed once. Passwords are
+never taken as an argument, because arguments are visible to ps and land in
+shell history.
 `);
 };
 
@@ -81,20 +83,50 @@ if (args.includes('--list')) {
   process.exit(0);
 }
 
-const passwordIndex = args.indexOf('--password');
-const provided = passwordIndex === -1 ? null : args[passwordIndex + 1];
+const KNOWN_FLAGS = new Set(['--help', '-h', '--list', '--password-stdin']);
 
-if (passwordIndex !== -1 && !provided) {
-  console.error('\n  --password needs a value.\n');
+const unknown = args.filter((value) => value.startsWith('-') && !KNOWN_FLAGS.has(value));
+
+if (unknown.length > 0 && !unknown.includes('--password')) {
+  console.error(`\n  Unrecognised option: ${unknown.join(', ')}\n`);
+  usage();
   process.exit(1);
 }
 
-if (provided && provided.length < MIN_PASSWORD_LENGTH) {
+if (args.includes('--password')) {
+  console.error(
+    "\n  --password is not accepted: an argument is visible to ps and stored in shell history.\n  Pipe it instead:  printf '%s' 'your passphrase' | node reset-password.mjs --password-stdin\n",
+  );
+  process.exit(1);
+}
+
+const readStdin = async () => {
+  if (process.stdin.isTTY) {
+    console.error(
+      "\n  --password-stdin expects the password on stdin, but nothing is piped in.\n  Try:  printf '%s' 'your passphrase' | node reset-password.mjs --password-stdin\n",
+    );
+    process.exit(1);
+  }
+
+  let value = '';
+  process.stdin.setEncoding('utf8');
+  for await (const chunk of process.stdin) value += chunk;
+  return value.replace(/\r?\n$/, '');
+};
+
+const provided = args.includes('--password-stdin') ? await readStdin() : null;
+
+if (provided !== null && provided.length === 0) {
+  console.error('\n  Nothing arrived on stdin, so no password was set.\n');
+  process.exit(1);
+}
+
+if (provided !== null && provided.length < MIN_PASSWORD_LENGTH) {
   console.error(`\n  That password is shorter than ${MIN_PASSWORD_LENGTH} characters.\n`);
   process.exit(1);
 }
 
-const email = args.find((value, index) => !value.startsWith('--') && index !== passwordIndex + 1);
+const email = args.find((value) => !value.startsWith('--'));
 
 const users = email
   ? await client.execute({
@@ -121,11 +153,6 @@ if (!email && users.rows.length > 1) {
 
 const user = users.rows[0];
 
-const accounts = await client.execute({
-  sql: 'select id from accounts where user_id = ? and provider_id = ?',
-  args: [user.id, 'credential'],
-});
-
 const password = provided ?? randomBytes(GENERATED_PASSWORD_BYTES).toString('base64url');
 
 const auth = betterAuth({
@@ -136,25 +163,50 @@ const context = await auth.$context;
 const hash = await context.password.hash(password);
 const now = Date.now();
 
-if (accounts.rows.length === 0) {
-  await client.execute({
-    sql: 'insert into accounts (id, account_id, provider_id, user_id, password, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?)',
-    args: [crypto.randomUUID(), user.id, 'credential', user.id, hash, now, now],
+const transaction = await client.transaction('write');
+let added = false;
+let signedOut = 0;
+
+try {
+  const accounts = await transaction.execute({
+    sql: 'select id from accounts where user_id = ? and provider_id = ?',
+    args: [user.id, 'credential'],
   });
-  console.log('\n  That account had no password sign-in; one has been added.');
-} else {
-  await client.execute({
-    sql: 'update accounts set password = ?, updated_at = ? where id = ?',
-    args: [hash, now, accounts.rows[0].id],
+
+  if (accounts.rows.length > 1) {
+    throw new Error(
+      `That account has ${accounts.rows.length} password sign-ins, so there is no single one to change. Remove the duplicates before resetting.`,
+    );
+  }
+
+  if (accounts.rows.length === 0) {
+    await transaction.execute({
+      sql: 'insert into accounts (id, account_id, provider_id, user_id, password, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?)',
+      args: [crypto.randomUUID(), user.id, 'credential', user.id, hash, now, now],
+    });
+    added = true;
+  } else {
+    await transaction.execute({
+      sql: 'update accounts set password = ?, updated_at = ? where id = ?',
+      args: [hash, now, accounts.rows[0].id],
+    });
+  }
+
+  const sessions = await transaction.execute({
+    sql: 'delete from sessions where user_id = ?',
+    args: [user.id],
   });
+  signedOut = sessions.rowsAffected;
+
+  await transaction.commit();
+} catch (error) {
+  await transaction.rollback();
+  console.error(`\n  Nothing was changed. ${error instanceof Error ? error.message : error}\n`);
+  process.exit(1);
 }
 
-const sessions = await client.execute({
-  sql: 'delete from sessions where user_id = ?',
-  args: [user.id],
-});
-
+if (added) console.log('\n  That account had no password sign-in; one has been added.');
 console.log(`\n  Password updated for ${user.email}.`);
-if (!provided) console.log(`\n    New password:  ${password}\n`);
-console.log(`  ${sessions.rowsAffected} existing session(s) signed out.\n`);
+if (provided === null) console.log(`\n    New password:  ${password}\n`);
+console.log(`  ${signedOut} existing session(s) signed out.\n`);
 process.exit(0);

--- a/apps/backend/src/scripts/reset-password.mjs
+++ b/apps/backend/src/scripts/reset-password.mjs
@@ -1,0 +1,160 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Sets a new password for an account from the command line, for self-hosters
+ * who have locked themselves out. There is no email transport in this app, so
+ * the built-in reset flow cannot be used.
+ *
+ * Hashes through Better Auth itself, so the result is exactly what a normal
+ * sign-in verifies against. Existing sessions are revoked, because a password
+ * reset that leaves old sessions alive is not a reset.
+ */
+
+import 'dotenv/config';
+import { createClient } from '@libsql/client';
+import { betterAuth } from 'better-auth';
+import { randomBytes } from 'node:crypto';
+
+const GENERATED_PASSWORD_BYTES = 12;
+const MIN_PASSWORD_LENGTH = 8;
+
+const DB_URL = process.env.DB_FILE_NAME ?? 'file:storage/local.db';
+
+const usage = () => {
+  console.log(`
+Set a new password for an account.
+
+  node reset-password.mjs
+  node reset-password.mjs --password '<new password>'
+  node reset-password.mjs <email>
+  node reset-password.mjs --list
+
+This instance holds a single account, so the email may be omitted. Without
+--password a strong one is generated and printed once.
+`);
+};
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+  usage();
+  process.exit(0);
+}
+
+const client = createClient({ url: DB_URL });
+
+const tableExists = async (name) => {
+  const result = await client.execute({
+    sql: "select name from sqlite_master where type='table' and name=?",
+    args: [name],
+  });
+  return result.rows.length > 0;
+};
+
+if (!(await tableExists('users')) || !(await tableExists('accounts'))) {
+  console.error(
+    `\n  No WordyMe database at ${DB_URL}.\n\n  Point DB_FILE_NAME at the database this instance uses and run again.\n`,
+  );
+  process.exit(1);
+}
+
+if (args.includes('--list')) {
+  const users = await client.execute(
+    'select u.email, u.name, (select count(*) from accounts a where a.user_id = u.id and a.provider_id = ?) as credentials from users u order by u.email',
+    ['credential'],
+  );
+
+  if (users.rows.length === 0) {
+    console.log('\n  No accounts exist yet. Open the app and sign up.\n');
+    process.exit(0);
+  }
+
+  console.log('\n  Accounts:\n');
+  for (const row of users.rows) {
+    const suffix = Number(row.credentials) > 0 ? '' : '  (no password sign-in)';
+    console.log(`    ${row.email}   ${row.name ?? ''}${suffix}`);
+  }
+  console.log('');
+  process.exit(0);
+}
+
+const passwordIndex = args.indexOf('--password');
+const provided = passwordIndex === -1 ? null : args[passwordIndex + 1];
+
+if (passwordIndex !== -1 && !provided) {
+  console.error('\n  --password needs a value.\n');
+  process.exit(1);
+}
+
+if (provided && provided.length < MIN_PASSWORD_LENGTH) {
+  console.error(`\n  That password is shorter than ${MIN_PASSWORD_LENGTH} characters.\n`);
+  process.exit(1);
+}
+
+const email = args.find((value, index) => !value.startsWith('--') && index !== passwordIndex + 1);
+
+const users = email
+  ? await client.execute({
+      sql: 'select id, email from users where email = ? collate nocase',
+      args: [email],
+    })
+  : await client.execute('select id, email from users');
+
+if (users.rows.length === 0) {
+  console.error(
+    email
+      ? `\n  No account with the email ${email}.\n  Run with --list to see the accounts on this instance.\n`
+      : '\n  This instance has no accounts yet. Open the app and sign up.\n',
+  );
+  process.exit(1);
+}
+
+if (!email && users.rows.length > 1) {
+  console.error('\n  This instance has more than one account. Name the one to reset:\n');
+  for (const row of users.rows) console.error(`    ${row.email}`);
+  console.error('');
+  process.exit(1);
+}
+
+const user = users.rows[0];
+
+const accounts = await client.execute({
+  sql: 'select id from accounts where user_id = ? and provider_id = ?',
+  args: [user.id, 'credential'],
+});
+
+const password = provided ?? randomBytes(GENERATED_PASSWORD_BYTES).toString('base64url');
+
+const auth = betterAuth({
+  baseURL: 'http://localhost',
+  emailAndPassword: { enabled: true },
+});
+const context = await auth.$context;
+const hash = await context.password.hash(password);
+const now = Date.now();
+
+if (accounts.rows.length === 0) {
+  await client.execute({
+    sql: 'insert into accounts (id, account_id, provider_id, user_id, password, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?)',
+    args: [crypto.randomUUID(), user.id, 'credential', user.id, hash, now, now],
+  });
+  console.log('\n  That account had no password sign-in; one has been added.');
+} else {
+  await client.execute({
+    sql: 'update accounts set password = ?, updated_at = ? where id = ?',
+    args: [hash, now, accounts.rows[0].id],
+  });
+}
+
+const sessions = await client.execute({
+  sql: 'delete from sessions where user_id = ?',
+  args: [user.id],
+});
+
+console.log(`\n  Password updated for ${user.email}.`);
+if (!provided) console.log(`\n    New password:  ${password}\n`);
+console.log(`  ${sessions.rowsAffected} existing session(s) signed out.\n`);
+process.exit(0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line password reset tool for self-hosted installations.
  * Supports account listing, email selection, generated passwords, and secure password input through standard input.
  * Validates passwords and database access, updates credentials, and signs out existing sessions after a reset.
  * Includes the tool in the Docker image for easier access.

* **Documentation**
  * Updated Docker password-reset instructions to use `--password-stdin`, helping prevent passwords from appearing in shell history or process listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->