### PR TITLE
docs(readme): make the header badges clickable links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 </h1>
 
 <p align="center">
-<img src="https://img.shields.io/badge/Made%20by-TeamCoderz%20Ltd-orange" alt="Made by TeamCoderz Ltd">
-<img src="https://img.shields.io/docker/pulls/teamcoderz/wordyme?color=2496ED&label=Docker%20pulls" alt="Docker pulls">
-<img src="https://img.shields.io/badge/PRs-Welcome-brightgreen" alt="PRs Welcome">
-<img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg" alt="License: AGPL-3.0">
+<a href="https://teamcoderz.org"><img src="https://img.shields.io/badge/Made%20by-TeamCoderz%20Ltd-orange" alt="Made by TeamCoderz Ltd"></a>
+<a href="https://hub.docker.com/r/teamcoderz/wordyme"><img src="https://img.shields.io/docker/pulls/teamcoderz/wordyme?color=2496ED&label=Docker%20pulls" alt="Docker pulls"></a>
+<a href="https://github.com/TeamCoderz/WordyMe?tab=contributing-ov-file"><img src="https://img.shields.io/badge/PRs-Welcome-brightgreen" alt="PRs Welcome"></a>
+<a href="https://github.com/TeamCoderz/WordyMe?tab=AGPL-3.0-1-ov-file"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg" alt="License: AGPL-3.0"></a>
 <a href="https://wordy.me/try-demo"><img src="https://img.shields.io/badge/Live%20Demo-Try%20it-brightgreen" alt="Live Demo"></a>
 </p>
 


### PR DESCRIPTION
## Summary

The four static badges at the top of the README (Made by TeamCoderz, Docker pulls, PRs Welcome, License) rendered as plain images - clicking them did nothing, while the Live Demo badge beside them was already a link. This wraps each badge in an anchor pointing at its natural destination, so the whole badge row behaves consistently and each badge leads somewhere useful.

## Related Issues

None - small standalone documentation fix.

## Type of Change

Documentation

## Changes

- **Made by TeamCoderz Ltd** badge now links to <https://teamcoderz.org>
- **Docker pulls** badge now links to the image's Docker Hub page (<https://hub.docker.com/r/teamcoderz/wordyme>)
- **PRs Welcome** badge now links to the repository's Contributing tab
- **License AGPL-3.0** badge now links to the repository's License tab
- No badge images, labels, or colors changed - only `<a>` wrappers were added, matching the pattern the Live Demo badge already used

## How to Test

1. Open the README on this branch.
2. Click each of the five badges in the header row.
3. Confirm each one navigates: TeamCoderz site, Docker Hub image page, Contributing tab, License tab, and the live demo.

**Expected result:** every badge is clickable and lands on its destination. All four new targets were verified to return HTTP 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README badges to link directly to the organization page, Docker Hub, contribution guidelines, and license information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->