### PR TITLE
docs(dockerhub): add the badge row to the Docker Hub landing page

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,5 +1,11 @@
 # WordyMe
 
+[![Made by TeamCoderz Ltd](https://img.shields.io/badge/Made%20by-TeamCoderz%20Ltd-orange)](https://teamcoderz.org)
+[![Docker pulls](https://img.shields.io/docker/pulls/teamcoderz/wordyme?color=2496ED&label=Docker%20pulls)](https://hub.docker.com/r/teamcoderz/wordyme/tags)
+[![PRs Welcome](https://img.shields.io/badge/PRs-Welcome-brightgreen)](https://github.com/TeamCoderz/WordyMe?tab=contributing-ov-file)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://github.com/TeamCoderz/WordyMe?tab=AGPL-3.0-1-ov-file)
+[![Live Demo](https://img.shields.io/badge/Live%20Demo-Try%20it-brightgreen)](https://wordy.me/try-demo)
+
 **A lightweight personal wiki you can self-host anywhere. Even on your Raspberry Pi.**
 
 WordyMe is a self-hosted personal wiki and note-taking app: rich documents with diagram (Mermaid), math (KaTeX) and music-notation support, organized into spaces, with revision history, favorites and real-time updates.


### PR DESCRIPTION
## Summary

`DOCKERHUB.md` is the page published as the Docker Hub listing for `teamcoderz/wordyme` — the first thing a stranger reads when deciding whether to pull the image. It had no badges at all, so the license, the pull count and the live demo that the GitHub README leads with were invisible to exactly the audience most likely to act on them. This adds the same five badges the README carries, so both landing pages present the same identity.

## Related Issues

None — small standalone documentation change.

## Type of Change

Documentation

## Changes

- Added a five-badge row directly under the `# WordyMe` heading: **Made by TeamCoderz Ltd**, **Docker pulls**, **PRs Welcome**, **License AGPL-3.0**, **Live Demo**
- Written in **plain Markdown image-links**, not the HTML the README uses. Docker Hub's description renderer is much stricter with raw HTML than GitHub's, so an HTML badge row risks rendering as literal text on the one page it is meant for. The trade-off is that the row is left-aligned rather than centred — Markdown has no centring, and a broken row would be worse than an off-centre one.
- The **Docker pulls** badge links to the image's **tags** page rather than its main page. On Docker Hub the main page is the page the reader is already on; tags is a useful destination in both contexts.
- No prose, headings, or existing links were touched — the diff is six added lines.

## How to Test

1. Check out this branch and open `DOCKERHUB.md`. In VS Code, press **Cmd/Ctrl+Shift+V** for the rendered preview.
2. Confirm the badge row renders as five shields under the title, above the "lightweight personal wiki" tagline, and that the Docker pulls badge shows a live count.
3. Click each badge and confirm the destination: TeamCoderz site, Docker Hub tags, Contributing tab, License tab, live demo.
4. Run `pnpm lint:md` and `pnpm exec prettier --check DOCKERHUB.md`.

**Expected result:** five working badges; `markdownlint` reports 0 issues across all files; Prettier reports no formatting changes. All five link targets were verified to return HTTP 200, and the pull-count badge currently renders "1.4k".

## Note for reviewers

Merging this does not update the Docker Hub page by itself. The listing is pushed by `release-publish.yml` (`Sync the Docker Hub listing`, `continue-on-error`), so the badges appear on Docker Hub at the **next release publish**; `verify-publishing.yml` exercises the same sync step fatally beforehand. The file stays far below Docker Hub's 25,000-byte listing cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added badges to the Docker Hub documentation for project maintenance, Docker pulls, contributions, licensing, and the live demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->