### PR TITLE
fix(pdf): give the PDFium worker an absolute wasm URL

### DIFF
--- a/packages/embed-pdf/src/viewer.tsx
+++ b/packages/embed-pdf/src/viewer.tsx
@@ -90,9 +90,12 @@ export interface PDFViewerProps {
   url: string;
 }
 
+const absoluteAssetUrl = (assetUrl: string) =>
+  typeof window === 'undefined' ? assetUrl : new URL(assetUrl, window.location.origin).href;
+
 export function PDFViewer({ url }: PDFViewerProps) {
   const { engine, isLoading, error } = usePdfiumEngine({
-    wasmUrl: pdfiumWasmUrl,
+    wasmUrl: absoluteAssetUrl(pdfiumWasmUrl),
     fontFallback: pdfFontFallback,
     worker: !import.meta.env.DEV,
   });


### PR DESCRIPTION
## What

The PDF viewer never loaded in the published image — it sat on "Loading document…" forever, with no error. Dev worked fine. One-line cause, one-line fix.

## Why it only broke in production

`packages/embed-pdf/src/viewer.tsx` runs the PDFium engine in a Blob-based Web Worker in production only:

```ts
worker: !import.meta.env.DEV   // false in dev, true in prod
wasmUrl: pdfiumWasmUrl         // "/assets/pdfium-<hash>.wasm"
```

A blob worker has an **opaque origin**, so it has no base URL to resolve a root-relative path against. The wasm fetch throws inside the worker before PDFium ever initialises, which is why the spinner never resolves and nothing is logged in the page console.

Dev is unaffected because `worker: false` means the main thread does the fetch, where `/assets/…` resolves normally.

## Evidence

Measured in a running container, same URL from two contexts:

| Context | Result |
| --- | --- |
| Page fetch | 200, `application/wasm`, 4,633,788 bytes |
| Blob worker, root-relative | `TypeError: Failed to parse URL from /assets/pdfium-<hash>.wasm` |
| Blob worker, absolute | 200, 4,633,788 bytes |

Assets and headers were already correct — the wasm, the worker chunk and the PDF itself all return 200 with the right content types, so this was never a serving problem.

## Verification

Built the image from source via `docker compose build` and loaded a PDF attachment end to end. Before: infinite "Loading document…". After: the page renders, toolbar reports `/ 1` pages, page text legible.

Confirmed the change is inert in dev — the converted URL is byte-identical there and still fetches 200:

```
relative: /@fs/…/@embedpdf/pdfium/dist/pdfium.wasm
absolute: http://localhost:5173/@fs/…/@embedpdf/pdfium/dist/pdfium.wasm
identical: yes   fetch: 200, 4633788 bytes
```

Gate: 9/9 type-check, 9/9 lint, SPDX, format.

## Noted while debugging, not fixed here

The container logs repeated `Failed to register a ServiceWorker … unknown error occurred when fetching the script` for `registerSW.js` on every page load. Unrelated to PDFs, worth its own issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF viewer loading by resolving the PDF rendering asset correctly in browser environments.
  * Preserved server-side rendering compatibility for PDF asset URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->