### PR TITLE
feat(sidebar): colored folder icons, opt-in via preferences

### DIFF
--- a/apps/backend/drizzle/0006_folder_color.sql
+++ b/apps/backend/drizzle/0006_folder_color.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `documents` ADD `color` text;

--- a/apps/backend/drizzle/meta/0006_snapshot.json
+++ b/apps/backend/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1228 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c9b3ccde-8d42-41ef-b324-6b2794e3e7fa",
+  "prevId": "d1ee3feb-ad88-4aab-8b4b-0243be38bec0",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_meta": {
+          "name": "image_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "cover_meta": {
+          "name": "cover_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "backup_restores": {
+      "name": "backup_restores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'note'"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_container": {
+          "name": "is_container",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "documents_user_id_idx": {
+          "name": "documents_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "documents_parent_id_idx": {
+          "name": "documents_parent_id_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "documents_space_id_idx": {
+          "name": "documents_space_id_idx",
+          "columns": [
+            "space_id"
+          ],
+          "isUnique": false
+        },
+        "documents_handle_idx": {
+          "name": "documents_handle_idx",
+          "columns": [
+            "handle"
+          ],
+          "isUnique": false
+        },
+        "documents_current_revision_id_idx": {
+          "name": "documents_current_revision_id_idx",
+          "columns": [
+            "current_revision_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "documents_current_revision_id_revisions_id_fk": {
+          "name": "documents_current_revision_id_revisions_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "revisions",
+          "columnsFrom": [
+            "current_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "documents_user_id_users_id_fk": {
+          "name": "documents_user_id_users_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "documents_parent_id_documents_id_fk": {
+          "name": "documents_parent_id_documents_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "documents_space_id_documents_id_fk": {
+          "name": "documents_space_id_documents_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "document_views": {
+      "name": "document_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "document_views_user_document_index": {
+          "name": "document_views_user_document_index",
+          "columns": [
+            "user_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "document_views_user_id_users_id_fk": {
+          "name": "document_views_user_id_users_id_fk",
+          "tableFrom": "document_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "document_views_document_id_documents_id_fk": {
+          "name": "document_views_document_id_documents_id_fk",
+          "tableFrom": "document_views",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "editor_settings": {
+      "name": "editor_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keep_previous_revision": {
+          "name": "keep_previous_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "autosave": {
+          "name": "autosave",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "editor_settings_user_id_unique": {
+          "name": "editor_settings_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "editor_settings_user_id_users_id_fk": {
+          "name": "editor_settings_user_id_users_id_fk",
+          "tableFrom": "editor_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "favorites": {
+      "name": "favorites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "favorites_user_document_unique": {
+          "name": "favorites_user_document_unique",
+          "columns": [
+            "user_id",
+            "document_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "favorites_document_id_documents_id_fk": {
+          "name": "favorites_document_id_documents_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_images": {
+      "name": "user_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_type": {
+          "name": "image_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "zoom": {
+          "name": "zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_images_user_id_users_id_fk": {
+          "name": "user_images_user_id_users_id_fk",
+          "tableFrom": "user_images",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "revisions": {
+      "name": "revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision_name": {
+          "name": "revision_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "revisions_document_id_created_at_idx": {
+          "name": "revisions_document_id_created_at_idx",
+          "columns": [
+            "document_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "revisions_user_id_idx": {
+          "name": "revisions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "revisions_document_id_documents_id_fk": {
+          "name": "revisions_document_id_documents_id_fk",
+          "tableFrom": "revisions",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "revisions_user_id_users_id_fk": {
+          "name": "revisions_user_id_users_id_fk",
+          "tableFrom": "revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "document_search_index": {
+      "name": "document_search_index",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "document_search_index_document_id_unique": {
+          "name": "document_search_index_document_id_unique",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": true
+        },
+        "document_search_index_user_id_idx": {
+          "name": "document_search_index_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "document_search_index_current_revision_id_idx": {
+          "name": "document_search_index_current_revision_id_idx",
+          "columns": [
+            "current_revision_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "document_search_index_document_id_documents_id_fk": {
+          "name": "document_search_index_document_id_documents_id_fk",
+          "tableFrom": "document_search_index",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "document_search_index_user_id_users_id_fk": {
+          "name": "document_search_index_user_id_users_id_fk",
+          "tableFrom": "document_search_index",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "document_search_index_current_revision_id_revisions_id_fk": {
+          "name": "document_search_index_current_revision_id_revisions_id_fk",
+          "tableFrom": "document_search_index",
+          "tableTo": "revisions",
+          "columnsFrom": [
+            "current_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1786906560166,
       "tag": "0005_backup_restore_journal",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1787337687801,
+      "tag": "0006_folder_color",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/models/documents.ts
+++ b/apps/backend/src/models/documents.ts
@@ -28,6 +28,7 @@ export const documentsTable = sqliteTable(
     name: text('name').notNull(),
     handle: text('handle').notNull(),
     icon: text('icon'),
+    color: text('color'),
     position: text('position'),
     currentRevisionId: text('current_revision_id').references(
       (): SQLiteColumn => revisionsTable.id,

--- a/apps/web/src/components/Layout/document-tree/ContainerDocumentItem.tsx
+++ b/apps/web/src/components/Layout/document-tree/ContainerDocumentItem.tsx
@@ -8,8 +8,10 @@
 import * as React from 'react';
 import {
   ChevronRight,
+  CircleOff,
   FilePlus,
   FolderPlus,
+  Palette,
   PencilLine,
   Repeat2,
   Settings2,
@@ -40,12 +42,15 @@ import {
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import {
   useUpdateDocumentIconMutation,
+  useUpdateDocumentColorMutation,
   useDeleteDocumentMutation,
   useDuplicateDocumentMutation,
   useCopyDocumentMutation,
   useMoveDocumentMutation,
   useExportDocumentMutation,
 } from '@/queries/documents';
+import { useTheme } from '@repo/ui/theme/theme-provider';
+import { THEME_BY_VALUE } from '@repo/ui/theme/themes';
 import { alert } from '../alert';
 import { cachedDocuments } from '@/queries/caches/documents';
 import {
@@ -90,6 +95,7 @@ export function ContainerDocumentItem({
   // Export document mutation
   const exportDocumentMutation = useExportDocumentMutation(document.id, document.name);
   const [isIconPickerOpen, setIsIconPickerOpen] = React.useState(false);
+  const [isColorPickerOpen, setIsColorPickerOpen] = React.useState(false);
   const navigate = useNavigate();
   const [isRenaming, setIsRenaming] = React.useState(false);
   // Note: container items are not links; click toggles expand/collapse
@@ -105,6 +111,18 @@ export function ContainerDocumentItem({
   const { updateDocumentIcon } = useUpdateDocumentIconMutation({
     document: document as any, // Cast to match ListDocumentResult type
   });
+
+  const { updateDocumentColor } = useUpdateDocumentColorMutation({
+    document: document as any,
+  });
+
+  const folderColorsEnabled = useSelector((state) => state.ui.folderColorsEnabled);
+  const folderDefaultColor = useSelector((state) => state.ui.folderDefaultColor);
+  const folderColor = folderColorsEnabled
+    ? (document.color ?? (folderDefaultColor === 'theme' ? null : folderDefaultColor))
+    : null;
+  const { theme } = useTheme();
+  const colorVariants = THEME_BY_VALUE[theme]['color-variants'];
 
   // Use the delete document mutation
   const deleteDocumentMutation = useDeleteDocumentMutation({
@@ -227,6 +245,24 @@ export function ContainerDocumentItem({
   const handleIconChange = (newIcon: string) => {
     try {
       updateDocumentIcon(document.id, newIcon);
+    } catch {
+      // Error handling is done in the mutation
+    } finally {
+      contextMenuContentRef.current?.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          code: 'Escape',
+          keyCode: 27,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    }
+  };
+
+  const handleColorChange = (newColor: string | null) => {
+    try {
+      updateDocumentColor(document.id, newColor);
     } catch {
       // Error handling is done in the mutation
     } finally {
@@ -368,6 +404,7 @@ export function ContainerDocumentItem({
           onOpenChange={(open) => {
             if (open) {
               setIsIconPickerOpen(false);
+              setIsColorPickerOpen(false);
             }
           }}
         >
@@ -393,8 +430,16 @@ export function ContainerDocumentItem({
               >
                 <ChevronRight className="transition-transform" />
 
-                <div className="flex items-center justify-center p-0.5 rounded-sm">
-                  <DynamicIcon name={document.icon || 'file'} className="size-4" />
+                <div
+                  className={cn(
+                    'flex items-center justify-center p-0.5 rounded-sm',
+                    folderColor && `color-${folderColor}`,
+                  )}
+                >
+                  <DynamicIcon
+                    name={document.icon || 'file'}
+                    className={cn('size-4', folderColorsEnabled && 'text-primary')}
+                  />
                 </div>
                 <span title={document.name} className="truncate text-sm flex-1 min-w-0">
                   {document.name}
@@ -454,6 +499,34 @@ export function ContainerDocumentItem({
                 inPlace
                 searchable
               />
+            ) : isColorPickerOpen ? (
+              <div className="flex items-center gap-1.5 p-1">
+                <button
+                  type="button"
+                  title="Default"
+                  onClick={() => handleColorChange(null)}
+                  className={cn(
+                    'flex size-6 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground hover:text-foreground',
+                    !document.color && 'ring-2 ring-ring ring-offset-1 ring-offset-background',
+                  )}
+                >
+                  <CircleOff className="size-3.5" />
+                </button>
+                {colorVariants.map((variant) => (
+                  <div key={variant.value} className={`color-${variant.value}`}>
+                    <button
+                      type="button"
+                      title={variant.name}
+                      onClick={() => handleColorChange(variant.value)}
+                      className={cn(
+                        'size-6 shrink-0 rounded-full border border-border bg-primary',
+                        document.color === variant.value &&
+                          'ring-2 ring-ring ring-offset-1 ring-offset-background',
+                      )}
+                    />
+                  </div>
+                ))}
+              </div>
             ) : (
               <>
                 <ContextMenuItem
@@ -504,6 +577,19 @@ export function ContainerDocumentItem({
                   <Repeat2 className="mr-2 h-4 w-4 group-hover:text-foreground" />
                   Change Icon
                 </ContextMenuItem>
+                {folderColorsEnabled && (
+                  <ContextMenuItem
+                    className="group"
+                    onSelect={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setIsColorPickerOpen(true);
+                    }}
+                  >
+                    <Palette className="mr-2 h-4 w-4 group-hover:text-foreground" />
+                    Change Color
+                  </ContextMenuItem>
+                )}
                 <ContextMenuItem
                   className="group"
                   onSelect={() => {

--- a/apps/web/src/components/Layout/document-tree/ContainerDocumentItem.tsx
+++ b/apps/web/src/components/Layout/document-tree/ContainerDocumentItem.tsx
@@ -124,7 +124,7 @@ export function ContainerDocumentItem({
     iconClass: folderIconClass,
   } = useFolderIconColor(document);
   const { theme } = useTheme();
-  const colorVariants = THEME_BY_VALUE[theme]['color-variants'];
+  const colorVariants = THEME_BY_VALUE[theme]?.['color-variants'] ?? [];
 
   // Use the delete document mutation
   const deleteDocumentMutation = useDeleteDocumentMutation({
@@ -507,6 +507,8 @@ export function ContainerDocumentItem({
                   <Button
                     variant={'default'}
                     title="Default"
+                    aria-label="Default"
+                    aria-pressed={!document.color}
                     onClick={() => handleColorChange(null)}
                     className="flex h-full w-full items-center justify-center p-0"
                   >
@@ -522,6 +524,8 @@ export function ContainerDocumentItem({
                     <Button
                       variant={'default'}
                       title={variant.name}
+                      aria-label={variant.name}
+                      aria-pressed={document.color === variant.value}
                       onClick={() => handleColorChange(variant.value)}
                       className="flex h-full w-full items-center justify-center p-0"
                     >

--- a/apps/web/src/components/Layout/document-tree/ContainerDocumentItem.tsx
+++ b/apps/web/src/components/Layout/document-tree/ContainerDocumentItem.tsx
@@ -51,6 +51,7 @@ import {
 } from '@/queries/documents';
 import { useTheme } from '@repo/ui/theme/theme-provider';
 import { THEME_BY_VALUE } from '@repo/ui/theme/themes';
+import { useFolderIconColor } from '@/hooks/use-folder-icon-color';
 import { alert } from '../alert';
 import { cachedDocuments } from '@/queries/caches/documents';
 import {
@@ -116,12 +117,11 @@ export function ContainerDocumentItem({
     document: document as any,
   });
 
-  const folderColorsEnabled = useSelector((state) => state.ui.folderColorsEnabled);
-  const folderDefaultColor = useSelector((state) => state.ui.folderDefaultColor);
-  const folderColorSolid = useSelector((state) => state.ui.folderColorSolid);
-  const folderColor = folderColorsEnabled
-    ? (document.color ?? (folderDefaultColor === 'theme' ? null : folderDefaultColor))
-    : null;
+  const {
+    enabled: folderColorsEnabled,
+    wrapperClass: folderColorClass,
+    iconClass: folderIconClass,
+  } = useFolderIconColor(document);
   const { theme } = useTheme();
   const colorVariants = THEME_BY_VALUE[theme]['color-variants'];
 
@@ -434,16 +434,12 @@ export function ContainerDocumentItem({
                 <div
                   className={cn(
                     'flex items-center justify-center p-0.5 rounded-sm',
-                    folderColor && `color-${folderColor}`,
+                    folderColorClass,
                   )}
                 >
                   <DynamicIcon
                     name={document.icon || 'file'}
-                    className={cn(
-                      'size-4',
-                      folderColorsEnabled && 'text-primary',
-                      folderColorsEnabled && folderColorSolid && 'fill-current',
-                    )}
+                    className={cn('size-4', folderIconClass)}
                   />
                 </div>
                 <span title={document.name} className="truncate text-sm flex-1 min-w-0">

--- a/apps/web/src/components/Layout/document-tree/ContainerDocumentItem.tsx
+++ b/apps/web/src/components/Layout/document-tree/ContainerDocumentItem.tsx
@@ -118,6 +118,7 @@ export function ContainerDocumentItem({
 
   const folderColorsEnabled = useSelector((state) => state.ui.folderColorsEnabled);
   const folderDefaultColor = useSelector((state) => state.ui.folderDefaultColor);
+  const folderColorSolid = useSelector((state) => state.ui.folderColorSolid);
   const folderColor = folderColorsEnabled
     ? (document.color ?? (folderDefaultColor === 'theme' ? null : folderDefaultColor))
     : null;
@@ -438,7 +439,11 @@ export function ContainerDocumentItem({
                 >
                   <DynamicIcon
                     name={document.icon || 'file'}
-                    className={cn('size-4', folderColorsEnabled && 'text-primary')}
+                    className={cn(
+                      'size-4',
+                      folderColorsEnabled && 'text-primary',
+                      folderColorsEnabled && folderColorSolid && 'fill-current',
+                    )}
                   />
                 </div>
                 <span title={document.name} className="truncate text-sm flex-1 min-w-0">

--- a/apps/web/src/components/Layout/document-tree/ContainerDocumentItem.tsx
+++ b/apps/web/src/components/Layout/document-tree/ContainerDocumentItem.tsx
@@ -22,6 +22,7 @@ import {
   CopyPlus,
   FolderOutput,
 } from '@repo/ui/components/icons';
+import { Button } from '@repo/ui/components/button';
 import { DynamicIcon } from '@repo/ui/components/dynamic-icon';
 import { cn } from '@repo/ui/lib/utils';
 import { DocumentData } from './types';
@@ -502,29 +503,30 @@ export function ContainerDocumentItem({
               />
             ) : isColorPickerOpen ? (
               <div className="flex items-center gap-1.5 p-1">
-                <button
-                  type="button"
-                  title="Default"
-                  onClick={() => handleColorChange(null)}
-                  className={cn(
-                    'flex size-6 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground hover:text-foreground',
-                    !document.color && 'ring-2 ring-ring ring-offset-1 ring-offset-background',
-                  )}
-                >
-                  <CircleOff className="size-3.5" />
-                </button>
+                <div className="size-6 shrink-0">
+                  <Button
+                    variant={'default'}
+                    title="Default"
+                    onClick={() => handleColorChange(null)}
+                    className="flex h-full w-full items-center justify-center p-0"
+                  >
+                    {!document.color ? (
+                      <CircleOff className="size-3.5" />
+                    ) : (
+                      <Palette className="size-3.5" />
+                    )}
+                  </Button>
+                </div>
                 {colorVariants.map((variant) => (
-                  <div key={variant.value} className={`color-${variant.value}`}>
-                    <button
-                      type="button"
+                  <div key={variant.value} className={`color-${variant.value} size-6 shrink-0`}>
+                    <Button
+                      variant={'default'}
                       title={variant.name}
                       onClick={() => handleColorChange(variant.value)}
-                      className={cn(
-                        'size-6 shrink-0 rounded-full border border-border bg-primary',
-                        document.color === variant.value &&
-                          'ring-2 ring-ring ring-offset-1 ring-offset-background',
-                      )}
-                    />
+                      className="flex h-full w-full items-center justify-center p-0"
+                    >
+                      {document.color === variant.value && <CircleOff className="size-3.5" />}
+                    </Button>
                   </div>
                 ))}
               </div>

--- a/apps/web/src/components/Layout/document-tree/index.tsx
+++ b/apps/web/src/components/Layout/document-tree/index.tsx
@@ -69,6 +69,7 @@ export function DocumentTree() {
         parentId: resolvedParentId,
         spaceId,
         createdAt: new Date(),
+        color: null,
         isFavorite: false,
         isContainer: params.type === 'folder',
         updatedAt: new Date(),

--- a/apps/web/src/components/Layout/space-switcher/SpaceSwitcher.tsx
+++ b/apps/web/src/components/Layout/space-switcher/SpaceSwitcher.tsx
@@ -181,6 +181,7 @@ export function SpaceSwitcher() {
         parentId: resolvedParentId,
         spaceId: null,
         createdAt: new Date(),
+        color: null,
         isFavorite: false,
         isContainer: params.type === 'folder',
         updatedAt: new Date(),

--- a/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
+++ b/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
@@ -138,7 +138,7 @@ function InterfacePreferencesSettings() {
             <div>
               <Label htmlFor="folderColorSolid">Solid Folder Color</Label>
               <p className="text-sm text-muted-foreground">
-                Fill folder icons instead of coloring only the outline
+                Fill folder icons instead of coloring only the outline - some icons may look chunky
               </p>
             </div>
             <Switch

--- a/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
+++ b/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
@@ -25,8 +25,14 @@ function InterfacePreferencesSettings() {
   const documentSidebar = useSelector((state) => state.ui.documentSidebar);
   const folderColorsEnabled = useSelector((state) => state.ui.folderColorsEnabled);
   const folderDefaultColor = useSelector((state) => state.ui.folderDefaultColor);
-  const { setAppSidebar, setDocumentSidebar, setFolderColorsEnabled, setFolderDefaultColor } =
-    useActions();
+  const folderColorSolid = useSelector((state) => state.ui.folderColorSolid);
+  const {
+    setAppSidebar,
+    setDocumentSidebar,
+    setFolderColorsEnabled,
+    setFolderDefaultColor,
+    setFolderColorSolid,
+  } = useActions();
   const { animations, setAnimations, theme } = useTheme();
   const colorVariants = THEME_BY_VALUE[theme]['color-variants'];
   return (
@@ -126,6 +132,22 @@ function InterfacePreferencesSettings() {
             onCheckedChange={setFolderColorsEnabled}
           />
         </div>
+
+        {folderColorsEnabled && (
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="folderColorSolid">Solid Folder Color</Label>
+              <p className="text-sm text-muted-foreground">
+                Fill folder icons instead of coloring only the outline
+              </p>
+            </div>
+            <Switch
+              id="folderColorSolid"
+              checked={folderColorSolid}
+              onCheckedChange={setFolderColorSolid}
+            />
+          </div>
+        )}
 
         {folderColorsEnabled && (
           <div className="flex items-center justify-between flex-wrap gap-3">

--- a/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
+++ b/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useActions, useSelector } from '@/store';
+import { Button } from '@repo/ui/components/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@repo/ui/components/card';
 import { Label } from '@repo/ui/components/label';
 import {
@@ -18,7 +19,13 @@ import { Switch } from '@repo/ui/components/switch';
 import { useTheme } from '@repo/ui/theme/theme-provider';
 import { THEME_BY_VALUE } from '@repo/ui/theme/themes';
 import { cn } from '@repo/ui/lib/utils';
-import { FoldHorizontal, Palette, RefreshCcw, UnfoldHorizontal } from '@repo/ui/components/icons';
+import {
+  CircleOff,
+  FoldHorizontal,
+  Palette,
+  RefreshCcw,
+  UnfoldHorizontal,
+} from '@repo/ui/components/icons';
 
 function InterfacePreferencesSettings() {
   const appSidebar = useSelector((state) => state.ui.appSidebar);
@@ -158,30 +165,26 @@ function InterfacePreferencesSettings() {
               </p>
             </div>
             <div className="flex gap-2 overflow-auto">
-              <button
-                type="button"
-                title="Theme"
-                onClick={() => setFolderDefaultColor('theme')}
-                className={cn(
-                  'flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-primary',
-                  folderDefaultColor === 'theme' &&
-                    'ring-2 ring-ring ring-offset-2 ring-offset-background',
-                )}
-              >
-                <Palette className="size-4 text-primary-foreground" />
-              </button>
+              <div className="w-8 h-8">
+                <Button
+                  variant={'default'}
+                  title="Theme"
+                  onClick={() => setFolderDefaultColor('theme')}
+                  className={cn('flex flex-col items-center gap-1 h-full py-3 w-full relative')}
+                >
+                  {folderDefaultColor === 'theme' ? <CircleOff /> : <Palette />}
+                </Button>
+              </div>
               {colorVariants.map((variant) => (
-                <div key={variant.value} className={`color-${variant.value}`}>
-                  <button
-                    type="button"
+                <div key={variant.value} className={`color-${variant.value} w-8 h-8`}>
+                  <Button
+                    variant={'default'}
                     title={variant.name}
                     onClick={() => setFolderDefaultColor(variant.value)}
-                    className={cn(
-                      'size-8 shrink-0 rounded-md border border-border bg-primary',
-                      folderDefaultColor === variant.value &&
-                        'ring-2 ring-ring ring-offset-2 ring-offset-background',
-                    )}
-                  />
+                    className={cn('flex flex-col items-center gap-1 h-full py-3 w-full relative')}
+                  >
+                    {folderDefaultColor === variant.value && <CircleOff />}
+                  </Button>
                 </div>
               ))}
             </div>

--- a/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
+++ b/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
@@ -16,13 +16,19 @@ import {
 import { Separator } from '@repo/ui/components/separator';
 import { Switch } from '@repo/ui/components/switch';
 import { useTheme } from '@repo/ui/theme/theme-provider';
-import { FoldHorizontal, RefreshCcw, UnfoldHorizontal } from '@repo/ui/components/icons';
+import { THEME_BY_VALUE } from '@repo/ui/theme/themes';
+import { cn } from '@repo/ui/lib/utils';
+import { FoldHorizontal, Palette, RefreshCcw, UnfoldHorizontal } from '@repo/ui/components/icons';
 
 function InterfacePreferencesSettings() {
   const appSidebar = useSelector((state) => state.ui.appSidebar);
   const documentSidebar = useSelector((state) => state.ui.documentSidebar);
-  const { setAppSidebar, setDocumentSidebar } = useActions();
-  const { animations, setAnimations } = useTheme();
+  const folderColorsEnabled = useSelector((state) => state.ui.folderColorsEnabled);
+  const folderDefaultColor = useSelector((state) => state.ui.folderDefaultColor);
+  const { setAppSidebar, setDocumentSidebar, setFolderColorsEnabled, setFolderDefaultColor } =
+    useActions();
+  const { animations, setAnimations, theme } = useTheme();
+  const colorVariants = THEME_BY_VALUE[theme]['color-variants'];
   return (
     <Card id="interface-preferences" className="bg-transparent p-0 overflow-hidden gap-0">
       <CardHeader className="bg-card border-b p-5 block !pb-5">
@@ -104,6 +110,61 @@ function InterfacePreferencesSettings() {
             onCheckedChange={(checked) => setAnimations(checked ? 'on' : 'off')}
           />
         </div>
+
+        <Separator className="bg-transparent border-t border-dashed h-0" />
+
+        <div className="flex items-center justify-between">
+          <div>
+            <Label htmlFor="folderColors">Colored Folders</Label>
+            <p className="text-sm text-muted-foreground">
+              Folder icons in the sidebar take a color
+            </p>
+          </div>
+          <Switch
+            id="folderColors"
+            checked={folderColorsEnabled}
+            onCheckedChange={setFolderColorsEnabled}
+          />
+        </div>
+
+        {folderColorsEnabled && (
+          <div className="flex items-center justify-between flex-wrap gap-3">
+            <div>
+              <Label>Default Folder Color</Label>
+              <p className="text-sm text-muted-foreground">
+                Folders without their own color use this one
+              </p>
+            </div>
+            <div className="flex gap-2 overflow-auto">
+              <button
+                type="button"
+                title="Theme"
+                onClick={() => setFolderDefaultColor('theme')}
+                className={cn(
+                  'flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-primary',
+                  folderDefaultColor === 'theme' &&
+                    'ring-2 ring-ring ring-offset-2 ring-offset-background',
+                )}
+              >
+                <Palette className="size-4 text-primary-foreground" />
+              </button>
+              {colorVariants.map((variant) => (
+                <div key={variant.value} className={`color-${variant.value}`}>
+                  <button
+                    type="button"
+                    title={variant.name}
+                    onClick={() => setFolderDefaultColor(variant.value)}
+                    className={cn(
+                      'size-8 shrink-0 rounded-md border border-border bg-primary',
+                      folderDefaultColor === variant.value &&
+                        'ring-2 ring-ring ring-offset-2 ring-offset-background',
+                    )}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
+++ b/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
@@ -41,7 +41,7 @@ function InterfacePreferencesSettings() {
     setFolderColorSolid,
   } = useActions();
   const { animations, setAnimations, theme } = useTheme();
-  const colorVariants = THEME_BY_VALUE[theme]['color-variants'];
+  const colorVariants = THEME_BY_VALUE[theme]?.['color-variants'] ?? [];
   return (
     <Card id="interface-preferences" className="bg-transparent p-0 overflow-hidden gap-0">
       <CardHeader className="bg-card border-b p-5 block !pb-5">
@@ -169,6 +169,8 @@ function InterfacePreferencesSettings() {
                 <Button
                   variant={'default'}
                   title="Theme"
+                  aria-label="Theme"
+                  aria-pressed={folderDefaultColor === 'theme'}
                   onClick={() => setFolderDefaultColor('theme')}
                   className={cn('flex flex-col items-center gap-1 h-full py-3 w-full relative')}
                 >
@@ -180,6 +182,8 @@ function InterfacePreferencesSettings() {
                   <Button
                     variant={'default'}
                     title={variant.name}
+                    aria-label={variant.name}
+                    aria-pressed={folderDefaultColor === variant.value}
                     onClick={() => setFolderDefaultColor(variant.value)}
                     className={cn('flex flex-col items-center gap-1 h-full py-3 w-full relative')}
                   >

--- a/apps/web/src/components/documents/manage/TableRow.tsx
+++ b/apps/web/src/components/documents/manage/TableRow.tsx
@@ -65,6 +65,7 @@ import {
   ContextMenuSubTrigger,
 } from '@repo/ui/components/context-menu';
 import { useSelector, useActions } from '@/store';
+import { useFolderIconColor } from '@/hooks/use-folder-icon-color';
 import { useQueryClient } from '@tanstack/react-query';
 import { isDocumentCached } from '@/queries/caches/documents';
 import { ItemInstance } from '@headless-tree/core';
@@ -103,6 +104,9 @@ export function ManageDocumentsTableRow({
   const doc = item.getItemData()?.data as ListDocumentResult[number] & {
     clientId: string | null;
   };
+  const { wrapperClass: folderColorClass, iconClass: folderIconClass } = useFolderIconColor(
+    doc ?? {},
+  );
   const isCreating = doc?.id === doc?.clientId || doc?.id === 'new-doc';
   const isPlaceholder = doc?.id === 'new-doc';
   const [placeholderName, setPlaceholderName] = React.useState<string>(doc?.name ?? '');
@@ -634,7 +638,10 @@ export function ManageDocumentsTableRow({
                   <button
                     type="button"
                     data-icon-trigger="true"
-                    className="flex items-center justify-center p-0.5 hover:bg-accent/50 rounded-sm"
+                    className={cn(
+                      'flex items-center justify-center p-0.5 hover:bg-accent/50 rounded-sm',
+                      folderColorClass,
+                    )}
                     onClick={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
@@ -642,7 +649,7 @@ export function ManageDocumentsTableRow({
                     disabled={isCreating}
                   >
                     <DynamicIcon
-                      className="size-4"
+                      className={cn('size-4', folderIconClass)}
                       name={item.getItemData()?.data.icon || 'file'}
                     />
                   </button>

--- a/apps/web/src/hooks/use-folder-icon-color.ts
+++ b/apps/web/src/hooks/use-folder-icon-color.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { useSelector } from '@/store';
+import { cn } from '@repo/ui/lib/utils';
+
+export function useFolderIconColor(document: {
+  isContainer?: boolean | null;
+  color?: string | null;
+}) {
+  const folderColorsEnabled = useSelector((state) => state.ui.folderColorsEnabled);
+  const folderDefaultColor = useSelector((state) => state.ui.folderDefaultColor);
+  const folderColorSolid = useSelector((state) => state.ui.folderColorSolid);
+
+  const enabled = folderColorsEnabled && document.isContainer === true;
+  const color = enabled
+    ? (document.color ?? (folderDefaultColor === 'theme' ? null : folderDefaultColor))
+    : null;
+
+  return {
+    enabled,
+    wrapperClass: color ? `color-${color}` : undefined,
+    iconClass: enabled ? cn('text-primary', folderColorSolid && 'fill-current') : undefined,
+  };
+}

--- a/apps/web/src/queries/documents.ts
+++ b/apps/web/src/queries/documents.ts
@@ -229,6 +229,8 @@ export const useUpdateDocumentIconMutation = ({
 }) => {
   const queryClient = useQueryClient();
   const invalidate = useAllQueriesInvalidate();
+  const latestIconRequestRef = useRef(0);
+  const iconRequestChainRef = useRef<Promise<unknown>>(Promise.resolve());
   const mutation = useMutation({
     mutationKey: ['updateDocumentIcon'],
     mutationFn: async ({ documentId, icon }: { documentId: string; icon: string }) => {
@@ -256,6 +258,7 @@ export const useUpdateDocumentIconMutation = ({
     },
   });
   const updateDocumentIcon = async (documentId: string, icon: string) => {
+    const requestId = ++latestIconRequestRef.current;
     const oldIcon = document.icon;
 
     queryClient.setQueryData(
@@ -274,25 +277,37 @@ export const useUpdateDocumentIconMutation = ({
       getDocumentByHandleQueryOptions(document.handle).queryKey,
       (old: any) => (old ? { ...old, icon } : old),
     );
-    mutation.mutateAsync(
-      { documentId, icon },
-      {
-        onError: () => {
-          queryClient.setQueryData(
-            getAllDocumentsQueryOptions(document.spaceId!).queryKey,
-            (old: ListDocumentResult) => {
-              return old?.map((document) => {
-                return { ...document, icon: oldIcon };
-              });
-            },
-          );
-          queryClient.setQueryData(
-            getDocumentByHandleQueryOptions(document.handle).queryKey,
-            (old: any) => (old ? { ...old, icon: oldIcon } : old),
-          );
+    // Serialize requests per document and skip rollbacks from superseded
+    // requests, so a slow or failing older write cannot clobber a newer pick.
+    const request = iconRequestChainRef.current.then(() =>
+      mutation.mutateAsync(
+        { documentId, icon },
+        {
+          onError: () => {
+            if (requestId !== latestIconRequestRef.current) return;
+            queryClient.setQueryData(
+              getAllDocumentsQueryOptions(document.spaceId!).queryKey,
+              (old: ListDocumentResult) => {
+                return old?.map((document) => {
+                  if (document.id === documentId) {
+                    return { ...document, icon: oldIcon };
+                  }
+                  return document;
+                });
+              },
+            );
+            queryClient.setQueryData(
+              getDocumentByHandleQueryOptions(document.handle).queryKey,
+              (old: any) => (old ? { ...old, icon: oldIcon } : old),
+            );
+          },
         },
-      },
+      ),
     );
+    iconRequestChainRef.current = request.catch(() => undefined);
+    return request.catch(() => {
+      // Error handling is done in the mutation
+    });
   };
   return { updateDocumentIcon, ...mutation };
 };

--- a/apps/web/src/queries/documents.ts
+++ b/apps/web/src/queries/documents.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { useRef } from 'react';
 import {
   keepPreviousData,
   useMutation,
@@ -303,6 +304,8 @@ export const useUpdateDocumentColorMutation = ({
 }) => {
   const queryClient = useQueryClient();
   const invalidate = useAllQueriesInvalidate();
+  const latestColorRequestRef = useRef(0);
+  const colorRequestChainRef = useRef<Promise<unknown>>(Promise.resolve());
   const mutation = useMutation({
     mutationKey: ['updateDocumentColor'],
     mutationFn: async ({ documentId, color }: { documentId: string; color: string | null }) => {
@@ -330,6 +333,7 @@ export const useUpdateDocumentColorMutation = ({
     },
   });
   const updateDocumentColor = async (documentId: string, color: string | null) => {
+    const requestId = ++latestColorRequestRef.current;
     const oldColor = document.color;
 
     queryClient.setQueryData(
@@ -343,11 +347,14 @@ export const useUpdateDocumentColorMutation = ({
         });
       },
     );
-    return mutation
-      .mutateAsync(
+    // Serialize requests per document and skip rollbacks from superseded
+    // requests, so a slow or failing older write cannot clobber a newer pick.
+    const request = colorRequestChainRef.current.then(() =>
+      mutation.mutateAsync(
         { documentId, color },
         {
           onError: () => {
+            if (requestId !== latestColorRequestRef.current) return;
             queryClient.setQueryData(
               getAllDocumentsQueryOptions(document.spaceId!).queryKey,
               (old: ListDocumentResult) => {
@@ -361,10 +368,12 @@ export const useUpdateDocumentColorMutation = ({
             );
           },
         },
-      )
-      .catch(() => {
-        // Error handling is done in the mutation
-      });
+      ),
+    );
+    colorRequestChainRef.current = request.catch(() => undefined);
+    return request.catch(() => {
+      // Error handling is done in the mutation
+    });
   };
   return { updateDocumentColor, ...mutation };
 };

--- a/apps/web/src/queries/documents.ts
+++ b/apps/web/src/queries/documents.ts
@@ -296,6 +296,75 @@ export const useUpdateDocumentIconMutation = ({
   return { updateDocumentIcon, ...mutation };
 };
 
+export const useUpdateDocumentColorMutation = ({
+  document,
+}: {
+  document: ListDocumentResult[number];
+}) => {
+  const queryClient = useQueryClient();
+  const invalidate = useAllQueriesInvalidate();
+  const mutation = useMutation({
+    mutationKey: ['updateDocumentColor'],
+    mutationFn: async ({ documentId, color }: { documentId: string; color: string | null }) => {
+      const { data, error } = await updateDocument(documentId, { color });
+      if (error) throw error;
+      invalidate([
+        DOCUMENTS_QUERY_KEYS.RECENT_VIEWS,
+        DOCUMENTS_QUERY_KEYS.FAVORITES,
+        DOCUMENTS_QUERY_KEYS.HOME.BASE,
+      ]);
+      return data;
+    },
+    onMutate() {
+      return toast.loading('Updating folder color...');
+    },
+    onSuccess: (_, __, toastId) => {
+      toast.success('Folder color updated successfully', {
+        id: toastId,
+      });
+    },
+    onError: (error, __, toastId) => {
+      toast.error(error.message || 'Failed to update folder color', {
+        id: toastId,
+      });
+    },
+  });
+  const updateDocumentColor = async (documentId: string, color: string | null) => {
+    const oldColor = document.color;
+
+    queryClient.setQueryData(
+      getAllDocumentsQueryOptions(document.spaceId!).queryKey,
+      (old: ListDocumentResult) => {
+        return old?.map((document) => {
+          if (document.id === documentId) {
+            return { ...document, color };
+          }
+          return document;
+        });
+      },
+    );
+    mutation.mutateAsync(
+      { documentId, color },
+      {
+        onError: () => {
+          queryClient.setQueryData(
+            getAllDocumentsQueryOptions(document.spaceId!).queryKey,
+            (old: ListDocumentResult) => {
+              return old?.map((document) => {
+                if (document.id === documentId) {
+                  return { ...document, color: oldColor };
+                }
+                return document;
+              });
+            },
+          );
+        },
+      },
+    );
+  };
+  return { updateDocumentColor, ...mutation };
+};
+
 const listFavoriteDocuments = async (
   filters: Omit<Parameters<typeof getFavorites>[0], 'documentType'>,
 ) => {

--- a/apps/web/src/queries/documents.ts
+++ b/apps/web/src/queries/documents.ts
@@ -259,7 +259,13 @@ export const useUpdateDocumentIconMutation = ({
   });
   const updateDocumentIcon = async (documentId: string, icon: string) => {
     const requestId = ++latestIconRequestRef.current;
-    const oldIcon = document.icon;
+    // Snapshot from the cache, not the render-time prop: cache writes are
+    // synchronous, so this stays correct during rapid successive updates.
+    const cachedDocument = (
+      queryClient.getQueryData(getAllDocumentsQueryOptions(document.spaceId!).queryKey) as
+        ListDocumentResult | undefined
+    )?.find((cached) => cached.id === documentId);
+    const oldIcon = cachedDocument ? cachedDocument.icon : document.icon;
 
     queryClient.setQueryData(
       getAllDocumentsQueryOptions(document.spaceId!).queryKey,
@@ -349,7 +355,13 @@ export const useUpdateDocumentColorMutation = ({
   });
   const updateDocumentColor = async (documentId: string, color: string | null) => {
     const requestId = ++latestColorRequestRef.current;
-    const oldColor = document.color;
+    // Snapshot from the cache, not the render-time prop: cache writes are
+    // synchronous, so this stays correct during rapid successive updates.
+    const cachedDocument = (
+      queryClient.getQueryData(getAllDocumentsQueryOptions(document.spaceId!).queryKey) as
+        ListDocumentResult | undefined
+    )?.find((cached) => cached.id === documentId);
+    const oldColor = cachedDocument ? cachedDocument.color : document.color;
 
     queryClient.setQueryData(
       getAllDocumentsQueryOptions(document.spaceId!).queryKey,

--- a/apps/web/src/queries/documents.ts
+++ b/apps/web/src/queries/documents.ts
@@ -343,24 +343,28 @@ export const useUpdateDocumentColorMutation = ({
         });
       },
     );
-    mutation.mutateAsync(
-      { documentId, color },
-      {
-        onError: () => {
-          queryClient.setQueryData(
-            getAllDocumentsQueryOptions(document.spaceId!).queryKey,
-            (old: ListDocumentResult) => {
-              return old?.map((document) => {
-                if (document.id === documentId) {
-                  return { ...document, color: oldColor };
-                }
-                return document;
-              });
-            },
-          );
+    return mutation
+      .mutateAsync(
+        { documentId, color },
+        {
+          onError: () => {
+            queryClient.setQueryData(
+              getAllDocumentsQueryOptions(document.spaceId!).queryKey,
+              (old: ListDocumentResult) => {
+                return old?.map((document) => {
+                  if (document.id === documentId) {
+                    return { ...document, color: oldColor };
+                  }
+                  return document;
+                });
+              },
+            );
+          },
         },
-      },
-    );
+      )
+      .catch(() => {
+        // Error handling is done in the mutation
+      });
   };
   return { updateDocumentColor, ...mutation };
 };

--- a/apps/web/src/queries/documents.ts
+++ b/apps/web/src/queries/documents.ts
@@ -306,6 +306,14 @@ export const useUpdateDocumentIconMutation = ({
               getDocumentByHandleQueryOptions(document.handle).queryKey,
               (old: any) => (old ? { ...old, icon: oldIcon } : old),
             );
+            // The rollback snapshot may itself be unconfirmed after queued
+            // failures, so re-sync with the server's actual state.
+            queryClient.invalidateQueries({
+              queryKey: getAllDocumentsQueryOptions(document.spaceId!).queryKey,
+            });
+            queryClient.invalidateQueries({
+              queryKey: getDocumentByHandleQueryOptions(document.handle).queryKey,
+            });
           },
         },
       ),
@@ -393,6 +401,11 @@ export const useUpdateDocumentColorMutation = ({
                 });
               },
             );
+            // The rollback snapshot may itself be unconfirmed after queued
+            // failures, so re-sync with the server's actual state.
+            queryClient.invalidateQueries({
+              queryKey: getAllDocumentsQueryOptions(document.spaceId!).queryKey,
+            });
           },
         },
       ),

--- a/apps/web/src/routes/_authed/docs/manage.tsx
+++ b/apps/web/src/routes/_authed/docs/manage.tsx
@@ -75,6 +75,7 @@ function ManageDocumentsPage() {
         parentId: resolvedParentId,
         spaceId: spaceID,
         createdAt: new Date(),
+        color: null,
         isFavorite: false,
         isContainer: params.type === 'folder',
         updatedAt: new Date(),

--- a/apps/web/src/routes/_authed/spaces/manage.tsx
+++ b/apps/web/src/routes/_authed/spaces/manage.tsx
@@ -73,6 +73,7 @@ function ManageSpacesPage() {
         parentId: resolvedParentId,
         spaceId: null,
         createdAt: new Date(),
+        color: null,
         isFavorite: false,
         isContainer: params.type === 'folder',
         updatedAt: new Date(),

--- a/apps/web/src/store/ui-slice.ts
+++ b/apps/web/src/store/ui-slice.ts
@@ -5,9 +5,12 @@
 
 import { StateCreator } from 'zustand';
 import type { SortOptions } from '@/types/sort';
+import type { Theme } from '@repo/ui/theme/themes';
 import type { Store } from './store';
 
 export type AppSidebarState = 'expanded' | 'collapsed' | 'remember';
+
+export type FolderColor = 'theme' | Theme['color-variants'][number]['value'];
 
 export type HomeSortState = {
   favoriteSpaces: SortOptions;
@@ -25,7 +28,7 @@ type UiState = {
   feedbackCardHidden: boolean;
   homeSorts: HomeSortState;
   folderColorsEnabled: boolean;
-  folderDefaultColor: string;
+  folderDefaultColor: FolderColor;
   folderColorSolid: boolean;
 };
 
@@ -39,7 +42,7 @@ type UiActions = {
   setFeedbackCardHidden: (hidden: boolean) => void;
   setHomeSorts: (sorts: HomeSortState | ((prev: HomeSortState) => HomeSortState)) => void;
   setFolderColorsEnabled: (enabled: boolean) => void;
-  setFolderDefaultColor: (color: string) => void;
+  setFolderDefaultColor: (color: FolderColor) => void;
   setFolderColorSolid: (solid: boolean) => void;
 };
 

--- a/apps/web/src/store/ui-slice.ts
+++ b/apps/web/src/store/ui-slice.ts
@@ -24,6 +24,8 @@ type UiState = {
   createDocumentSectionHidden: boolean;
   feedbackCardHidden: boolean;
   homeSorts: HomeSortState;
+  folderColorsEnabled: boolean;
+  folderDefaultColor: string;
 };
 
 type UiActions = {
@@ -35,6 +37,8 @@ type UiActions = {
   setCreateDocumentSectionHidden: (hidden: boolean) => void;
   setFeedbackCardHidden: (hidden: boolean) => void;
   setHomeSorts: (sorts: HomeSortState | ((prev: HomeSortState) => HomeSortState)) => void;
+  setFolderColorsEnabled: (enabled: boolean) => void;
+  setFolderDefaultColor: (color: string) => void;
 };
 
 export type UiSlice = { ui: UiState; uiActions: UiActions };
@@ -52,6 +56,8 @@ const initialState: UiState = {
     favoriteDocuments: 'a-z',
     allDocs: 'a-z',
   },
+  folderColorsEnabled: false,
+  folderDefaultColor: 'theme',
 };
 
 export const createUiSlice: StateCreator<
@@ -83,6 +89,10 @@ export const createUiSlice: StateCreator<
             homeSorts: typeof sorts === 'function' ? sorts(state.ui.homeSorts) : sorts,
           },
         })),
+      setFolderColorsEnabled: (folderColorsEnabled) =>
+        set((state) => ({ ui: { ...state.ui, folderColorsEnabled } })),
+      setFolderDefaultColor: (folderDefaultColor) =>
+        set((state) => ({ ui: { ...state.ui, folderDefaultColor } })),
     },
   };
 };

--- a/apps/web/src/store/ui-slice.ts
+++ b/apps/web/src/store/ui-slice.ts
@@ -26,6 +26,7 @@ type UiState = {
   homeSorts: HomeSortState;
   folderColorsEnabled: boolean;
   folderDefaultColor: string;
+  folderColorSolid: boolean;
 };
 
 type UiActions = {
@@ -39,6 +40,7 @@ type UiActions = {
   setHomeSorts: (sorts: HomeSortState | ((prev: HomeSortState) => HomeSortState)) => void;
   setFolderColorsEnabled: (enabled: boolean) => void;
   setFolderDefaultColor: (color: string) => void;
+  setFolderColorSolid: (solid: boolean) => void;
 };
 
 export type UiSlice = { ui: UiState; uiActions: UiActions };
@@ -58,6 +60,7 @@ const initialState: UiState = {
   },
   folderColorsEnabled: false,
   folderDefaultColor: 'theme',
+  folderColorSolid: false,
 };
 
 export const createUiSlice: StateCreator<
@@ -93,6 +96,8 @@ export const createUiSlice: StateCreator<
         set((state) => ({ ui: { ...state.ui, folderColorsEnabled } })),
       setFolderDefaultColor: (folderDefaultColor) =>
         set((state) => ({ ui: { ...state.ui, folderDefaultColor } })),
+      setFolderColorSolid: (folderColorSolid) =>
+        set((state) => ({ ui: { ...state.ui, folderColorSolid } })),
     },
   };
 };

--- a/packages/types/src/documents.ts
+++ b/packages/types/src/documents.ts
@@ -12,6 +12,7 @@ export interface EditorDocument {
   name: string;
   handle: string;
   icon: string | null;
+  color: string | null;
   position: string | null;
   currentRevisionId: string | null;
   userId: string;

--- a/packages/types/src/spaces.ts
+++ b/packages/types/src/spaces.ts
@@ -16,6 +16,7 @@ export interface Space {
   name: string;
   handle: string;
   icon: string | null;
+  color: string | null;
   position: string | null;
   currentRevisionId: string | null;
   userId: string;


### PR DESCRIPTION
## Summary

Folders in the sidebar's document tree can now take a color. The feature is **off by
default** — nothing changes for anyone until they enable it in Settings → Preferences →
Interface Preferences. Once on, unpainted folders follow the user's theme color, a
per-Space default can be chosen, and any folder can be pinned to one of the theme's 8
color variants from its right-click menu. An optional "Solid Folder Color" switch fills
the icon shape instead of coloring only the outline. The Manage Documents page renders
the same colors as the sidebar.

Only theme colors are offered — no custom colors — so folder icons always stay coherent
with the active theme, in both light and dark mode.

## Related Issues

None.

## Type of Change

New feature.

## Changes

- **Backend**: one nullable `color` column on the `documents` table
  (`apps/backend/src/models/documents.ts`), written through the existing
  `PATCH /documents/:documentId` — the update schema derives from the table, so no API
  changes were needed. `null` means "unpainted, follow the user's preference".
- **Migration `0006_folder_color.sql`**: a single `ALTER TABLE`. Note for reviewers: the
  generated SQL was trimmed by hand — drizzle-kit produced a duplicate
  `CREATE TABLE backup_restores` because migrations 0002 and 0005 were hand-written
  without snapshot files, so the generator diffed against a stale schema. The large
  `meta/0006_snapshot.json` in this PR is deliberate: it captures the full current model
  and repairs that snapshot gap for all future `drizzle-kit generate` runs.
- **Preferences** (`apps/web/src/store/ui-slice.ts`): three keys on the persisted `ui`
  slice — `folderColorsEnabled` (default `false`), `folderDefaultColor` (default
  `'theme'` = follow the theme color), `folderColorSolid` (default `false`). Per-browser
  by design, like the theme itself; pinned per-folder colors live in the database and
  sync everywhere. No persist-version bump needed — zustand fills missing keys from
  `initialState`.
- **Settings UI** (`InterfacePreferencesSettings.tsx`): "Colored Folders" switch, "Solid
  Folder Color" switch, and a "Default Folder Color" swatch row styled identically to the
  Theme page's color selector (same `Button` swatches, selected swatch marked by an icon
  inside it). The "Theme" swatch carries a palette glyph so it is distinguishable from
  the variant that currently matches the theme.
- **Folder right-click menu** (`ContainerDocumentItem.tsx`): a "Change Color" item under
  "Change Icon" (rendered only while the feature is on), which swaps the menu content for
  an in-place swatch row — "Default" resets to `null`, mirroring the existing
  `isIconPickerOpen` mechanism.
- **Rendering** (`apps/web/src/hooks/use-folder-icon-color.ts`): one shared hook resolves
  the effective classes — the folder's pinned color wins, else the default preference,
  else the theme color via a bare `text-primary`. Colors come from the existing
  `color-<variant>` CSS classes in `packages/ui/src/styles/themes.css`, which already
  support per-element scoping (`& .color-blue`), so no new CSS was added and light/dark
  values stay correct automatically. Solid fill is `fill-current`, the same idiom the
  favorite stars use. The hook only paints rows with `isContainer: true`.
- **Manage Documents page** (`documents/manage/TableRow.tsx`): uses the same hook, so the
  table and the sidebar can never drift apart.
- **New mutation** `useUpdateDocumentColorMutation` (`apps/web/src/queries/documents.ts`),
  cloned from the icon mutation, with an optimistic cache update whose error rollback
  restores only the affected document.
- **Type mirrors**: `color: string | null` added to `EditorDocument` and `Space` in
  `packages/types`; four placeholder object literals gained `color: null`.

## How to Test

> **After checking out the branch, run the pending migrations against your dev database**
> (Docker does this automatically at startup; `pnpm dev` does not):
>
> ```
> cd apps/backend
> DB_FILE_NAME="file:storage/local.db" node src/scripts/run-migrations.mjs
> ```

1. Start the app with the feature **off** (fresh state): folder icons are neutral and the
   right-click menu has no "Change Color" item — today's behavior, bit for bit.
2. Settings → Preferences → Interface Preferences → enable **Colored Folders**: every
   unpainted folder icon in the sidebar immediately takes the theme color, no reload.
3. Change the theme color on the Theme page: unpainted folders follow it. Toggle dark
   mode: folder colors switch to their dark values.
4. Right-click a folder → **Change Color** → pick a variant: that folder keeps its color
   when the theme changes; siblings keep following the theme. "Default" resets it.
5. Set a **Default Folder Color** variant in Settings: unpainted folders adopt it; pinned
   folders are unaffected.
6. Enable **Solid Folder Color**: colored folder icons fill in completely.
7. Open **Manage Docs**: folder rows show the same colors as the sidebar; notes stay
   neutral everywhere.
8. Reload: everything persists. In a second browser, pinned folder colors appear
   (database) while the on/off and default preferences do not (per-browser, matching how
   the theme behaves).
9. `pnpm lint && pnpm check-types && pnpm build` — all green.

**Expected result:** with the feature off the app is visually unchanged; with it on,
folder icons in the sidebar tree and Manage Docs take theme-consistent colors that
respect per-folder pins, the chosen default, dark mode, and the solid-fill preference.

## Screenshots

<img width="1257" height="683" alt="Screenshot 2026-08-21 at 20 54 50" src="https://github.com/user-attachments/assets/fb8b4029-d0ed-475a-877e-1ebf6db03b82" />

<img width="1257" height="683" alt="Screenshot 2026-08-21 at 20 56 24" src="https://github.com/user-attachments/assets/cd3ff571-92d5-4aae-a05e-016966c7058e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added customizable folder colors in document navigation and management views.
  - Added settings to enable colored folders, choose solid or themed colors, and select a default color.
  - Added a context-menu color picker for individual folders.
  - Folder colors are saved and displayed consistently across the app.
  - Added accessible color controls with clear selection states.

- **Bug Fixes**
  - Improved color-saving reliability with immediate updates and automatic recovery if saving fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->