### PR TITLE
chore: release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.4.0](https://github.com/TeamCoderz/WordyMe/compare/v1.3.1...v1.4.0) (2026-08-21)
+
+### Features
+
+- **sidebar:** colored folder icons, opt-in via preferences ([#124](https://github.com/TeamCoderz/WordyMe/issues/124)) ([c62e83a](https://github.com/TeamCoderz/WordyMe/commit/c62e83a412ce500040fb71e275a3c7c2c3d5c064))
+
+### Bug Fixes
+
+- **editor:** reliable unsaved-changes tracking and save feedback ([#125](https://github.com/TeamCoderz/WordyMe/issues/125)) ([7ba186e](https://github.com/TeamCoderz/WordyMe/commit/7ba186e505e05672ff0d2cad3640ee4c597df38c))
+
 ## [1.3.1](https://github.com/TeamCoderz/WordyMe/compare/v1.3.0...v1.3.1) (2026-08-20)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oss",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",


### PR DESCRIPTION
## Summary

Release v1.4.0. The version bump and changelog are generated by the Prepare Release
workflow — the full details are in this PR's `CHANGELOG.md` diff.

### Features
- **sidebar:** colored folder icons, opt-in via preferences (#124)

### Bug Fixes
- **editor:** reliable unsaved-changes tracking and save feedback (#125)

## On merge

Merging tags `v1.4.0` and triggers Publish Release: Docker images
(`teamcoderz/wordyme:1.4.0`, `1.4`, `latest`, both architectures, GHCR mirror)
and the Docker Hub listing sync — which puts the badge row from #121 live on
Docker Hub for the first time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in colored folder icons in the sidebar.
  * Improved tracking of unsaved editor changes with clearer save feedback.

* **Release**
  * Updated the application version to 1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->