### PR TITLE
feat(mcp): local MCP server exposing the wiki to AI clients

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,3 +52,8 @@ apps/backend/storage/
 Dockerfile*
 docker-compose*.yml
 .dockerignore
+
+# ---------- Non-runtime workspaces ----------
+# The MCP server is a local development companion; nothing in the image depends
+# on it, and excluding it keeps its edits out of the build context cache key.
+apps/mcp

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "wordyme": {
+      "command": "pnpm",
+      "args": ["--filter", "@repo/mcp", "--silent", "start"]
+    }
+  }
+}

--- a/MCP.md
+++ b/MCP.md
@@ -44,6 +44,7 @@ Docker image changes.
 | `read_document`    | Return a page as Markdown                                      |
 | `create_note`      | Create a note from Markdown, optionally inside a folder        |
 | `update_document`  | Replace a page body with new Markdown, saved as a new revision |
+| `move_document`    | Move a page or folder into a folder, or back to the Space root |
 
 Things people ask once it is connected:
 

--- a/MCP.md
+++ b/MCP.md
@@ -1,0 +1,114 @@
+# Connect Claude to your wiki
+
+WordyMe ships an [MCP](https://modelcontextprotocol.io) server. Point Claude Code or
+Claude Desktop at your wiki and Claude can search it, read any page, write new notes and
+revise existing ones — in plain Markdown, as your own account, with every change recorded
+as a restorable revision.
+
+```text
+You:    Read my DOCKERHUB document and create a note called "MCP Test"
+        with a summary table and a mermaid diagram of the release flow.
+
+Claude: Created "MCP Test" in Color Workspace — open it in WordyMe:
+        the table renders, the diagram draws, Revisions History says "via Claude".
+```
+
+## Why this one is different
+
+**It speaks the editor's own language.** Claude writes Markdown; WordyMe's editor converts
+it with the exact transformers it uses when _you_ type Markdown. Headings, lists, tables,
+code blocks and even Mermaid diagram fences become real rich-text nodes — not an
+approximation. Reading goes the other way through the same transformers, so Claude sees
+your pages as faithful Markdown.
+
+**It is you, not a second user.** WordyMe is deliberately single-user. The server signs in
+with your credentials and acts on your behalf — the same delegation model every
+connected app uses — so there is no "AI account" to manage and no sharing model to bolt
+on.
+
+**Nothing is ever lost.** Every write is a new revision named **"via Claude"**. Earlier
+revisions stay in Revisions History and can be restored with one click. The server never
+deletes anything.
+
+**Local by design.** It runs on your machine, next to your clone of the repository.
+Credentials live in a git-ignored file you control. Nothing about the WordyMe app or its
+Docker image changes.
+
+## What Claude can do
+
+| Tool               | What it does                                                   |
+| ------------------ | -------------------------------------------------------------- |
+| `list_spaces`      | List your Spaces                                               |
+| `list_documents`   | List the documents and folders of one Space                    |
+| `search_documents` | Full-text search across the wiki, with snippets                |
+| `read_document`    | Return a page as Markdown                                      |
+| `create_note`      | Create a note from Markdown, optionally inside a folder        |
+| `update_document`  | Replace a page body with new Markdown, saved as a new revision |
+
+Things people ask once it is connected:
+
+- _"Search my wiki for everything about backups and summarise it."_
+- _"Read my meeting notes from this week and draft the follow-up email."_
+- _"Turn this rough list into a properly structured page with a table."_
+- _"Add a Mermaid diagram of the deployment flow to the Docker page."_
+
+## Setup in three steps
+
+Requires a running WordyMe and a clone of this repository.
+
+1. **Credentials** — copy the example and fill in your login:
+
+   ```bash
+   cp apps/mcp/.env.example apps/mcp/.env
+   ```
+
+   `WORDYME_URL` is where the API answers: `http://localhost:3000` for `pnpm dev`,
+   `http://localhost:8080` for Docker, or your instance URL.
+
+2. **Claude Code** (desktop app or CLI) — nothing to install. The repository carries a
+   project-level `.mcp.json`; open the repository in Claude Code and approve the
+   `wordyme` server when prompted.
+
+3. **Claude Desktop** — add to `claude_desktop_config.json`:
+
+   ```json
+   {
+     "mcpServers": {
+       "wordyme": {
+         "command": "pnpm",
+         "args": ["--dir", "/path/to/WordyMe", "--filter", "@repo/mcp", "--silent", "start"]
+       }
+     }
+   }
+   ```
+
+Then ask Claude to list your Spaces.
+
+## How it works
+
+- **Conversion** runs a headless copy of the WordyMe editor in Node — the same node list
+  and the same Markdown transformers the browser uses — so output is what the editor
+  itself would have produced.
+- **Authentication** uses the backend's existing Better Auth bearer-token support: one
+  sign-in at first use, an expired session re-signs transparently.
+- **Writes** go through the normal document and revision APIs; MCP-created notes are
+  structurally identical to notes created in the editor.
+
+The implementation lives in [`apps/mcp`](apps/mcp/README.md).
+
+## Honest limits
+
+- Fidelity is bounded by Markdown. Standard constructs and the editor's fenced
+  extensions (` ```mermaid `) round-trip; exotic nodes such as sketches, scores and
+  stickies degrade to plain text when read.
+- Nested list items need 4-space indentation.
+- Claude acts with your full account; the server is meant for your own machine.
+
+## What's next
+
+- **Built into the image.** An opt-in `/mcp` endpoint inside the WordyMe container, so
+  self-hosters connect Claude with a URL and no local setup.
+- **Proper OAuth.** WordyMe as the identity provider — Claude signs in through WordyMe's
+  own consent screen, with revocable tokens and read-only scopes.
+- **claude.ai.** With the two above, publicly reachable instances connect from the web app
+  as well.

--- a/MCP.md
+++ b/MCP.md
@@ -26,9 +26,10 @@ with your credentials and acts on your behalf — the same delegation model ever
 connected app uses — so there is no "AI account" to manage and no sharing model to bolt
 on.
 
-**Nothing is ever lost.** Every write is a new revision named **"via Claude"**. Earlier
-revisions stay in Revisions History and can be restored with one click. The server never
-deletes anything.
+**Nothing is ever lost.** Every content write — creating a page or revising one — is saved
+as a new revision named **"via Claude"**. Earlier revisions stay in Revisions History and
+can be restored with one click. Moving a page only changes where it sits in the tree. The
+server never deletes anything.
 
 **Local by design.** It runs on your machine, next to your clone of the repository.
 Credentials live in a git-ignored file you control. Nothing about the WordyMe app or its

--- a/README.md
+++ b/README.md
@@ -189,8 +189,9 @@ Already running an older version? Ports and origins changed; see
 ## Connect Claude (MCP)
 
 WordyMe™ ships an MCP server, so Claude Code and Claude Desktop can search your wiki, read
-any page and write notes — in Markdown, as your own account, with every change saved as a
-restorable revision. See [MCP.md](MCP.md) for the three-step setup and what it can do.
+any page and write notes — in Markdown, as your own account, with every content change
+saved as a restorable revision. See [MCP.md](MCP.md) for the three-step setup and what it
+can do.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ This project uses [Turborepo](https://turborepo.com) for managing a monorepo wit
 - User profiles with avatar and cover images
 - Editor settings and preferences
 - Real-time updates via WebSocket
+- MCP server for Claude Code and Claude Desktop — see [MCP.md](MCP.md)
 
 ### Performance
 
@@ -184,6 +185,12 @@ frontend URL. The API reference is at <http://localhost:8080/api/docs>.
 
 Already running an older version? Ports and origins changed; see
 [Upgrading](DOCKER.md#upgrading-from-a-version-before-the-all-in-one-image).
+
+## Connect Claude (MCP)
+
+WordyMe™ ships an MCP server, so Claude Code and Claude Desktop can search your wiki, read
+any page and write notes — in Markdown, as your own account, with every change saved as a
+restorable revision. See [MCP.md](MCP.md) for the three-step setup and what it can do.
 
 ## Development Workflow
 

--- a/apps/mcp/.env.example
+++ b/apps/mcp/.env.example
@@ -1,0 +1,6 @@
+# Copy to .env (git-ignored). Variables already set in the environment take precedence.
+# The origin the WordyMe API answers on: http://localhost:3000 for `pnpm dev`,
+# http://localhost:8080 for Docker, or your instance URL.
+WORDYME_URL=http://localhost:3000
+WORDYME_EMAIL=you@example.com
+WORDYME_PASSWORD=your-password

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -5,9 +5,9 @@ clients such as Claude Code and Claude Desktop. Markdown in, Markdown out — co
 converted with the editor's own transformers, so what the AI writes is exactly what the
 editor would produce if you typed the same Markdown yourself.
 
-The server acts **as your account** (delegation — WordyMe stays single-user). Every
+The server acts **as your account** (delegation — WordyMe stays single-user). Every content
 change it makes is saved as a new revision named **"via Claude"**, restorable from
-Revisions History.
+Revisions History; moving a document only changes its place in the tree.
 
 ## Tools
 

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -11,14 +11,15 @@ Revisions History.
 
 ## Tools
 
-| Tool               | What it does                                             |
-| ------------------ | -------------------------------------------------------- |
-| `list_spaces`      | List the Spaces in the wiki                              |
-| `list_documents`   | List one Space's documents and folders                   |
-| `search_documents` | Full-text search with snippets                           |
-| `read_document`    | Return a document as Markdown                            |
-| `create_note`      | Create a note from Markdown                              |
-| `update_document`  | Replace a document body with new Markdown (new revision) |
+| Tool               | What it does                                                  |
+| ------------------ | ------------------------------------------------------------- |
+| `list_spaces`      | List the Spaces in the wiki                                   |
+| `list_documents`   | List one Space's documents and folders                        |
+| `search_documents` | Full-text search with snippets                                |
+| `read_document`    | Return a document as Markdown                                 |
+| `create_note`      | Create a note from Markdown                                   |
+| `update_document`  | Replace a document body with new Markdown (new revision)      |
+| `move_document`    | Move a document or folder into a folder, or to the Space root |
 
 ## Setup
 

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -1,0 +1,73 @@
+# @repo/mcp
+
+A local MCP (Model Context Protocol) server that exposes a WordyMe instance to AI
+clients such as Claude Code and Claude Desktop. Markdown in, Markdown out — content is
+converted with the editor's own transformers, so what the AI writes is exactly what the
+editor would produce if you typed the same Markdown yourself.
+
+The server acts **as your account** (delegation — WordyMe stays single-user). Every
+change it makes is saved as a new revision named **"via Claude"**, restorable from
+Revisions History.
+
+## Tools
+
+| Tool               | What it does                                             |
+| ------------------ | -------------------------------------------------------- |
+| `list_spaces`      | List the Spaces in the wiki                              |
+| `list_documents`   | List one Space's documents and folders                   |
+| `search_documents` | Full-text search with snippets                           |
+| `read_document`    | Return a document as Markdown                            |
+| `create_note`      | Create a note from Markdown                              |
+| `update_document`  | Replace a document body with new Markdown (new revision) |
+
+## Setup
+
+Requires a running WordyMe instance and its owner credentials. `WORDYME_URL` is the
+origin the API answers on:
+
+| How WordyMe runs              | `WORDYME_URL`                                  |
+| ----------------------------- | ---------------------------------------------- |
+| `pnpm dev` (backend directly) | `http://localhost:3000`                        |
+| Docker / self-hosted          | `http://localhost:8080` (or your instance URL) |
+
+### 1. Credentials
+
+```bash
+cp apps/mcp/.env.example apps/mcp/.env
+```
+
+Fill in `apps/mcp/.env`. It is git-ignored and read by the server at startup; variables
+already present in the environment take precedence over the file.
+
+### 2. Claude Code (desktop app or CLI)
+
+Nothing to install: the repository ships a project-level `.mcp.json` that starts the
+server with `pnpm --filter @repo/mcp --silent start`. Open the repository in Claude Code
+and approve the project MCP server when prompted — new sessions then have the `wordyme`
+tools. Check status with `/mcp` inside a session.
+
+### Claude Desktop
+
+`claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "wordyme": {
+      "command": "pnpm",
+      "args": ["--dir", "/path/to/WordyMe", "--filter", "@repo/mcp", "--silent", "start"]
+    }
+  }
+}
+```
+
+Credentials never live in MCP client configuration or in this repository — only in
+`apps/mcp/.env` (or the process environment).
+
+## Notes
+
+- `pnpm smoke` runs the Markdown round-trip self-test (no WordyMe instance needed).
+- Content fidelity is bounded by Markdown: standard constructs plus the editor's fenced
+  extensions (```mermaid diagrams) round-trip; exotic nodes (sketches, scores, stickies)
+  degrade to plain text. Nested list items need 4-space indentation.
+- The server never deletes anything and every write is a new revision.

--- a/apps/mcp/eslint.config.js
+++ b/apps/mcp/eslint.config.js
@@ -1,0 +1,3 @@
+import { config } from '@repo/eslint-config/base';
+
+export default config;

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@repo/mcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=esm --banner:js=\"import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);\" --outfile=dist/index.js --loader:.css=empty --loader:.svg=empty --loader:.png=empty --loader:.jpg=empty --loader:.woff=empty --loader:.woff2=empty --log-level=warning",
+    "start": "pnpm build && node --env-file-if-exists=.env dist/index.js",
+    "smoke": "esbuild scripts/smoke-markdown.ts --bundle --platform=node --target=node20 --format=esm --banner:js=\"import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);\" --outfile=dist/smoke.js --loader:.css=empty --loader:.svg=empty --loader:.png=empty --loader:.jpg=empty --loader:.woff=empty --loader:.woff2=empty --log-level=warning && node dist/smoke.js",
+    "lint": "eslint .",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@happy-dom/global-registrator": "^20.11.2",
+    "@lexical/markdown": "^0.41.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@repo/backend": "workspace:*",
+    "@repo/editor": "workspace:*",
+    "@repo/lib": "workspace:*",
+    "@repo/sdk": "workspace:*",
+    "axios": "^1.19.0",
+    "lexical": "^0.41.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "^26.2.0",
+    "esbuild": "^0.25.12",
+    "eslint": "^10.8.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22.9.0"
+  },
   "scripts": {
     "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=esm --banner:js=\"import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);\" --outfile=dist/index.js --loader:.css=empty --loader:.svg=empty --loader:.png=empty --loader:.jpg=empty --loader:.woff=empty --loader:.woff2=empty --log-level=warning",
     "start": "pnpm build && node --env-file-if-exists=.env dist/index.js",

--- a/apps/mcp/scripts/smoke-markdown.ts
+++ b/apps/mcp/scripts/smoke-markdown.ts
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { fromMarkdown, toMarkdown } from '../src/markdown.js';
+
+const sample = `# Smoke Test
+
+Some **bold** and *italic* text with a [link](https://wordy.me).
+
+## A list
+
+- one
+- two
+  - nested
+
+## A table
+
+| Col A | Col B |
+| ----- | ----- |
+| 1     | 2     |
+
+## Code
+
+\`\`\`ts
+const x: number = 1;
+\`\`\`
+
+\`\`\`mermaid
+graph TD; A-->B;
+\`\`\`
+`;
+
+const state = fromMarkdown(sample);
+const roundTripped = toMarkdown(state);
+
+const rootTypes = state.root.children.map((node) => node.type);
+if (rootTypes[0] !== 'page-setup' || rootTypes[1] !== 'page') {
+  throw new Error(`Expected the editor's page scaffold, got root children: ${rootTypes}`);
+}
+if (!roundTripped.includes('## A table') || !roundTripped.includes('```mermaid')) {
+  throw new Error('Round-trip lost block structure');
+}
+
+console.log('--- root structure ---');
+console.log(rootTypes.join(' > '));
+console.log('--- markdown round-trip ---');
+console.log(roundTripped);

--- a/apps/mcp/src/auth.ts
+++ b/apps/mcp/src/auth.ts
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from 'axios';
+import { client } from '@repo/sdk/client.ts';
+
+const url = process.env.WORDYME_URL?.replace(/\/$/, '');
+const email = process.env.WORDYME_EMAIL;
+const password = process.env.WORDYME_PASSWORD;
+
+export function assertConfig(): void {
+  const missing = [
+    !url && 'WORDYME_URL',
+    !email && 'WORDYME_EMAIL',
+    !password && 'WORDYME_PASSWORD',
+  ].filter(Boolean);
+  if (missing.length > 0) {
+    throw new Error(`Missing environment variables: ${missing.join(', ')}`);
+  }
+}
+
+let loginPromise: Promise<void> | null = null;
+
+async function login(): Promise<void> {
+  // Plain Node HTTP on purpose: the global fetch adds Sec-Fetch-* headers, which
+  // make Better Auth treat the call as a browser submission and demand an Origin.
+  const response = await axios.post<{ message?: string }>(
+    `${url}/api/auth/sign-in/email`,
+    { email, password },
+    { adapter: 'http', validateStatus: () => true },
+  );
+  if (response.status !== 200) {
+    const detail = response.data?.message ? `: ${response.data.message}` : '';
+    throw new Error(
+      `WordyMe sign-in failed (HTTP ${response.status}${detail}) — check WORDYME_EMAIL and WORDYME_PASSWORD`,
+    );
+  }
+  // Provided by the backend's Better Auth bearer() plugin.
+  const token = response.headers['set-auth-token'];
+  if (typeof token !== 'string' || !token) {
+    throw new Error('WordyMe sign-in returned no set-auth-token header');
+  }
+  client.defaults.headers.common.Authorization = `Bearer ${token}`;
+}
+
+export function ensureAuth(): Promise<void> {
+  loginPromise ??= login().catch((error: unknown) => {
+    loginPromise = null;
+    throw error;
+  });
+  return loginPromise;
+}
+
+export function configureClient(): void {
+  client.defaults.baseURL = `${url}/api`;
+  client.defaults.adapter = 'http';
+  client.interceptors.response.use(undefined, async (error) => {
+    const config = error?.config;
+    if (error?.response?.status === 401 && config && !config.__retriedAfterLogin) {
+      config.__retriedAfterLogin = true;
+      loginPromise = null;
+      await ensureAuth();
+      config.headers = {
+        ...config.headers,
+        Authorization: client.defaults.headers.common.Authorization,
+      };
+      return client.request(config);
+    }
+    throw error;
+  });
+}

--- a/apps/mcp/src/dom-shim.ts
+++ b/apps/mcp/src/dom-shim.ts
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+
+// Several editor nodes (MathLive, and the DOM-rendering decorators) expect
+// browser globals at module load. Register a headless DOM before any
+// @repo/editor module is imported — this file must stay the first import.
+const nodeFetch = globalThis.fetch;
+
+if (typeof globalThis.window === 'undefined') {
+  GlobalRegistrator.register();
+  // happy-dom also installs browser-style fetch/XMLHttpRequest that enforce the
+  // same-origin policy. Networking must stay Node's own.
+  globalThis.fetch = nodeFetch;
+  delete (globalThis as { XMLHttpRequest?: unknown }).XMLHttpRequest;
+}
+
+// MathLive skips its window registration outside a real browser, but the
+// editor's MathNode module reads these globals at import time.
+const win = globalThis.window as unknown as Record<string, unknown>;
+win.MathfieldElement ??= class {};
+win.mathVirtualKeyboard ??= {
+  normalizedLayouts: Array.from({ length: 4 }, () => ({
+    layers: [
+      {
+        rows: Array.from({ length: 8 }, () =>
+          Array.from({ length: 16 }, () => ({ variants: [] as unknown[] })),
+        ),
+      },
+    ],
+  })),
+};

--- a/apps/mcp/src/env.d.ts
+++ b/apps/mcp/src/env.d.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+// The editor and sdk packages are authored for Vite; these ambient
+// declarations stand in for Vite's when their sources are type-checked here.
+declare module '*.css';
+
+interface ImportMeta {
+  readonly env?: Record<string, string | undefined>;
+}

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -1,0 +1,225 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import './dom-shim.js';
+import { randomUUID } from 'node:crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import {
+  createDocumentWithRevision,
+  getDocumentByHandle,
+  getDocumentById,
+  getUserDocuments,
+  searchDocuments,
+} from '@repo/sdk/documents.ts';
+import { createRevision, getRevisionById } from '@repo/sdk/revisions.ts';
+import { generatePositionKeyBetween, getSiblings, sortByPosition } from '@repo/lib/utils/position';
+import { computeChecksum } from '@repo/editor/utils/computeChecksum';
+import { generateText } from '@repo/editor/utils/generateText';
+import { assertConfig, configureClient, ensureAuth } from './auth.js';
+import { fromMarkdown, toMarkdown } from './markdown.js';
+
+const REVISION_NAME = 'via Claude';
+
+type ToolResult = { content: Array<{ type: 'text'; text: string }>; isError?: boolean };
+
+function ok(text: string): ToolResult {
+  return { content: [{ type: 'text', text }] };
+}
+
+function fail(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+async function run(handler: () => Promise<ToolResult>): Promise<ToolResult> {
+  try {
+    await ensureAuth();
+    return await handler();
+  } catch (error) {
+    return fail(error instanceof Error ? error.message : String(error));
+  }
+}
+
+async function resolveDocument(input: { id?: string; handle?: string }) {
+  if (input.id) {
+    const { data, error } = await getDocumentById(input.id);
+    if (error || !data) throw new Error(`Document not found for id "${input.id}"`);
+    return data;
+  }
+  if (input.handle) {
+    const { data, error } = await getDocumentByHandle(input.handle);
+    if (error || !data) throw new Error(`Document not found for handle "${input.handle}"`);
+    return data;
+  }
+  throw new Error('Provide either "id" or "handle"');
+}
+
+async function markdownToRevisionFields(markdown: string) {
+  const state = fromMarkdown(markdown);
+  return {
+    content: JSON.stringify(state),
+    checksum: computeChecksum(state),
+    text: generateText(state),
+  };
+}
+
+const server = new McpServer({ name: 'wordyme', version: '0.1.0' });
+
+server.registerTool(
+  'list_spaces',
+  {
+    description:
+      'List all Spaces (top-level workspaces) in the WordyMe wiki, including folder-type container spaces.',
+    inputSchema: {},
+  },
+  async () =>
+    run(async () => {
+      const { data, error } = await getUserDocuments({ documentType: 'space' });
+      if (error) throw new Error(error.message);
+      const spaces = (data ?? []).map((s) => ({
+        id: s.id,
+        name: s.name,
+        parentId: s.parentId,
+        isFolder: s.isContainer,
+      }));
+      return ok(JSON.stringify(spaces, null, 2));
+    }),
+);
+
+server.registerTool(
+  'list_documents',
+  {
+    description:
+      'List the documents and folders inside one Space as a flat list; reconstruct the tree via parentId.',
+    inputSchema: { space_id: z.string().describe('The Space id, from list_spaces') },
+  },
+  async ({ space_id }) =>
+    run(async () => {
+      const { data, error } = await getUserDocuments({ spaceId: space_id });
+      if (error) throw new Error(error.message);
+      const documents = (data ?? []).map((d) => ({
+        id: d.id,
+        name: d.name,
+        handle: d.handle,
+        parentId: d.parentId,
+        isFolder: d.isContainer,
+        updatedAt: d.updatedAt,
+      }));
+      return ok(JSON.stringify(documents, null, 2));
+    }),
+);
+
+server.registerTool(
+  'search_documents',
+  {
+    description: 'Full-text search across the wiki. Returns matching documents with snippets.',
+    inputSchema: {
+      query: z.string().describe('Search terms'),
+      space_id: z.string().optional().describe('Restrict the search to one Space'),
+      limit: z.number().int().min(1).max(50).optional(),
+    },
+  },
+  async ({ query, space_id, limit }) =>
+    run(async () => {
+      const { data, error } = await searchDocuments(query, limit ?? 20, space_id);
+      if (error) throw new Error(error.message);
+      return ok(JSON.stringify(data ?? [], null, 2));
+    }),
+);
+
+server.registerTool(
+  'read_document',
+  {
+    description: 'Read one document and return its content as Markdown.',
+    inputSchema: {
+      id: z.string().optional().describe('Document id'),
+      handle: z.string().optional().describe('Document handle (URL slug), alternative to id'),
+    },
+  },
+  async (input) =>
+    run(async () => {
+      const document = await resolveDocument(input);
+      if (!document.currentRevisionId) {
+        return ok(`# ${document.name}\n\n(This document has no content yet.)`);
+      }
+      const { data: revision, error } = await getRevisionById(document.currentRevisionId);
+      if (error || !revision) throw new Error('Could not load the document content');
+      const markdown = toMarkdown(JSON.parse(revision.content));
+      return ok(markdown);
+    }),
+);
+
+server.registerTool(
+  'create_note',
+  {
+    description:
+      'Create a new note in a Space from Markdown content. Returns the new document id and handle.',
+    inputSchema: {
+      space_id: z.string().describe('The Space id, from list_spaces'),
+      name: z.string().describe('The note title'),
+      markdown: z.string().describe('The note body as Markdown'),
+      parent_id: z
+        .string()
+        .optional()
+        .describe('Optional folder (container document) id to create the note inside'),
+    },
+  },
+  async ({ space_id, name, markdown, parent_id }) =>
+    run(async () => {
+      const { data: documents, error: listError } = await getUserDocuments({ spaceId: space_id });
+      if (listError) throw new Error(listError.message);
+      const siblings = sortByPosition(getSiblings(documents ?? [], parent_id ?? null));
+      const last = siblings.at(-1);
+      const position = last ? generatePositionKeyBetween(last.position || 'a0', null) : 'a0';
+
+      const revision = await markdownToRevisionFields(markdown);
+      const { data, error } = await createDocumentWithRevision({
+        name,
+        icon: 'file',
+        parentId: parent_id ?? null,
+        position,
+        spaceId: space_id,
+        isContainer: false,
+        clientId: randomUUID(),
+        documentType: 'note',
+        revision: { ...revision, revisionName: REVISION_NAME, makeCurrentRevision: true },
+      });
+      if (error || !data) throw new Error(error?.message ?? 'Failed to create the note');
+      return ok(JSON.stringify({ id: data.id, handle: data.handle, name: data.name }, null, 2));
+    }),
+);
+
+server.registerTool(
+  'update_document',
+  {
+    description:
+      'Replace a document body with new Markdown content. Saved as a new revision named "via Claude"; earlier revisions stay restorable from Revisions History.',
+    inputSchema: {
+      id: z.string().optional().describe('Document id'),
+      handle: z.string().optional().describe('Document handle (URL slug), alternative to id'),
+      markdown: z.string().describe('The full new document body as Markdown'),
+    },
+  },
+  async ({ markdown, ...input }) =>
+    run(async () => {
+      const document = await resolveDocument(input);
+      const revision = await markdownToRevisionFields(markdown);
+      const { data, error } = await createRevision({
+        documentId: document.id,
+        ...revision,
+        revisionName: REVISION_NAME,
+        makeCurrentRevision: true,
+      });
+      if (error || !data) throw new Error(error?.message ?? 'Failed to update the document');
+      return ok(
+        JSON.stringify({ id: document.id, handle: document.handle, revisionId: data.id }, null, 2),
+      );
+    }),
+);
+
+assertConfig();
+configureClient();
+await server.connect(new StdioServerTransport());

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -14,6 +14,7 @@ import {
   getDocumentById,
   getUserDocuments,
   searchDocuments,
+  updateDocument,
 } from '@repo/sdk/documents.ts';
 import { createRevision, getRevisionById } from '@repo/sdk/revisions.ts';
 import { generatePositionKeyBetween, getSiblings, sortByPosition } from '@repo/lib/utils/position';
@@ -216,6 +217,57 @@ server.registerTool(
       if (error || !data) throw new Error(error?.message ?? 'Failed to update the document');
       return ok(
         JSON.stringify({ id: document.id, handle: document.handle, revisionId: data.id }, null, 2),
+      );
+    }),
+);
+
+server.registerTool(
+  'move_document',
+  {
+    description:
+      'Move a document or folder into another folder of the same Space, or to the Space root. It is placed last among its new siblings.',
+    inputSchema: {
+      id: z.string().optional().describe('Document id'),
+      handle: z.string().optional().describe('Document handle (URL slug), alternative to id'),
+      parent_id: z
+        .string()
+        .nullable()
+        .describe('Target folder id (from list_documents), or null for the Space root'),
+    },
+  },
+  async ({ parent_id, ...input }) =>
+    run(async () => {
+      const document = await resolveDocument(input);
+      if (!document.spaceId) throw new Error('Only documents inside a Space can be moved');
+      const { data: documents, error: listError } = await getUserDocuments({
+        spaceId: document.spaceId,
+      });
+      if (listError) throw new Error(listError.message);
+      const all = documents ?? [];
+
+      if (parent_id) {
+        const target = all.find((d) => d.id === parent_id);
+        if (!target) throw new Error(`Folder "${parent_id}" not found in this Space`);
+        if (!target.isContainer) throw new Error(`"${target.name}" is a note, not a folder`);
+        for (let cursor = target; cursor;) {
+          if (cursor.id === document.id) {
+            throw new Error('Cannot move a folder into itself or one of its subfolders');
+          }
+          const next = cursor.parentId ? all.find((d) => d.id === cursor.parentId) : undefined;
+          if (!next) break;
+          cursor = next;
+        }
+      }
+
+      const siblings = sortByPosition(getSiblings(all, parent_id)).filter(
+        (d) => d.id !== document.id,
+      );
+      const last = siblings.at(-1);
+      const position = last ? generatePositionKeyBetween(last.position || 'a0', null) : 'a0';
+      const { data, error } = await updateDocument(document.id, { parentId: parent_id, position });
+      if (error || !data) throw new Error(error?.message ?? 'Failed to move the document');
+      return ok(
+        JSON.stringify({ id: data.id, handle: data.handle, parentId: data.parentId }, null, 2),
       );
     }),
 );

--- a/apps/mcp/src/markdown.ts
+++ b/apps/mcp/src/markdown.ts
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: 2026 TeamCoderz Ltd <legal@teamcoderz.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import './dom-shim.js';
+import {
+  $getRoot,
+  $isElementNode,
+  createEditor,
+  type ElementNode,
+  type LexicalNode,
+  type SerializedEditorState,
+} from 'lexical';
+import { $convertFromMarkdownString, $convertToMarkdownString } from '@lexical/markdown';
+import { editorConfig } from '@repo/editor/config';
+import { createTransformers } from '@repo/editor/plugins/MarkdownPlugin';
+import { serializeEditorState } from '@repo/editor/utils/editorState';
+import { getInitialEditorState } from '@repo/editor/utils/getInitialEditorState';
+
+// Same headless pattern the app itself uses in @repo/editor/utils/generateText:
+// a bare editor with the full node list, never attached to a DOM.
+const editor = createEditor({ ...editorConfig });
+const transformers = createTransformers(editor);
+
+// Documents are wrapped in page nodes (page-setup, page → header/content/footer).
+// Markdown lives inside the page-content nodes; the wrapper has no transformer.
+function $findPageContents(): ElementNode[] {
+  const found: ElementNode[] = [];
+  const visit = (node: LexicalNode) => {
+    if (!$isElementNode(node)) return;
+    if (node.getType() === 'page-content') {
+      found.push(node);
+      return;
+    }
+    node.getChildren().forEach(visit);
+  };
+  visit($getRoot());
+  return found;
+}
+
+export function toMarkdown(state: SerializedEditorState): string {
+  editor.setEditorState(editor.parseEditorState(state));
+  return editor.read(() => {
+    const contents = $findPageContents();
+    if (contents.length === 0) return $convertToMarkdownString(transformers);
+    return contents.map((content) => $convertToMarkdownString(transformers, content)).join('\n\n');
+  });
+}
+
+export function fromMarkdown(markdown: string): SerializedEditorState {
+  // Start from the app's own new-document scaffold so the result is
+  // structurally identical to a note created in the editor.
+  editor.setEditorState(editor.parseEditorState(getInitialEditorState('')));
+  editor.update(
+    () => {
+      const [content] = $findPageContents();
+      $convertFromMarkdownString(markdown, transformers, content);
+    },
+    { discrete: true },
+  );
+  return serializeEditorState(editor.getEditorState()) as SerializedEditorState;
+}

--- a/apps/mcp/tsconfig.json
+++ b/apps/mcp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@repo/typescript-config/node.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["./src/**/*", "./scripts/**/*"]
+}

--- a/packages/sdk/src/app/client.ts
+++ b/packages/sdk/src/app/client.ts
@@ -8,7 +8,9 @@ import axios, { AxiosError } from 'axios';
 import { applyBackendMessageToAxiosError } from './axios-backend-message.js';
 
 export const client = axios.create({
-  baseURL: import.meta.env.VITE_BACKEND_URL + '/api',
+  // Optional chaining: import.meta.env only exists under Vite; Node consumers
+  // (the MCP server) override baseURL at startup.
+  baseURL: (import.meta.env?.VITE_BACKEND_URL ?? '') + '/api',
   withCredentials: true,
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
     devDependencies:
       '@release-it/conventional-changelog':
         specifier: ^10.0.6
-        version: 10.0.6(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@19.2.4(@types/node@25.9.5))
+        version: 10.0.6(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@19.2.4(@types/node@26.2.0))
       lefthook:
         specifier: ^2.1.4
         version: 2.1.10
@@ -57,7 +57,7 @@ importers:
         version: 3.9.6
       release-it:
         specifier: ^19.2.4
-        version: 19.2.4(@types/node@25.9.5)
+        version: 19.2.4(@types/node@26.2.0)
       turbo:
         specifier: ^2.9.3
         version: 2.10.8
@@ -81,7 +81,7 @@ importers:
         version: 0.9.20
       better-auth:
         specifier: ^1.6.25
-        version: 1.6.26(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9)))
+        version: 1.6.26(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(happy-dom@20.11.2)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9)))
       cors:
         specifier: ^2.8.6
         version: 2.8.6
@@ -169,6 +169,58 @@ importers:
         version: 4.23.9
       typescript:
         specifier: ^6.0.2
+        version: 6.0.3
+
+  apps/mcp:
+    dependencies:
+      '@happy-dom/global-registrator':
+        specifier: ^20.11.2
+        version: 20.11.2
+      '@lexical/markdown':
+        specifier: ^0.41.0
+        version: 0.41.0
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(zod@3.25.76)
+      '@repo/backend':
+        specifier: workspace:*
+        version: link:../backend
+      '@repo/editor':
+        specifier: workspace:*
+        version: link:../../packages/editor
+      '@repo/lib':
+        specifier: workspace:*
+        version: link:../../packages/lib
+      '@repo/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      axios:
+        specifier: ^1.19.0
+        version: 1.19.0
+      lexical:
+        specifier: ^0.41.0
+        version: 0.41.0
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@types/node':
+        specifier: ^26.2.0
+        version: 26.2.0
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      eslint:
+        specifier: ^10.8.0
+        version: 10.8.0(jiti@2.7.0)
+      typescript:
+        specifier: ^6.0.3
         version: 6.0.3
 
   apps/web:
@@ -356,7 +408,7 @@ importers:
         version: 1.3.0(@types/babel__core@7.20.5)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9))
       vitest:
         specifier: ^4.0.18
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(happy-dom@20.11.2)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9))
       web-vitals:
         specifier: ^5.1.0
         version: 5.3.0
@@ -704,7 +756,7 @@ importers:
         version: 1.19.0
       better-auth:
         specifier: ^1.6.25
-        version: 1.6.26(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9)))
+        version: 1.6.26(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(happy-dom@20.11.2)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9)))
       socket.io-client:
         specifier: ^4.8.3
         version: 4.8.3
@@ -2273,6 +2325,10 @@ packages:
   '@fontsource/roboto@5.3.0':
     resolution: {integrity: sha512-BapRJOWYP+LZ21zp+wBQjfpPYKRoxc4LspJ/RLuI+HSMBD5u/X4O+ESDrSvEqDSy0rAl7GwBJ+09mdc16cVQ1Q==}
 
+  '@happy-dom/global-registrator@20.11.2':
+    resolution: {integrity: sha512-7fkpoXZWzyxaBkzRtlD0wRU5ckxbNT4j6BywzpSYh+SFPsGxEVmNR9KHaMwM2xkHB0pADQLl4Z8DSrztECJ7Ww==}
+    engines: {node: '>=20.0.0'}
+
   '@headless-tree/core@1.7.0':
     resolution: {integrity: sha512-LxcX7LNepwfOPrZcs4PNfDwCzbi326uCAX5jYBfw94jI+pZQA7ANaE/No3LW0XFgcBcQtK/G2bInbVEhLF1C/Q==}
 
@@ -2282,6 +2338,12 @@ packages:
       '@headless-tree/core': '*'
       react: '*'
       react-dom: '*'
+
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
 
   '@hookform/resolvers@5.7.1':
     resolution: {integrity: sha512-8wS/P4UDr5sQDe4nFaV51TVyfDPrWgNIXweqG0Bs9Z5LSuzKLb+RQNPvkN2oHM5SRrJyWrVH/F+LOUcFjUyvwQ==}
@@ -2679,6 +2741,16 @@ packages:
 
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
@@ -4577,6 +4649,9 @@ packages:
   '@types/node@25.9.5':
     resolution: {integrity: sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==}
 
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -4615,6 +4690,9 @@ packages:
 
   '@types/vexflow@1.2.42':
     resolution: {integrity: sha512-bj3If1sm1FYJN0tJMV2BJNrwoeQ6xfrTt+rbmFvUytyxUhklLlW79MR4uwQ+upzrNJLVy012TnC7oZqSpEglSw==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -4787,6 +4865,9 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -5080,6 +5161,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -6067,6 +6152,14 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -6081,6 +6174,12 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -6370,6 +6469,10 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
+  happy-dom@20.11.2:
+    resolution: {integrity: sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw==}
+    engines: {node: '>=20.0.0'}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -6398,6 +6501,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  hono@4.13.2:
+    resolution: {integrity: sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==}
+    engines: {node: '>=16.9.0'}
 
   hosted-git-info@8.1.0:
     resolution: {integrity: sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==}
@@ -6792,6 +6899,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -7739,6 +7849,10 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
@@ -8609,6 +8723,9 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   undici@6.28.0:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
@@ -8906,6 +9023,10 @@ packages:
   webworkify@1.5.0:
     resolution: {integrity: sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
@@ -9098,11 +9219,19 @@ packages:
     peerDependencies:
       zod: ^3.25.74 || ^4.0.0
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -10517,6 +10646,14 @@ snapshots:
 
   '@fontsource/roboto@5.3.0': {}
 
+  '@happy-dom/global-registrator@20.11.2':
+    dependencies:
+      '@types/node': 25.9.5
+      happy-dom: 20.11.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@headless-tree/core@1.7.0': {}
 
   '@headless-tree/react@1.7.0(@headless-tree/core@1.7.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
@@ -10524,6 +10661,10 @@ snapshots:
       '@headless-tree/core': 1.7.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
+
+  '@hono/node-server@2.1.1(hono@4.13.2)':
+    dependencies:
+      hono: 4.13.2
 
   '@hookform/resolvers@5.7.1(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.84.0(react@19.2.8))(zod@4.4.3)':
     dependencies:
@@ -10564,12 +10705,29 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.5
 
+  '@inquirer/checkbox@4.3.2(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@26.2.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 26.2.0
+
   '@inquirer/confirm@5.1.21(@types/node@25.9.5)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.9.5)
       '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
       '@types/node': 25.9.5
+
+  '@inquirer/confirm@5.1.21(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@26.2.0)
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
 
   '@inquirer/core@10.3.2(@types/node@25.9.5)':
     dependencies:
@@ -10584,6 +10742,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.5
 
+  '@inquirer/core@10.3.2(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 26.2.0
+
   '@inquirer/editor@4.2.23(@types/node@25.9.5)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.9.5)
@@ -10591,6 +10762,14 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
       '@types/node': 25.9.5
+
+  '@inquirer/editor@4.2.23(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@26.2.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@26.2.0)
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
 
   '@inquirer/expand@4.0.23(@types/node@25.9.5)':
     dependencies:
@@ -10600,12 +10779,27 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.5
 
+  '@inquirer/expand@4.0.23(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@26.2.0)
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 26.2.0
+
   '@inquirer/external-editor@1.0.3(@types/node@25.9.5)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.3
     optionalDependencies:
       '@types/node': 25.9.5
+
+  '@inquirer/external-editor@1.0.3(@types/node@26.2.0)':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 26.2.0
 
   '@inquirer/figures@1.0.15': {}
 
@@ -10616,12 +10810,26 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.5
 
+  '@inquirer/input@4.3.1(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@26.2.0)
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
   '@inquirer/number@3.0.23(@types/node@25.9.5)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.9.5)
       '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
       '@types/node': 25.9.5
+
+  '@inquirer/number@3.0.23(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@26.2.0)
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
 
   '@inquirer/password@4.0.23(@types/node@25.9.5)':
     dependencies:
@@ -10630,6 +10838,14 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@25.9.5)
     optionalDependencies:
       '@types/node': 25.9.5
+
+  '@inquirer/password@4.0.23(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@26.2.0)
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
 
   '@inquirer/prompts@7.10.1(@types/node@25.9.5)':
     dependencies:
@@ -10646,6 +10862,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.5
 
+  '@inquirer/prompts@7.10.1(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@26.2.0)
+      '@inquirer/confirm': 5.1.21(@types/node@26.2.0)
+      '@inquirer/editor': 4.2.23(@types/node@26.2.0)
+      '@inquirer/expand': 4.0.23(@types/node@26.2.0)
+      '@inquirer/input': 4.3.1(@types/node@26.2.0)
+      '@inquirer/number': 3.0.23(@types/node@26.2.0)
+      '@inquirer/password': 4.0.23(@types/node@26.2.0)
+      '@inquirer/rawlist': 4.1.11(@types/node@26.2.0)
+      '@inquirer/search': 3.2.2(@types/node@26.2.0)
+      '@inquirer/select': 4.4.2(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
   '@inquirer/rawlist@4.1.11(@types/node@25.9.5)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.9.5)
@@ -10653,6 +10884,14 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.9.5
+
+  '@inquirer/rawlist@4.1.11(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@26.2.0)
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 26.2.0
 
   '@inquirer/search@3.2.2(@types/node@25.9.5)':
     dependencies:
@@ -10662,6 +10901,15 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.9.5
+
+  '@inquirer/search@3.2.2(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@26.2.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 26.2.0
 
   '@inquirer/select@4.4.2(@types/node@25.9.5)':
     dependencies:
@@ -10673,9 +10921,23 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.5
 
+  '@inquirer/select@4.4.2(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@26.2.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 26.2.0
+
   '@inquirer/type@3.0.10(@types/node@25.9.5)':
     optionalDependencies:
       '@types/node': 25.9.5
+
+  '@inquirer/type@3.0.10(@types/node@26.2.0)':
+    optionalDependencies:
+      '@types/node': 26.2.0
 
   '@isaacs/cliui@9.0.0': {}
 
@@ -10927,6 +11189,28 @@ snapshots:
   '@mermaid-js/parser@0.6.3':
     dependencies:
       langium: 3.3.1
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.2)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.6.2(express@5.2.1)
+      hono: 4.13.2
+      jose: 6.2.8
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
@@ -12127,7 +12411,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.3': {}
 
-  '@release-it/conventional-changelog@10.0.6(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@19.2.4(@types/node@25.9.5))':
+  '@release-it/conventional-changelog@10.0.6(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@19.2.4(@types/node@26.2.0))':
     dependencies:
       '@conventional-changelog/git-client': 2.7.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)
       concat-stream: 2.0.0
@@ -12135,7 +12419,7 @@ snapshots:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-conventionalcommits: 9.3.1
       conventional-recommended-bump: 11.2.0
-      release-it: 19.2.4(@types/node@25.9.5)
+      release-it: 19.2.4(@types/node@26.2.0)
       semver: 7.8.5
     transitivePeerDependencies:
       - conventional-commits-filter
@@ -12739,6 +13023,10 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/node@26.2.0':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-path@7.1.0':
@@ -12773,6 +13061,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/vexflow@1.2.42': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -12944,6 +13234,15 @@ snapshots:
     optionalDependencies:
       vite: 8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9)
 
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9)
+    optional: true
+
   '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.1
@@ -12994,6 +13293,10 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1:
+    dependencies:
+      ajv: 8.20.0
 
   ajv@6.15.0:
     dependencies:
@@ -13191,7 +13494,7 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.26(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9))):
+  better-auth@1.6.26(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(happy-dom@20.11.2)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9))):
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)
       '@better-auth/drizzle-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(kysely@0.28.17))
@@ -13215,7 +13518,36 @@ snapshots:
       drizzle-orm: 0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(kysely@0.28.17)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(happy-dom@20.11.2)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-auth@1.6.26(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(happy-dom@20.11.2)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9))):
+    dependencies:
+      '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)
+      '@better-auth/drizzle-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(kysely@0.28.17))
+      '@better-auth/kysely-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.3.0
+      better-call: 1.3.7(zod@4.4.3)
+      defu: 6.1.7
+      jose: 6.2.8
+      kysely: 0.28.17
+      nanostores: 1.4.2
+      zod: 4.4.3
+    optionalDependencies:
+      drizzle-kit: 0.31.10
+      drizzle-orm: 0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(kysely@0.28.17)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(happy-dom@20.11.2)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -13296,6 +13628,10 @@ snapshots:
   buffer-crc32@1.0.0: {}
 
   buffer-from@1.1.2: {}
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 25.9.5
 
   buffer@5.7.1:
     dependencies:
@@ -14365,6 +14701,12 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -14384,6 +14726,14 @@ snapshots:
 
   exponential-backoff@3.1.3:
     optional: true
+
+  express-rate-limit@8.6.2(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   express@5.2.1:
     dependencies:
@@ -14742,6 +15092,19 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
+  happy-dom@20.11.2:
+    dependencies:
+      '@types/node': 25.9.5
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   has-bigints@1.1.0: {}
 
   has-property-descriptors@1.0.2:
@@ -14767,6 +15130,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  hono@4.13.2: {}
 
   hosted-git-info@8.1.0:
     dependencies:
@@ -14855,17 +15220,17 @@ snapshots:
   ini@1.3.8:
     optional: true
 
-  inquirer@12.11.1(@types/node@25.9.5):
+  inquirer@12.11.1(@types/node@26.2.0):
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@25.9.5)
-      '@inquirer/prompts': 7.10.1(@types/node@25.9.5)
-      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+      '@inquirer/core': 10.3.2(@types/node@26.2.0)
+      '@inquirer/prompts': 7.10.1(@types/node@26.2.0)
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
       mute-stream: 2.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 25.9.5
+      '@types/node': 26.2.0
 
   internal-slot@1.1.0:
     dependencies:
@@ -15149,6 +15514,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -16260,6 +16627,8 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  pkce-challenge@5.0.1: {}
+
   pkg-types@2.3.1:
     dependencies:
       confbox: 0.2.4
@@ -16631,7 +17000,7 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
-  release-it@19.2.4(@types/node@25.9.5):
+  release-it@19.2.4(@types/node@26.2.0):
     dependencies:
       '@nodeutils/defaults-deep': 1.1.0
       '@octokit/rest': 22.0.1
@@ -16641,7 +17010,7 @@ snapshots:
       ci-info: 4.4.0
       eta: 4.5.0
       git-url-parse: 16.1.0
-      inquirer: 12.11.1(@types/node@25.9.5)
+      inquirer: 12.11.1(@types/node@26.2.0)
       issue-parser: 7.0.1
       lodash.merge: 4.6.2
       mime-types: 3.0.2
@@ -17373,6 +17742,8 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  undici-types@8.3.0: {}
+
   undici@6.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -17510,7 +17881,23 @@ snapshots:
       terser: 5.49.2
       tsx: 4.23.9
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9)):
+  vite@8.2.0(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.2.0
+      esbuild: 0.25.12
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.49.2
+      tsx: 4.23.9
+    optional: true
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(happy-dom@20.11.2)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@25.9.5)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9))
@@ -17535,9 +17922,41 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.5
+      happy-dom: 20.11.2
       jsdom: 28.1.0(@noble/hashes@2.3.0)
     transitivePeerDependencies:
       - msw
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(happy-dom@20.11.2)(jsdom@28.1.0(@noble/hashes@2.3.0))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.9)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.2.0
+      happy-dom: 20.11.2
+      jsdom: 28.1.0(@noble/hashes@2.3.0)
+    transitivePeerDependencies:
+      - msw
+    optional: true
 
   vscode-jsonrpc@8.2.0: {}
 
@@ -17571,6 +17990,8 @@ snapshots:
   webpack-virtual-modules@0.6.2: {}
 
   webworkify@1.5.0: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@5.0.0: {}
 
@@ -17836,9 +18257,15 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}
 


### PR DESCRIPTION
## Summary

Adds an MCP ([Model Context Protocol](https://modelcontextprotocol.io)) server, so Claude
Code and Claude Desktop can work with a WordyMe wiki: search it, read pages, create notes,
revise them, and move them between folders — all in Markdown.

Content crosses the boundary through **the editor's own Markdown transformers**, running in
a headless copy of the editor. There is no bespoke translation layer: what Claude writes is
what the editor itself would produce if you typed the same Markdown, so headings, lists,
tables, code blocks and Mermaid diagram fences become real rich-text nodes.

Three design decisions worth stating up front:

- **Delegation, not a second user.** WordyMe is deliberately single-user, and has no
  sharing model — an "AI account" would see an empty wiki. The server signs in with the
  owner's credentials and acts as that account, the way any connected app does. The
  single-admin bootstrap trigger is untouched.
- **Nothing is destructive.** Every write creates a new revision named **"via Claude"**,
  visible and restorable in Revisions History. No tool deletes anything.
- **Nothing ships to self-hosters.** This is a local development companion. `apps/mcp` is
  excluded from the Docker build context and no shipped workspace depends on it — verified
  by inspecting the built image (below).

## Related Issues

None.

## Type of Change

New feature.

## Changes

- **New workspace `apps/mcp`** (`@repo/mcp`), private, run with `pnpm --filter @repo/mcp start`.
  It bundles with esbuild and speaks MCP over stdio.
- **Seven tools**, each a thin wrapper over the existing typed SDK in `packages/sdk`:
  `list_spaces`, `list_documents`, `search_documents`, `read_document`, `create_note`,
  `update_document`, `move_document`.
- **`src/markdown.ts`** — the conversion seam. A headless Lexical editor built from
  `editorConfig` (`packages/editor/src/config.ts`) with the app's own
  `createTransformers()` (`packages/editor/src/plugins/MarkdownPlugin`). Reads and writes
  target the `page-content` nodes inside the editor's page scaffold, and new notes start
  from `getInitialEditorState()` — so MCP-created documents are structurally identical to
  ones created in the editor.
- **`src/dom-shim.ts`** — several editor nodes (MathLive in particular) touch browser
  globals at import time, so a headless DOM is registered before any editor module loads.
  Node's own `fetch` is restored immediately afterwards: the shim's browser `fetch`
  enforces the same-origin policy and blocked every API call.
- **`src/auth.ts`** — signs in against the backend's existing Better Auth `bearer()` plugin
  and reuses the returned token. A 401 triggers one transparent re-login and retry.
  Sign-in deliberately uses plain Node HTTP rather than global `fetch`: `fetch` adds
  `Sec-Fetch-*` headers, which make Better Auth's CSRF guard treat the call as a browser
  form submission and reject it with `MISSING_OR_NULL_ORIGIN`.
- **`move_document`** mirrors the app's own drag-and-drop (`parentId` + a fresh sort
  position via `generatePositionKeyBetween`) and refuses moves that would corrupt the tree:
  into a note rather than a folder, into itself or a descendant, or into an unknown id.
- **`.mcp.json`** at the repo root registers the server for Claude Code with no secrets in
  it. Credentials live in `apps/mcp/.env` (git-ignored, `.env.example` provided), read at
  startup via Node's `--env-file-if-exists`.
- **Docs**: [`MCP.md`](MCP.md) at the root (what it does, three-step setup, honest limits,
  roadmap), linked from the README; implementation notes in `apps/mcp/README.md`.
- **One change outside `apps/mcp`**: `packages/sdk/src/app/client.ts` now reads
  `import.meta.env?.VITE_BACKEND_URL` — optional chaining, because that property does not
  exist under Node and the bare access crashes at module load. Verified not to change the
  browser bundle (below).

## How to Test

No test harness in the repo yet, so this is manual. Requires a running WordyMe.

1. **Markdown conversion, no instance needed** — `pnpm --filter @repo/mcp smoke` round-trips
   a sample with headings, a list, a table, a code fence and a Mermaid fence, and asserts
   the editor's page scaffold is produced.
2. **Credentials** — `cp apps/mcp/.env.example apps/mcp/.env` and fill it in.
   `WORDYME_URL` is `http://localhost:3000` for `pnpm dev`, `http://localhost:8080` for Docker.
3. **Connect** — open the repository in Claude Code and approve the `wordyme` server, or add
   the Claude Desktop snippet from `MCP.md`. Then ask it to list your Spaces.
4. **Read** — ask Claude to read a rich document; headings, tables and code fences should
   come back as faithful Markdown.
5. **Write** — ask it to create a note containing a table and a ```mermaid fence. Open the
   note in WordyMe: it renders as rich content, the diagram draws, and Revisions History
   shows "via Claude".
6. **Revise** — ask it to update that note. A second revision appears; the first stays
   restorable.
7. **Move** — ask it to move the note into a folder. Confirm in the sidebar.
8. `pnpm lint && pnpm check-types && pnpm build && pnpm lint:md && pnpm license:check` — all clean.

**Expected result:** Claude can search, read, write, revise and organise the wiki in
Markdown, as the owner's account, with every change recorded as a restorable "via Claude"
revision — and the shipped application and Docker image behave exactly as before.

### Verification already performed

Beyond the CI gates (all run locally and green, including the Docker image build and stack
health check):

- **The image is unaffected** — searched inside the built image: no `apps/mcp` files and no
  `@modelcontextprotocol` package. Container reports healthy, `/api/health` → 200.
  (Built on `linux/arm64`; CI covers `amd64`.)
- **The SDK edit does not change the browser bundle** — the compiled output still yields
  `baseURL: "/api"`, identical to before the change.
- **All seven tools exercised against a real wiki**, including a 286-line document with
  nested headings and a box-drawing code block.
- **Error paths exercised**: missing environment variables, wrong credentials (surfaces the
  backend's real `401 Invalid email or password`), and all three `move_document` guards.

## Known limits

- Fidelity is bounded by Markdown: standard constructs and the editor's fenced extensions
  (```mermaid) round-trip; sketches, scores and stickies degrade to plain text when read.
- Nested list items need 4-space indentation.
- The server acts with the owner's full account and is intended for the owner's own machine.
- Bundling the server into the Docker image behind an opt-in `/mcp` endpoint, with OAuth via
  Better Auth so tokens are revocable and scopable, is outlined as future work in `MCP.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added MCP support for connecting Claude Code and Claude Desktop to WordyMe.
  - Added tools for browsing, searching, reading, creating, updating, and moving documents and Spaces.
  - Added Markdown and Mermaid conversion with revision-preserving updates.
  - Added delegated authentication and local configuration support.

- **Documentation**
  - Added setup guides, configuration examples, supported tools, limitations, and integration instructions.

- **Bug Fixes**
  - Improved API client compatibility in environments without `import.meta.env`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->