### PR TITLE
feat(tabs): preview split-view tabs and a configurable split modifier

### DIFF
--- a/apps/web/src/components/Layout/tabs/LinkButton.tsx
+++ b/apps/web/src/components/Layout/tabs/LinkButton.tsx
@@ -78,6 +78,8 @@ function LinkButtonFn<
     state.tabs.tabList.find((t) => t.id === state.tabs.activeTabId[state.tabs.activePane]),
   );
   const activePane = useSelector((state) => state.tabs.activePane);
+  const documentLinkTarget = useSelector((state) => state.ui.documentLinkTarget);
+  const splitTabsArePreview = useSelector((state) => state.ui.splitTabsArePreview);
   const primaryTabList = useSelector((state) =>
     state.tabs.tabList.filter((t) => state.tabs.paneTabIds.primary.includes(t.id)),
   );
@@ -113,6 +115,10 @@ function LinkButtonFn<
       isShiftHeld: event.shiftKey,
       newTab,
       newSplitTab,
+      // LinkButton renders UI chrome (the space switcher), never document content.
+      isInDocument: false,
+      documentLinkTarget,
+      splitTabsArePreview,
     });
 
     switch (action.type) {

--- a/apps/web/src/components/Layout/tabs/TabSync.tsx
+++ b/apps/web/src/components/Layout/tabs/TabSync.tsx
@@ -7,6 +7,8 @@ import { useSelector, useActions } from '@/store';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import { useEffect, useRef } from 'react';
 import { resolveModifier, useKeyHold } from '@tanstack/react-hotkeys';
+import { useQueryClient } from '@tanstack/react-query';
+import { getDocumentByIdQueryOptions } from '@/queries/documents';
 import { matchTabLocation, findGroupTab, resolveTabAction } from './utils';
 
 /**
@@ -18,6 +20,7 @@ import { matchTabLocation, findGroupTab, resolveTabAction } from './utils';
  */
 export function TabSync() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { openTab, updateTab, setActiveTab } = useActions();
 
   const tabList = useSelector((state) => state.tabs.tabList);
@@ -207,7 +210,16 @@ export function TabSync() {
     }
     const isSameDocument = isDocumentTab && pathname.split('/').pop() === documentHandle;
     const isSamePath = activeTab && activeTab.pathname === pathname;
-    if (isSameDocument || isSamePath) {
+    // A tab opened from an in-document link holds `/view/<id>?id=true`; the route
+    // redirects it to the handle. That is the same document, so update the tab
+    // (keeping its preview state) rather than opening a second one.
+    const isIdRedirect =
+      !!activeTab?.search?.id &&
+      isDocumentTab &&
+      queryClient.getQueryData<{ handle?: string }>(
+        getDocumentByIdQueryOptions(documentHandle ?? '').queryKey,
+      )?.handle === pathname.split('/').pop();
+    if (isSameDocument || isSamePath || isIdRedirect) {
       updateTab(activeTab.id, {
         pathname,
         search,

--- a/apps/web/src/components/Layout/tabs/TabSync.tsx
+++ b/apps/web/src/components/Layout/tabs/TabSync.tsx
@@ -32,6 +32,8 @@ export function TabSync() {
     state.tabs.tabList.filter((t) => state.tabs.paneTabIds.secondary.includes(t.id)),
   );
   const activePane = useSelector((state) => state.tabs.activePane);
+  const documentLinkTarget = useSelector((state) => state.ui.documentLinkTarget);
+  const splitTabsArePreview = useSelector((state) => state.ui.splitTabsArePreview);
   const isDocumentTab =
     activeTab &&
     (activeTab.pathname.startsWith('/edit/') || activeTab.pathname.startsWith('/view/'));
@@ -50,6 +52,8 @@ export function TabSync() {
   const activeTabRef = useRef(activeTab);
   const isModifierHeldRef = useRef(isModifierHeld);
   const isShiftHeldRef = useRef(isShiftHeld);
+  const documentLinkTargetRef = useRef(documentLinkTarget);
+  const splitTabsArePreviewRef = useRef(splitTabsArePreview);
   useEffect(() => {
     primaryTabListRef.current = primaryTabList;
     secondaryTabListRef.current = secondaryTabList;
@@ -57,7 +61,18 @@ export function TabSync() {
     activeTabRef.current = activeTab;
     isModifierHeldRef.current = isModifierHeld;
     isShiftHeldRef.current = isShiftHeld;
-  }, [primaryTabList, secondaryTabList, activePane, activeTab, isModifierHeld, isShiftHeld]);
+    documentLinkTargetRef.current = documentLinkTarget;
+    splitTabsArePreviewRef.current = splitTabsArePreview;
+  }, [
+    primaryTabList,
+    secondaryTabList,
+    activePane,
+    activeTab,
+    isModifierHeld,
+    isShiftHeld,
+    documentLinkTarget,
+    splitTabsArePreview,
+  ]);
 
   useEffect(() => {
     const handleLinkClick = (event: MouseEvent) => {
@@ -80,6 +95,9 @@ export function TabSync() {
         isShiftHeld: isShiftHeldRef.current,
         newTab: link.dataset.newTab === 'true',
         newSplitTab: link.dataset.newSplitTab === 'true',
+        isInDocument: !!link.closest('.editor-input'),
+        documentLinkTarget: documentLinkTargetRef.current,
+        splitTabsArePreview: splitTabsArePreviewRef.current,
       });
 
       event.preventDefault();

--- a/apps/web/src/components/Layout/tabs/TabSync.tsx
+++ b/apps/web/src/components/Layout/tabs/TabSync.tsx
@@ -78,14 +78,45 @@ export function TabSync() {
   ]);
 
   useEffect(() => {
+    // In-document links address documents by id (`/view/<id>?id=true`) so they
+    // survive renames. Resolve that to the handle before routing, so the tab is
+    // created with its canonical location: tab matching works against open
+    // tabs, and nothing ever looks the id up as a handle.
+    const resolveDocumentLocation = async (
+      pathname: string,
+      search: Record<string, string>,
+    ): Promise<{ pathname: string; search: Record<string, string> }> => {
+      const isDocumentPath = pathname.startsWith('/view/') || pathname.startsWith('/edit/');
+      const id = pathname.split('/').pop();
+      if (!search.id || !isDocumentPath || !id) return { pathname, search };
+      try {
+        const document = await queryClient.ensureQueryData(
+          getDocumentByIdQueryOptions(id, queryClient),
+        );
+        const { id: _id, ...rest } = search;
+        return { pathname: pathname.replace(id, document.handle), search: rest };
+      } catch {
+        return { pathname, search };
+      }
+    };
+
     const handleLinkClick = (event: MouseEvent) => {
       const link = event.currentTarget as HTMLAnchorElement;
-      const { origin, pathname, searchParams, hash } = new URL(link.href);
+      const { origin, pathname: rawPathname, searchParams, hash } = new URL(link.href);
       if (origin !== location.origin) return;
       if (link.download) return;
-      const search = Object.fromEntries(searchParams.entries());
-      const normalizedHash = hash.slice(1);
+      event.preventDefault();
+      void resolveDocumentLocation(rawPathname, Object.fromEntries(searchParams.entries())).then(
+        ({ pathname, search }) => routeLink(link, pathname, search, hash.slice(1)),
+      );
+    };
 
+    const routeLink = (
+      link: HTMLAnchorElement,
+      pathname: string,
+      search: Record<string, string>,
+      normalizedHash: string,
+    ) => {
       const action = resolveTabAction({
         pathname,
         search,
@@ -102,8 +133,6 @@ export function TabSync() {
         documentLinkTarget: documentLinkTargetRef.current,
         splitTabsArePreview: splitTabsArePreviewRef.current,
       });
-
-      event.preventDefault();
 
       switch (action.type) {
         case 'activate':

--- a/apps/web/src/components/Layout/tabs/TabSync.tsx
+++ b/apps/web/src/components/Layout/tabs/TabSync.tsx
@@ -200,6 +200,20 @@ export function TabSync() {
     if (pathname.startsWith('/login') || pathname.startsWith('/signup')) return;
     const locationMatches = activeTab && matchTabLocation(activeTab, pathname, search, hash);
     if (locationMatches) return;
+    // A tab opened from an in-document link holds `/view/<id>?id=true`; the route
+    // redirects it to the handle. That redirect belongs to the active tab, so it
+    // is updated in place (keeping its preview state) — checked before any other
+    // tab with the same location, which would otherwise steal the navigation.
+    const isIdRedirect =
+      !!activeTab?.search?.id &&
+      isDocumentTab &&
+      queryClient.getQueryData<{ handle?: string }>(
+        getDocumentByIdQueryOptions(documentHandle ?? '').queryKey,
+      )?.handle === pathname.split('/').pop();
+    if (isIdRedirect) {
+      updateTab(activeTab.id, { pathname, search, hash });
+      return;
+    }
     const existingTab = tabList.find((t) => matchTabLocation(t, pathname, search, hash));
     if (existingTab) return setActiveTab(existingTab.id);
     const existingGroupTab = findGroupTab(tabList, pathname);
@@ -210,16 +224,7 @@ export function TabSync() {
     }
     const isSameDocument = isDocumentTab && pathname.split('/').pop() === documentHandle;
     const isSamePath = activeTab && activeTab.pathname === pathname;
-    // A tab opened from an in-document link holds `/view/<id>?id=true`; the route
-    // redirects it to the handle. That is the same document, so update the tab
-    // (keeping its preview state) rather than opening a second one.
-    const isIdRedirect =
-      !!activeTab?.search?.id &&
-      isDocumentTab &&
-      queryClient.getQueryData<{ handle?: string }>(
-        getDocumentByIdQueryOptions(documentHandle ?? '').queryKey,
-      )?.handle === pathname.split('/').pop();
-    if (isSameDocument || isSamePath || isIdRedirect) {
+    if (isSameDocument || isSamePath) {
       updateTab(activeTab.id, {
         pathname,
         search,

--- a/apps/web/src/components/Layout/tabs/resolveTabMetadata.ts
+++ b/apps/web/src/components/Layout/tabs/resolveTabMetadata.ts
@@ -4,7 +4,7 @@
  */
 
 import type { TabMetadata } from '@repo/types';
-import { getDocumentByHandleQueryOptions } from '@/queries/documents';
+import { getDocumentByHandleQueryOptions, getDocumentByIdQueryOptions } from '@/queries/documents';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
 export type TabMetadataQueryOption = UseQueryOptions<any, any, TabMetadata>;
@@ -74,7 +74,12 @@ export function resolveTabMetadata(
   // 3. Document routes (dynamic — title & icon come from a query)
   const handle = getDocumentHandle(pathname);
   if (handle) {
-    const docQueryOpts = getDocumentByHandleQueryOptions(handle);
+    // In-document links carry the document id (`?id=true`) and are redirected
+    // to the handle by the route; looking the id up as a handle 404s, and a
+    // failed lookup auto-closes the tab.
+    const docQueryOpts = search?.id
+      ? getDocumentByIdQueryOptions(handle)
+      : getDocumentByHandleQueryOptions(handle);
     return {
       metadata: { title: '', icon: null }, // fallback while loading
       queryOption: {

--- a/apps/web/src/components/Layout/tabs/utils.ts
+++ b/apps/web/src/components/Layout/tabs/utils.ts
@@ -219,13 +219,14 @@ export const resolveTabAction = ({
       : null;
 
   // Honor new-tab/new-split-tab requests across group and same-path reuse branches.
-  // Exact-match tabs may still be activated when splitting — only forced new-tab (Ctrl/newTab)
-  // blocks that, because the existing tab is already in the target pane.
+  // An exact-match tab in the target pane is activated unless Ctrl/Cmd forces a
+  // new tab: a data-new-tab link only forbids replacing the reader's tab, and
+  // activating the target's own tab does not — opening another would duplicate it.
   if (existingGroupTab && !shouldOpenNewTab && !shouldSplitTab) {
     return { type: 'activate-and-update', tabId: existingGroupTab.id, pathname, search, hash };
   } else if (existingTabSamePath && !shouldOpenNewTab && !shouldSplitTab) {
     return { type: 'activate-and-update', tabId: existingTabSamePath.id, pathname, search, hash };
-  } else if (existingTab && !shouldOpenNewTab) {
+  } else if (existingTab && !isModifierHeld) {
     return { type: 'activate', tabId: existingTab.id };
   } else if (isPreviewEligible) {
     return {

--- a/apps/web/src/components/Layout/tabs/utils.ts
+++ b/apps/web/src/components/Layout/tabs/utils.ts
@@ -189,10 +189,12 @@ export const resolveTabAction = ({
   documentLinkTarget,
   splitTabsArePreview,
 }: ResolveTabActionInput): TabAction => {
+  // Two different intents: `newTab` (the editor marks every in-document link
+  // with data-new-tab) only means "never replace the document being read";
+  // Ctrl/Cmd means "a permanent new tab". Both block in-place navigation, only
+  // the modifier blocks preview and split-by-default.
   const shouldOpenNewTab = isModifierHeld || newTab;
-  // Not applied when forcing a new tab: Ctrl/Cmd means "new tab in this pane"
-  // and Ctrl+Shift "new tab beside it", identically in both modes.
-  const splitByDefault = documentLinkTarget === 'split-view' && isInDocument && !shouldOpenNewTab;
+  const splitByDefault = documentLinkTarget === 'split-view' && isInDocument && !isModifierHeld;
   const shouldSplitTab = (splitByDefault ? !isShiftHeld : isShiftHeld) || newSplitTab;
 
   const activePaneTabList = activePane === 'secondary' ? secondaryTabList : primaryTabList;
@@ -201,8 +203,10 @@ export const resolveTabAction = ({
   const targetTabList = shouldSplitTab ? oppositePaneTabList : activePaneTabList;
 
   const isViewLink = pathname.startsWith('/view/');
+  // A same-pane open of a data-new-tab link stays a permanent tab, as before;
+  // a split open is preview when the preference says so.
   const isPreviewEligible =
-    isViewLink && !shouldOpenNewTab && (!shouldSplitTab || splitTabsArePreview);
+    isViewLink && !isModifierHeld && (shouldSplitTab ? splitTabsArePreview : !newTab);
 
   const existingTab =
     targetTabList.find((t) => matchTabLocation(t, pathname, search, hash)) ?? null;

--- a/apps/web/src/components/Layout/tabs/utils.ts
+++ b/apps/web/src/components/Layout/tabs/utils.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Tab } from '@repo/types';
+import type { DocumentLinkTarget } from '@/store/ui-slice';
 
 export const matchTabLocation = (
   tab: Tab,
@@ -113,6 +114,10 @@ export interface ResolveTabActionInput {
   isShiftHeld: boolean;
   newTab: boolean;
   newSplitTab: boolean;
+  /** True when the clicked link lives inside document content (`.editor-input`). */
+  isInDocument: boolean;
+  documentLinkTarget: DocumentLinkTarget;
+  splitTabsArePreview: boolean;
 }
 
 export type TabAction =
@@ -126,7 +131,7 @@ export type TabAction =
     }
   | {
       type: 'preview';
-      pane: 'primary' | 'secondary';
+      pane: 'primary' | 'secondary' | 'opposite';
       pathname: string;
       search: Record<string, unknown>;
       hash: string;
@@ -162,6 +167,11 @@ export type TabAction =
  * - The exact-match (`existingTab`) branch is only gated on `!shouldOpenNewTab`,
  *   allowing split navigation to activate an existing tab in the target pane
  *   rather than creating a duplicate.
+ * - When `documentLinkTarget` is 'split-view', Shift inverts for links inside
+ *   document content: a plain click splits and Shift+Click stays in the current
+ *   pane. An explicit `data-new-split-tab` still forces a split either way.
+ * - Split opens are preview-eligible when `splitTabsArePreview` is set; the
+ *   store scopes preview replacement per pane, so each pane keeps its own.
  */
 export const resolveTabAction = ({
   pathname,
@@ -175,9 +185,15 @@ export const resolveTabAction = ({
   isShiftHeld,
   newTab,
   newSplitTab,
+  isInDocument,
+  documentLinkTarget,
+  splitTabsArePreview,
 }: ResolveTabActionInput): TabAction => {
   const shouldOpenNewTab = isModifierHeld || newTab;
-  const shouldSplitTab = isShiftHeld || newSplitTab;
+  // Not applied when forcing a new tab: Ctrl/Cmd means "new tab in this pane"
+  // and Ctrl+Shift "new tab beside it", identically in both modes.
+  const splitByDefault = documentLinkTarget === 'split-view' && isInDocument && !shouldOpenNewTab;
+  const shouldSplitTab = (splitByDefault ? !isShiftHeld : isShiftHeld) || newSplitTab;
 
   const activePaneTabList = activePane === 'secondary' ? secondaryTabList : primaryTabList;
   const oppositePaneTabList = activePane === 'secondary' ? primaryTabList : secondaryTabList;
@@ -185,7 +201,8 @@ export const resolveTabAction = ({
   const targetTabList = shouldSplitTab ? oppositePaneTabList : activePaneTabList;
 
   const isViewLink = pathname.startsWith('/view/');
-  const isPreviewEligible = isViewLink && !shouldOpenNewTab && !shouldSplitTab;
+  const isPreviewEligible =
+    isViewLink && !shouldOpenNewTab && (!shouldSplitTab || splitTabsArePreview);
 
   const existingTab =
     targetTabList.find((t) => matchTabLocation(t, pathname, search, hash)) ?? null;
@@ -207,7 +224,13 @@ export const resolveTabAction = ({
   } else if (existingTab && !shouldOpenNewTab) {
     return { type: 'activate', tabId: existingTab.id };
   } else if (isPreviewEligible) {
-    return { type: 'preview', pane: activePane, pathname, search, hash };
+    return {
+      type: 'preview',
+      pane: shouldSplitTab ? 'opposite' : activePane,
+      pathname,
+      search,
+      hash,
+    };
   } else if (!(shouldOpenNewTab || shouldSplitTab) && activeTab) {
     const isDocumentLink = pathname.startsWith('/edit/') || pathname.startsWith('/view/');
     const requiresAutosave =

--- a/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
+++ b/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
@@ -233,10 +233,10 @@ function InterfacePreferencesSettings() {
 
         <div className="flex items-center justify-between">
           <div>
-            <Label htmlFor="splitTabsArePreview">Split-View Tabs Are Temporary</Label>
+            <Label htmlFor="splitTabsArePreview">Split-View Tabs Are Preview Tabs</Label>
             <p className="text-sm text-muted-foreground">
-              Temporary tabs show in italics and are replaced by the next one — double-click a tab
-              to keep it
+              Preview tabs show in italics and are replaced by the next one — double-click a tab to
+              keep it
             </p>
           </div>
           <Switch

--- a/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
+++ b/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
@@ -21,11 +21,14 @@ import { THEME_BY_VALUE } from '@repo/ui/theme/themes';
 import { cn } from '@repo/ui/lib/utils';
 import {
   CircleOff,
+  Columns2,
   FoldHorizontal,
   Palette,
   RefreshCcw,
+  Square,
   UnfoldHorizontal,
 } from '@repo/ui/components/icons';
+import type { DocumentLinkTarget } from '@/store/ui-slice';
 
 function InterfacePreferencesSettings() {
   const appSidebar = useSelector((state) => state.ui.appSidebar);
@@ -33,9 +36,13 @@ function InterfacePreferencesSettings() {
   const folderColorsEnabled = useSelector((state) => state.ui.folderColorsEnabled);
   const folderDefaultColor = useSelector((state) => state.ui.folderDefaultColor);
   const folderColorSolid = useSelector((state) => state.ui.folderColorSolid);
+  const documentLinkTarget = useSelector((state) => state.ui.documentLinkTarget);
+  const splitTabsArePreview = useSelector((state) => state.ui.splitTabsArePreview);
   const {
     setAppSidebar,
     setDocumentSidebar,
+    setDocumentLinkTarget,
+    setSplitTabsArePreview,
     setFolderColorsEnabled,
     setFolderDefaultColor,
     setFolderColorSolid,
@@ -194,6 +201,50 @@ function InterfacePreferencesSettings() {
             </div>
           </div>
         )}
+
+        <Separator className="bg-transparent border-t border-dashed h-0" />
+
+        <div className="flex items-center justify-between">
+          <div>
+            <Label htmlFor="documentLinkTarget">Open Links Inside Documents</Label>
+            <p className="text-sm text-muted-foreground">
+              Where a link in a document opens; Shift+Click does the opposite
+            </p>
+          </div>
+          <Select
+            value={documentLinkTarget}
+            onValueChange={(value) => setDocumentLinkTarget(value as DocumentLinkTarget)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select option" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="current-pane" className="flex items-center gap-2">
+                <Square className="text-foreground" />
+                Current Pane
+              </SelectItem>
+              <SelectItem value="split-view" className="flex items-center gap-2">
+                <Columns2 className="text-foreground" />
+                Split View
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div>
+            <Label htmlFor="splitTabsArePreview">Split-View Tabs Are Temporary</Label>
+            <p className="text-sm text-muted-foreground">
+              Temporary tabs show in italics and are replaced by the next one — double-click a tab
+              to keep it
+            </p>
+          </div>
+          <Switch
+            id="splitTabsArePreview"
+            checked={splitTabsArePreview}
+            onCheckedChange={setSplitTabsArePreview}
+          />
+        </div>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
+++ b/apps/web/src/components/Settings/Preferences/InterfacePreferencesSettings.tsx
@@ -64,7 +64,7 @@ function InterfacePreferencesSettings() {
             defaultValue={appSidebar}
             onValueChange={(value) => setAppSidebar(value as 'expanded' | 'collapsed' | 'remember')}
           >
-            <SelectTrigger className="">
+            <SelectTrigger id="appSidebar">
               <SelectValue placeholder="Select option" />
             </SelectTrigger>
             <SelectContent>
@@ -97,7 +97,7 @@ function InterfacePreferencesSettings() {
               setDocumentSidebar(value as 'expanded' | 'collapsed' | 'remember')
             }
           >
-            <SelectTrigger>
+            <SelectTrigger id="documentSidebar">
               <SelectValue placeholder="Select option" />
             </SelectTrigger>
             <SelectContent>
@@ -215,7 +215,7 @@ function InterfacePreferencesSettings() {
             value={documentLinkTarget}
             onValueChange={(value) => setDocumentLinkTarget(value as DocumentLinkTarget)}
           >
-            <SelectTrigger>
+            <SelectTrigger id="documentLinkTarget">
               <SelectValue placeholder="Select option" />
             </SelectTrigger>
             <SelectContent>

--- a/apps/web/src/store/store.ts
+++ b/apps/web/src/store/store.ts
@@ -37,6 +37,21 @@ export const store = createStore<Store>()(
           ui: state.ui,
           wordy: state.wordy,
         }),
+        // Zustand's default merge is shallow: a persisted slice replaces the
+        // whole slice, so keys added to a slice's initial state later would be
+        // undefined for anyone with existing storage. Merge per slice instead,
+        // so new preferences pick up their defaults without a version bump.
+        merge: (persistedState, currentState) => {
+          const persisted = (persistedState ?? {}) as Partial<Store>;
+          return {
+            ...currentState,
+            ...persisted,
+            app: { ...currentState.app, ...persisted.app },
+            tabs: { ...currentState.tabs, ...persisted.tabs },
+            ui: { ...currentState.ui, ...persisted.ui },
+            wordy: { ...currentState.wordy, ...persisted.wordy },
+          };
+        },
       },
     ),
     { name: 'Wordy' },

--- a/apps/web/src/store/store.ts
+++ b/apps/web/src/store/store.ts
@@ -25,7 +25,16 @@ export const store = createStore<Store>()(
       }),
       {
         name: 'Wordy',
-        version: 4,
+        version: 5,
+        migrate: (persistedState, version) => {
+          const state = (persistedState ?? {}) as Pick<Store, 'app' | 'tabs' | 'ui' | 'wordy'>;
+          // v5: the split-view default changed before the feature shipped, so
+          // the only persisted 'current-pane' values come from pre-release builds.
+          if (version < 5 && state.ui) {
+            return { ...state, ui: { ...state.ui, documentLinkTarget: 'split-view' as const } };
+          }
+          return state;
+        },
         partialize: (state) => ({
           app: state.app,
           tabs: {

--- a/apps/web/src/store/ui-slice.ts
+++ b/apps/web/src/store/ui-slice.ts
@@ -10,6 +10,8 @@ import type { Store } from './store';
 
 export type AppSidebarState = 'expanded' | 'collapsed' | 'remember';
 
+export type DocumentLinkTarget = 'current-pane' | 'split-view';
+
 export type FolderColor = 'theme' | Theme['color-variants'][number]['value'];
 
 export type HomeSortState = {
@@ -30,6 +32,8 @@ type UiState = {
   folderColorsEnabled: boolean;
   folderDefaultColor: FolderColor;
   folderColorSolid: boolean;
+  documentLinkTarget: DocumentLinkTarget;
+  splitTabsArePreview: boolean;
 };
 
 type UiActions = {
@@ -44,6 +48,8 @@ type UiActions = {
   setFolderColorsEnabled: (enabled: boolean) => void;
   setFolderDefaultColor: (color: FolderColor) => void;
   setFolderColorSolid: (solid: boolean) => void;
+  setDocumentLinkTarget: (target: DocumentLinkTarget) => void;
+  setSplitTabsArePreview: (preview: boolean) => void;
 };
 
 export type UiSlice = { ui: UiState; uiActions: UiActions };
@@ -64,6 +70,8 @@ const initialState: UiState = {
   folderColorsEnabled: false,
   folderDefaultColor: 'theme',
   folderColorSolid: false,
+  documentLinkTarget: 'current-pane',
+  splitTabsArePreview: true,
 };
 
 export const createUiSlice: StateCreator<
@@ -101,6 +109,10 @@ export const createUiSlice: StateCreator<
         set((state) => ({ ui: { ...state.ui, folderDefaultColor } })),
       setFolderColorSolid: (folderColorSolid) =>
         set((state) => ({ ui: { ...state.ui, folderColorSolid } })),
+      setDocumentLinkTarget: (documentLinkTarget) =>
+        set((state) => ({ ui: { ...state.ui, documentLinkTarget } })),
+      setSplitTabsArePreview: (splitTabsArePreview) =>
+        set((state) => ({ ui: { ...state.ui, splitTabsArePreview } })),
     },
   };
 };

--- a/apps/web/src/store/ui-slice.ts
+++ b/apps/web/src/store/ui-slice.ts
@@ -70,7 +70,7 @@ const initialState: UiState = {
   folderColorsEnabled: false,
   folderDefaultColor: 'theme',
   folderColorSolid: false,
-  documentLinkTarget: 'current-pane',
+  documentLinkTarget: 'split-view',
   splitTabsArePreview: true,
 };
 


### PR DESCRIPTION
## Summary

Makes split-view tabs behave like VS Code preview tabs, and lets the user choose where a
link inside a document opens.

Today, clicking a note in the sidebar opens a **preview** tab (italic title) that the next
click replaces, and double-clicking promotes it — but a Shift+Click split always produced a
permanent tab, so following several links from one page left a trail of tabs to close by
hand. Split opens are now preview tabs too, each pane keeping its own, and the behaviour is
configurable.

Two new rows in Settings → Preferences → Interface Preferences:

- **Open Links Inside Documents** — *Split View* (default) or *Current Pane*. In split-view
  mode a plain click on a link inside a document opens it beside the page you are reading
  and **Shift+Click inverts** (opens in the current pane); in current-pane mode it is the
  other way round. Sidebar, search and home clicks are unaffected.
- **Split-View Tabs Are Preview Tabs** — on by default. Preview tabs show in italics and are
  replaced by the next one; double-click a tab to keep it.

Ctrl/Cmd+Click still means a permanent new tab in both modes; Ctrl/Cmd+Shift a permanent
tab beside.

## Related Issues

None.

## Type of Change

New feature, plus fixes for pre-existing defects in tab routing that this feature exposed
(listed separately below).

## Changes

**The feature**

- `apps/web/src/components/Layout/tabs/utils.ts` — `resolveTabAction` gains `isInDocument`,
  `documentLinkTarget` and `splitTabsArePreview` inputs. Split opens become
  preview-eligible, the preview action can target the opposite pane, and split-by-default
  inverts Shift for in-document links. The tab store needed no changes: `openTab` already
  resolves `'opposite'` before its per-pane preview lookup.
- `TabSync.tsx` / `LinkButton.tsx` — pass the new inputs (`isInDocument` is
  `link.closest('.editor-input')`; `LinkButton` is UI chrome, so `false`).
- `store/ui-slice.ts` — `documentLinkTarget` (default `'split-view'`) and
  `splitTabsArePreview` (default `true`).
- `InterfacePreferencesSettings.tsx` — the two rows.

**Pre-existing defects fixed along the way** — each surfaced because preview tabs made
them visible; each was verified live in the browser before and after:

1. **Persisted state hydration was shallow** (`store/store.ts`). Zustand's default merge
   replaced a whole slice from storage, so any key added to a slice's initial state later
   was `undefined` for existing users — the folder-colour preferences shipped with this
   latent bug, masked only because their defaults were falsy. Persisted state is now
   merged per slice. Also bumps the persist version to 5 with a `migrate` that rewrites the
   split-view default; safe because the key has never shipped, so only pre-release browsers
   hold the old value.
2. **In-document links are addressed by document id** (`/view/<id>?id=true`, so they
   survive renames) and the route redirects to the handle. The tab used to be created with
   the id path, its title loader looked the id up *as a handle*, 404'd, raised "Document not
   found" and **auto-closed the tab**; the redirect then opened a fresh permanent one. Every
   in-document link click was creating, killing and replacing a tab. `TabSync` now resolves
   the id to the handle **before routing**, so the tab is born with its canonical URL — no
   404, no toast, and links finally match already-open tabs. The redirect handling in the
   URL sync and the title loader stay as defensive code for tabs persisted from older builds.
3. **`data-new-tab` was conflated with Ctrl+Click.** The editor stamps every internal
   link with `data-new-tab` ("never replace the document being read"); the router treated
   it like a forced new tab, which blocked preview for in-document links entirely and also
   made an already-open target open a **duplicate** instead of activating. Only the real
   modifier now forces a new tab.

## How to Test

Manual (no test harness in the repo). Run `pnpm dev`, hard-refresh, open a document that
links to other notes.

1. Plain-click a link → opens **beside** the page, italic. Click another link → it
   **replaces** the first; the split pane still holds one tab.
2. Double-click that tab → italics clear; the next link opens a new tab beside it.
3. Click a link to a note already open in the split pane → it is **activated**, not
   duplicated.
4. Shift+Click a link → opens in the **current** pane (the inversion).
5. Sidebar: plain click → preview in the current pane (unchanged); Shift+Click → preview in
   the split pane.
6. Ctrl/Cmd+Click → permanent tab in the current pane; Ctrl/Cmd+Shift+Click → permanent
   beside. Same in both modes.
7. Settings → set "Open Links Inside Documents" to *Current Pane*: plain click now opens
   in the current pane, Shift+Click beside. Turn "Split-View Tabs Are Preview Tabs" off:
   split opens are permanent again.
8. No "Document not found" toast at any point; the network log shows no 404 on
   `/api/documents/handle/<uuid>`.
9. Reload: both preferences persist; existing settings and open tabs are intact (preview
   state is deliberately session-only, unchanged).
10. `pnpm lint && pnpm check-types && pnpm build` — clean.

**Expected result:** split-view tabs behave like VS Code preview tabs, the two preferences
do what their labels say, and in-document links open without flicker, toast or duplicates.

### Verification already performed

- A decision-matrix script exercising `resolveTabAction` over 18 combinations of mode,
  modifier, link origin, pane and already-open state — all passing. It caught one real
  bug before release (Ctrl+Click inverting with the mode) and was corrected once to model
  links the way the editor actually renders them.
- All flows above were driven live in a browser against the dev stack, reading the tab
  store and the network log rather than relying on screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added preferences to open document links in the current pane or a split view.
  * Added an option to use preview tabs in split views.
  * Improved document link navigation, including links that reference document IDs.
  * Preserved preview state when links redirect to the matching document.

* **Bug Fixes**
  * Improved tab activation and split-view behavior for document links, including keyboard shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->